### PR TITLE
Add caching to docs api route

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -27,6 +27,23 @@ return [
         'description' => '',
     ],
 
+    'cache' => [
+        /*
+         * Enable caching of the docs/api.json route
+         */
+        'enabled' => env('SCRAMBLE_CACHE_ENABLED', false),
+
+        /*
+         * Specify the driver to use for caching, leave null to use default cache driver.
+         */
+        'driver' => env('SCRAMBLE_CACHE_DRIVER', null),
+
+        /*
+         * Specify the amount of time to cache the response for in seconds.
+         */
+        'ttl' => env('SCRAMBLE_CACHE_EXPIRY_SECONDS', 60 * 60)
+    ],
+
     /*
      * The list of servers of the API. By default (when `null`), server URL will be created from
      * `scramble.api_path` and `scramble.api_domain` config variables. When providing an array, you

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,10 +1,21 @@
 <?php
 
 use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(config('scramble.middleware', [RestrictedDocsAccess::class]))->group(function () {
     Route::get('docs/api.json', function (Dedoc\Scramble\Generator $generator) {
+        if (config('scramble.cache.enabled')) {
+            return Cache::driver(config('scramble.cache.driver'))->remember(
+                'scramble.docs.index.cache',
+                (int) config('scramble.cache.ttl'),
+                function () use ($generator) {
+                    return $generator();
+                },
+            );
+        }
+
         return $generator();
     })->name('scramble.docs.index');
 


### PR DESCRIPTION
This is a proof of concept of adding caching to the `docs/api.json` rather than generating the file every time the docs are loaded. 

This can be especially helpful when the docs are deployed to production and won't change until next deployment.