### PR TITLE
Fix Stoplight typo

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -6,6 +6,6 @@ weight: 0
 
 Scramble generates API documentation for Laravel project. Without requiring you to manually write PHPDoc annotations. 
 
-Docs are generated in OpenAPI 3.1.0 format. To show the documentation in UI, [Spotlight Elements](https://github.com/stoplightio/elements) is used.
+Docs are generated in OpenAPI 3.1.0 format. To show the documentation in UI, [Stoplight Elements](https://github.com/stoplightio/elements) is used.
 
 The main motto of the project is to generate as much API documentation automatically as possible. This allows you to focus on code and avoid annotating every possible param/field as it may result in outdated documentation. By generating docs automatically from the code your API will always have up-to-date documentation you can trust.


### PR DESCRIPTION
There was a typo in `docs/introduction.md`

`Stoplight` was misspelled as `Spotlight`