### PR TITLE
Add support for translations in abort messages

### DIFF
--- a/src/Support/Type/TypeHelper.php
+++ b/src/Support/Type/TypeHelper.php
@@ -86,7 +86,7 @@ class TypeHelper
      * @param  Node\Arg[]  $args
      * @param  array{0: string, 1: int}  $parameterNameIndex
      */
-    private static function getArg(array $args, array $parameterNameIndex)
+    public static function getArg(array $args, array $parameterNameIndex)
     {
         [$name, $index] = $parameterNameIndex;
 

--- a/tests/Generator/AbortHelpersResponseDocumentation.php
+++ b/tests/Generator/AbortHelpersResponseDocumentation.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Route as RouteFacade;
 
 it('documents abort helper with 404 status as referenced error response', function () {
@@ -22,7 +23,7 @@ it('documents abort helper as not referenced error response', function () {
         ->toHaveKey('content')
         ->and($response)
         ->not->toHaveKey('$ref')
-        ->toHaveKey('content.application/json.schema.properties.message.example', 'Something is wrong.');
+        ->toHaveKey('content.application/json.schema.properties.message.example', 'Something is wrong abort.');
 });
 
 it('documents abort_if helper', function () {
@@ -35,7 +36,7 @@ it('documents abort_if helper', function () {
         ->toHaveKey('content')
         ->and($response)
         ->not->toHaveKey('$ref')
-        ->toHaveKey('content.application/json.schema.properties.message.example', 'Something is wrong.');
+        ->toHaveKey('content.application/json.schema.properties.message.example', 'Something is wrong abort_if.');
 });
 
 it('documents abort_unless helper', function () {
@@ -48,28 +49,62 @@ it('documents abort_unless helper', function () {
         ->toHaveKey('content')
         ->and($response)
         ->not->toHaveKey('$ref')
-        ->toHaveKey('content.application/json.schema.properties.message.example', 'Something is wrong.');
+        ->toHaveKey('content.application/json.schema.properties.message.example', 'Something is wrong abort_unless.');
 });
+
+it('documents helper with translated string', function (string $method) {
+    $expected = 'This is a translated string in the method.';
+    Lang::addLines(["example.$method" => $expected], 'en');
+
+    $openApiDocument = generateForRoute(function () use ($method) {
+        return RouteFacade::post('api/test', [AbortHelpersResponseDocumentationTranslated_Test::class, $method]);
+    });
+
+    expect($response = $openApiDocument['paths']['/test']['post']['responses'][400] ?? [])
+        ->toHaveKey('description')
+        ->toHaveKey('content')
+        ->and($response)
+        ->not->toHaveKey('$ref')
+        ->toHaveKey('content.application/json.schema.properties.message.example', $expected);
+})->with(['abort', 'abort_if', 'abort_unless']);
 
 class AbortHelpersResponseDocumentation_Test extends \Illuminate\Routing\Controller
 {
     public function abort_404()
     {
-        abort(404, 'Something is wrong.');
+        abort(404, 'Something is wrong abort_404.');
     }
 
     public function abort()
     {
-        abort(400, 'Something is wrong.');
+        abort(400, 'Something is wrong abort.');
     }
 
     public function abort_if()
     {
-        abort_if(rand(0, 1) > 0, 402, 'Something is wrong.');
+        abort_if(rand(0, 1) > 0, 402, 'Something is wrong abort_if.');
     }
 
     public function abort_unless()
     {
-        abort_unless(rand(0, 1) > 0, 403, 'Something is wrong.');
+        abort_unless(rand(0, 1) > 0, 403, 'Something is wrong abort_unless.');
+    }
+}
+
+class AbortHelpersResponseDocumentationTranslated_Test extends \Illuminate\Routing\Controller
+{
+    public function abort()
+    {
+        abort(400, __('example.abort'));
+    }
+
+    public function abort_if()
+    {
+        abort_if(rand(0, 1) > 0, 400, \Illuminate\Support\Facades\Lang::get('example.abort_if'));
+    }
+
+    public function abort_unless()
+    {
+        abort_unless(rand(0, 1) > 0, 400, trans('example.abort_unless'));
     }
 }


### PR DESCRIPTION
This is a POC for parsing ranslations when used in abort helpers:

```php
abort(400, __('response.abort'));
abort(400, __('This is an error'));
abort_if(rand(0, 1) > 0, 400, \Illuminate\Support\Facades\Lang::get('response.abort_if'));
abort_unless(rand(0, 1) > 0, 400, trans('response.abort_unless'));
```

It will check if the string is translatable and if it is use the translated value as an example in the docs.

I have tried to keep it pretty clean, but this is my first time diving into this repo so I appreciate there may have been a better way to approach this.