### PR TITLE
Access to docs in `local` env only by default and using `viewApiDocs` gate in other environments

### DIFF
--- a/docs/usage/access.md
+++ b/docs/usage/access.md
@@ -3,9 +3,9 @@ title: Docs authorization
 weight: 5
 ---
 
-Scramble exposes docs at the `/docs/api` URI. By default, you will only be able to access this route if the environment is not `production`.
+Scramble exposes docs at the `/docs/api` URI. By default, you will only be able to access this route in the `local` environment.
 
-If you need to allow access to docs in `production` environment, implement gate called `viewApiDocs`:
+Define `viewApiDocs` gate if you need to allow the access in other environments:
 
 ```php
 Gate::define('viewApiDocs', function (User $user) {

--- a/src/Http/Middleware/RestrictedDocsAccess.php
+++ b/src/Http/Middleware/RestrictedDocsAccess.php
@@ -8,15 +8,11 @@ class RestrictedDocsAccess
 {
     public function handle($request, \Closure $next)
     {
-        if (array_key_exists('viewApiDocs', Gate::abilities())) {
-            if (Gate::allows('viewApiDocs')) {
-                return $next($request);
-            }
-            
-            abort(403);
+        if (app()->environment('local')) {
+            return $next($request);
         }
-
-        if (! app()->environment('production')) {
+        
+        if (array_key_exists('viewApiDocs', Gate::abilities()) && Gate::allows('viewApiDocs')) {
             return $next($request);
         }
 

--- a/src/Http/Middleware/RestrictedDocsAccess.php
+++ b/src/Http/Middleware/RestrictedDocsAccess.php
@@ -11,7 +11,7 @@ class RestrictedDocsAccess
         if (app()->environment('local')) {
             return $next($request);
         }
-        
+
         if (array_key_exists('viewApiDocs', Gate::abilities()) && Gate::allows('viewApiDocs')) {
             return $next($request);
         }

--- a/src/Http/Middleware/RestrictedDocsAccess.php
+++ b/src/Http/Middleware/RestrictedDocsAccess.php
@@ -8,11 +8,15 @@ class RestrictedDocsAccess
 {
     public function handle($request, \Closure $next)
     {
-        if (! app()->environment('production')) {
-            return $next($request);
+        if (array_key_exists('viewApiDocs', Gate::abilities())) {
+            if (Gate::allows('viewApiDocs')) {
+                return $next($request);
+            }
+            
+            abort(403);
         }
-
-        if ((bool) $request->user() && array_key_exists('viewApiDocs', Gate::abilities()) && Gate::check('viewApiDocs', [$request->user()])) {
+        
+        if (! app()->environment('production')) {
             return $next($request);
         }
 

--- a/src/Http/Middleware/RestrictedDocsAccess.php
+++ b/src/Http/Middleware/RestrictedDocsAccess.php
@@ -12,7 +12,7 @@ class RestrictedDocsAccess
             return $next($request);
         }
 
-        if (array_key_exists('viewApiDocs', Gate::abilities()) && Gate::allows('viewApiDocs')) {
+        if (Gate::allows('viewApiDocs')) {
             return $next($request);
         }
 

--- a/src/Http/Middleware/RestrictedDocsAccess.php
+++ b/src/Http/Middleware/RestrictedDocsAccess.php
@@ -15,7 +15,7 @@ class RestrictedDocsAccess
             
             abort(403);
         }
-        
+
         if (! app()->environment('production')) {
             return $next($request);
         }


### PR DESCRIPTION
Hey,

This is a bit opinionated and I am aware I can remove or replace the middleware in config, but this logic might be useful for other users as well (potential scenarios outlined at the end of comment).

Currently the logic is such that:

- If the environment is not `production`, docs are accessible regardless of `viewApiDocs`
- If the environment is `production` and the user is not authenticated, docs are not accessible regardless of `viewApiDocs`

This PR changes the order so that `viewApiDocs` gate takes priority. Once this gate is defined, docs will be accessible if and only if it allows access. The environment check will only be used as a fallback when the `viewApiDocs` gate is not defined at all. Besides this PR also removes the `(bool) $request->user()` check so that "guest gates" would also be usable.

This will enable scenarios like:

- Adding guest access on prod (for public API docs) e.g. `Gate::define('viewApiDocs', fn($user = null) => true)`
- Disabling and enabling docs via a config switch on any environment, e.g. `Gate::define('viewApiDocs', fn($user) => config('scramble.enabled') && /* other checks */)`
- Adding auth to deployment in a `dev` or `staging` environment, e.g. `Gate::define('viewApiDocs', fn($user) => /* checks */)` (this is currently not checked in such environments)