### PR TITLE
Fix using closure on route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,12 +1,11 @@
 <?php
 
+use Dedoc\Scramble\Generator;
 use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(config('scramble.middleware', [RestrictedDocsAccess::class]))->group(function () {
-    Route::get('docs/api.json', function (Dedoc\Scramble\Generator $generator) {
-        return $generator();
-    })->name('scramble.docs.index');
+    Route::get('docs/api.json', Generator::class)->name('scramble.docs.index');
 
     Route::view('docs/api', 'scramble::docs')->name('scramble.docs.api');
 });


### PR DESCRIPTION
### TL;DR
Laravel vapor doesn't support route closures when using `route:cache`  this fixes the `docs/api.json` to not use a closure.

### Description
We deploy our apps using Laravel vapor and it is a known issue that it doesn't support route closures when using `php artisan route:cache`.

The issue is that because the route caching process serializes closures unfortunately we end up with these errors when trying to access the `docs/api.json` route.

```json
{
    "message": "Your serialized closure might have been modified or it's unsafe to be unserialized.",
    "context": {
        "userId": 1,
        "exception": {
            "class": "Laravel\\SerializableClosure\\Exceptions\\InvalidSignatureException",
            "message": "Your serialized closure might have been modified or it's unsafe to be unserialized.",
            "code": 0,
            "file": "/var/task/vendor/laravel/serializable-closure/src/Serializers/Signed.php:83"
        },
        "aws_request_id": "749878ac-8385-4730-87a2-c86d22240a28"
    },
    "level": 400,
    "level_name": "ERROR",
    "channel": "test",
    "datetime": "2023-03-03T01:08:38.143823+00:00",
    "extra": {}
}
```

This makes the docs page show this error:
<img width="1341" alt="image" src="https://user-images.githubusercontent.com/20278756/222609213-e3d2250a-d283-4d88-afe2-feef0205c1d3.png">
