### PR TITLE
Fix missing `phpDoc` attributes on resolved type attached by `PhpDocHandler` when they're attached to pending type 

### DIFF
--- a/src/Infer/Scope/PendingTypes.php
+++ b/src/Infer/Scope/PendingTypes.php
@@ -34,10 +34,11 @@ class PendingTypes
                 }
 
                 if (count((new TypeWalker)->find($resolvedType, fn ($t) => $t === $pendingType))) {
-                    $resolvedType = $pendingType->getDefaultType();
+                    $resolvedType = $pendingType->defaultType;
                 }
 
-                $referenceResolver($pendingType, $resolvedType);
+                $this->resolveType($pendingType, $referenceResolver, $resolvedType);
+
                 unset($this->references[$index][2][$pendingTypeIndex]);
                 $hasResolvedSomeReferences = true;
             }
@@ -61,12 +62,21 @@ class PendingTypes
     {
         foreach ($this->references as [$type, $referenceResolver, $pendingTypes]) {
             foreach ($pendingTypes as $pendingType) {
-                $resolvedType = $pendingType->getDefaultType();
+                $resolvedType = $pendingType->defaultType;
 
-                $referenceResolver($pendingType, $resolvedType);
+                $this->resolveType($pendingType, $referenceResolver, $resolvedType);
             }
         }
 
         $this->references = [];
+    }
+
+    private function resolveType(PendingReturnType $pendingType, callable $referenceResolver, Type $resolvedType)
+    {
+        foreach ($pendingType->defaultType->attributes() as $name => $value) {
+            $resolvedType->setAttribute($name, $value);
+        }
+
+        $referenceResolver($pendingType, $resolvedType);
     }
 }

--- a/src/Infer/Scope/PendingTypes.php
+++ b/src/Infer/Scope/PendingTypes.php
@@ -9,7 +9,7 @@ use Dedoc\Scramble\Support\Type\UnknownType;
 
 class PendingTypes
 {
-    /** @var array{0: Type, 1: callable(PendingReturnType, Type): void, 2: PendingReturnType[] } */
+    /** @var array{0: Type, 1: callable(PendingReturnType, Type): void, 2: PendingReturnType[] }[] */
     private array $references = [];
 
     public function addReference(Type $type, callable $referenceResolver, array $pendingTypes)
@@ -34,7 +34,7 @@ class PendingTypes
                 }
 
                 if (count((new TypeWalker)->find($resolvedType, fn ($t) => $t === $pendingType))) {
-                    $resolvedType = new UnknownType;
+                    $resolvedType = $pendingType->getDefaultType();
                 }
 
                 $referenceResolver($pendingType, $resolvedType);
@@ -61,7 +61,7 @@ class PendingTypes
     {
         foreach ($this->references as [$type, $referenceResolver, $pendingTypes]) {
             foreach ($pendingTypes as $pendingType) {
-                $resolvedType = $pendingType->defaultType;
+                $resolvedType = $pendingType->getDefaultType();
 
                 $referenceResolver($pendingType, $resolvedType);
             }

--- a/src/Infer/Scope/Scope.php
+++ b/src/Infer/Scope/Scope.php
@@ -92,7 +92,7 @@ class Scope
 
         // Here we either don't have type for node cached (so we've got a freshly created
         // instance of UnknownType), or we have pending type that needs to be resolved.
-        $type = $type instanceof PendingReturnType ? $type->defaultType : $type;
+        $type = $type instanceof PendingReturnType ? $type->getDefaultType() : $type;
 
         if ($node instanceof Node\Expr\MethodCall) {
             // Only string method names support.
@@ -109,10 +109,12 @@ class Scope
                 ];
             }
 
-            $type = $this->setType(
-                $node,
-                $objectType->getMethodCallType($node->name->name),
-            );
+            $methodCallType = $objectType->getMethodCallType($node->name->name);
+            if ($methodCallType instanceof UnknownType && $type instanceof UnknownType) {
+                $methodCallType = $type;
+            }
+
+            $type = $this->setType($node, $methodCallType);
         }
 
         if ($node instanceof Node\Expr\FuncCall) {
@@ -130,7 +132,7 @@ class Scope
                 ];
             }
 
-            $type = $this->setType($node, $fnType ? $fnType->getReturnType() : new UnknownType);
+            $type = $this->setType($node, $fnType ? $fnType->getReturnType() : $type);
         }
 
         return $type;

--- a/src/Support/Type/PendingReturnType.php
+++ b/src/Support/Type/PendingReturnType.php
@@ -32,4 +32,13 @@ class PendingReturnType extends AbstractType
     {
         return 'pending-type';
     }
+
+    public function getDefaultType()
+    {
+        foreach ($this->attributes() as $name => $value) {
+            $this->defaultType->setAttribute($name, $value);
+        }
+
+        return $this->defaultType;
+    }
 }

--- a/src/Support/Type/TypeAttributes.php
+++ b/src/Support/Type/TypeAttributes.php
@@ -31,4 +31,9 @@ trait TypeAttributes
 
         return null;
     }
+
+    public function attributes()
+    {
+        return $this->attributes;
+    }
 }

--- a/tests/Generator/ManualResponseDocumentation.php
+++ b/tests/Generator/ManualResponseDocumentation.php
@@ -20,6 +20,6 @@ class ManualResponseDocumentation_Test extends \Illuminate\Routing\Controller
          * Wow.
          * @body array{id: int}
          */
-        return unknown_fn();
+        return $this->unknown_fn();
     }
 }

--- a/tests/Generator/ManualResponseDocumentation.php
+++ b/tests/Generator/ManualResponseDocumentation.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Support\Facades\Route as RouteFacade;
+
+it('documents a response even when return type is taken from an annotation', function () {
+    $openApiDocument = generateForRoute(function () {
+        return RouteFacade::get('api/test', [ManualResponseDocumentation_Test::class, 'a']);
+    });
+
+    expect($openApiDocument['paths']['/test']['get']['responses'][200])
+        ->toHaveKey('description', 'Wow.')
+        ->toHaveKey('content.application/json.schema.properties.id.type', 'integer');
+});
+
+class ManualResponseDocumentation_Test extends \Illuminate\Routing\Controller
+{
+    public function a(): \Illuminate\Http\Resources\Json\JsonResource
+    {
+        /**
+         * Wow.
+         * @body array{id: int}
+         */
+        return unknown_fn();
+    }
+}

--- a/tests/Generator/ManualResponseDocumentation.php
+++ b/tests/Generator/ManualResponseDocumentation.php
@@ -14,10 +14,11 @@ it('documents a response even when return type is taken from an annotation', fun
 
 class ManualResponseDocumentation_Test extends \Illuminate\Routing\Controller
 {
-    public function a(): \Illuminate\Http\Resources\Json\JsonResource
+    public function a(): Illuminate\Http\Resources\Json\JsonResource
     {
         /**
          * Wow.
+         *
          * @body array{id: int}
          */
         return $this->unknown_fn();


### PR DESCRIPTION
fixes #68 