### PR TITLE
support ConstExprNode node to avoid crashing with 500

### DIFF
--- a/src/PhpDoc/PhpDocTypeWalker.php
+++ b/src/PhpDoc/PhpDocTypeWalker.php
@@ -2,6 +2,7 @@
 
 namespace Dedoc\Scramble\PhpDoc;
 
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
@@ -13,7 +14,7 @@ use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 
 class PhpDocTypeWalker
 {
-    public static function traverse(TypeNode $type, array $visitors)
+    public static function traverse(TypeNode|ConstExprNode $type, array $visitors)
     {
         $callVisitors = function ($node, $method) use ($visitors) {
             foreach ($visitors as $visitor) {


### PR DESCRIPTION
This allows the AST parser to not break on a ConstExprNode when going through documentation.

![2022-10-05_1920x1080_12:05:04](https://user-images.githubusercontent.com/627094/194038333-6a537f9f-0317-4108-ac13-9edbabba25cf.png)