### PR TITLE
Specify how env auth works

### DIFF
--- a/docs/usage/access.md
+++ b/docs/usage/access.md
@@ -3,7 +3,7 @@ title: Docs authorization
 weight: 5
 ---
 
-Scramble exposes docs at the `/docs/api` URI. By default, you will only be able to access this route in the `local` environment.
+Scramble exposes docs at the `/docs/api` URI. By default, you will only be able to access this route if the environment is not `production`.
 
 If you need to allow access to docs in `production` environment, implement gate called `viewApiDocs`:
 


### PR DESCRIPTION
The docs said that the docs would only be accessible in `local` environment, i. e. they wouldn't work in environments like `staging` or `testing`. But in fact they are enabled in any environment that is not `production`.

Here is the relevant piece of logic: https://github.com/dedoc/scramble/blob/46a8fd6c6ed77eba3764fcc32a971a2873ad829f/src/Http/Middleware/RestrictedDocsAccess.php#L11