### PR TITLE
Ensuring that generated operation ID is always unique 

### DIFF
--- a/src/Support/Generator/Operation.php
+++ b/src/Support/Generator/Operation.php
@@ -4,6 +4,8 @@ namespace Dedoc\Scramble\Support\Generator;
 
 class Operation
 {
+    use WithAttributes;
+
     public string $method;
 
     public string $path = '';

--- a/src/Support/Generator/Types/Type.php
+++ b/src/Support/Generator/Types/Type.php
@@ -3,10 +3,11 @@
 namespace Dedoc\Scramble\Support\Generator\Types;
 
 use Dedoc\Scramble\Support\Generator\MissingExample;
+use Dedoc\Scramble\Support\Generator\WithAttributes;
 
 abstract class Type
 {
-    use TypeAttributes;
+    use WithAttributes;
 
     protected string $type;
 

--- a/src/Support/Generator/UniqueNameOptions.php
+++ b/src/Support/Generator/UniqueNameOptions.php
@@ -9,8 +9,7 @@ class UniqueNameOptions
         public readonly array $unique,
         public readonly string $separator = '.',
         public readonly int $fallbackEloquentPartsCount = 2,
-    )
-    {
+    ) {
     }
 
     public function getFallbackEloquent(): string
@@ -22,6 +21,6 @@ class UniqueNameOptions
 
     public function getFallback(): string
     {
-        return join($this->separator, $this->unique);
+        return implode($this->separator, $this->unique);
     }
 }

--- a/src/Support/Generator/UniqueNameOptions.php
+++ b/src/Support/Generator/UniqueNameOptions.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Dedoc\Scramble\Support\Generator;
+
+class UniqueNameOptions
+{
+    public function __construct(
+        public readonly ?string $eloquent,
+        public readonly array $unique,
+        public readonly string $separator = '.',
+        public readonly int $fallbackEloquentPartsCount = 2,
+    )
+    {
+    }
+
+    public function getFallbackEloquent(): string
+    {
+        return collect($this->unique)
+            ->take(-$this->fallbackEloquentPartsCount)
+            ->join($this->separator);
+    }
+
+    public function getFallback(): string
+    {
+        return join($this->separator, $this->unique);
+    }
+}

--- a/src/Support/Generator/UniqueNamesOptionsCollection.php
+++ b/src/Support/Generator/UniqueNamesOptionsCollection.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Dedoc\Scramble\Support\Generator;
+
+use Illuminate\Support\Collection;
+
+class UniqueNamesOptionsCollection
+{
+    /**
+     * @var array<string, UniqueNameOptions[]>
+     */
+    private array $eloquentNames = [];
+
+    /**
+     * @var array<string, UniqueNameOptions[]>
+     */
+    private array $fallbackEloquentNames = [];
+
+    /**
+     * @var array<string, UniqueNameOptions[]>
+     */
+    private array $fallbackNames = [];
+
+    public function __construct(
+        private Collection $names = new Collection,
+    )
+    {
+    }
+
+    public function push(UniqueNameOptions $name)
+    {
+        $this->names->push($name);
+
+        $this->eloquentNames[$name->eloquent] ??= [];
+        $this->eloquentNames[$name->eloquent][] = $name;
+
+        $this->fallbackEloquentNames[$name->getFallbackEloquent()] ??= [];
+        $this->fallbackEloquentNames[$name->getFallbackEloquent()][] = $name;
+
+        $this->fallbackNames[$name->getFallback()] ??= [];
+        $this->fallbackNames[$name->getFallback()][] = $name;
+
+        return $this;
+    }
+
+    public function getUniqueName(UniqueNameOptions $name, ?callable $onNotUniqueFallback = null): string
+    {
+        if ($name->eloquent && count($this->eloquentNames[$name->eloquent]) === 1) {
+            return $name->eloquent;
+        }
+
+        if (count($this->fallbackEloquentNames[$name->getFallbackEloquent()]) === 1) {
+            return $name->getFallbackEloquent();
+        }
+
+        if (count($this->fallbackNames[$name->getFallback()]) === 1) {
+            return $name->getFallback();
+        }
+
+        return $onNotUniqueFallback ? $onNotUniqueFallback($name->getFallback()) : throw new \LogicException('Cannot retrieve a unique name');
+    }
+}

--- a/src/Support/Generator/UniqueNamesOptionsCollection.php
+++ b/src/Support/Generator/UniqueNamesOptionsCollection.php
@@ -23,8 +23,7 @@ class UniqueNamesOptionsCollection
 
     public function __construct(
         private Collection $names = new Collection,
-    )
-    {
+    ) {
     }
 
     public function push(UniqueNameOptions $name)
@@ -43,7 +42,7 @@ class UniqueNamesOptionsCollection
         return $this;
     }
 
-    public function getUniqueName(UniqueNameOptions $name, ?callable $onNotUniqueFallback = null): string
+    public function getUniqueName(UniqueNameOptions $name, callable $onNotUniqueFallback = null): string
     {
         if ($name->eloquent && count($this->eloquentNames[$name->eloquent]) === 1) {
             return $name->eloquent;

--- a/src/Support/Generator/WithAttributes.php
+++ b/src/Support/Generator/WithAttributes.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Dedoc\Scramble\Support\Generator\Types;
+namespace Dedoc\Scramble\Support\Generator;
 
-trait TypeAttributes
+trait WithAttributes
 {
     /** @var array<string, mixed> */
     private $attributes = [];

--- a/src/Support/OperationExtensions/RequestEssentialsExtension.php
+++ b/src/Support/OperationExtensions/RequestEssentialsExtension.php
@@ -15,6 +15,7 @@ use Dedoc\Scramble\Support\Generator\Types\NumberType;
 use Dedoc\Scramble\Support\Generator\Types\StringType;
 use Dedoc\Scramble\Support\Generator\Types\Type;
 use Dedoc\Scramble\Support\Generator\TypeTransformer;
+use Dedoc\Scramble\Support\Generator\UniqueNameOptions;
 use Dedoc\Scramble\Support\PhpDoc;
 use Dedoc\Scramble\Support\RouteInfo;
 use Dedoc\Scramble\Support\ServerFactory;
@@ -66,7 +67,7 @@ class RequestEssentialsExtension extends OperationExtension
             $operation->addSecurity([]);
         }
 
-        $operation->setOperationId($this->getOperationId($routeInfo));
+        $operation->setAttribute('operationId', $this->getOperationId($routeInfo));
     }
 
     /**
@@ -240,22 +241,38 @@ class RequestEssentialsExtension extends OperationExtension
 
     private function getOperationId(RouteInfo $routeInfo)
     {
-        // Manual operation ID setting.
-        if (
-            ($operationId = $routeInfo->phpDoc()->getTagsByName('@operationId'))
-            && ($value = trim(Arr::first($operationId)?->value?->value))
-        ) {
-            return $value;
-        }
+        $routeClassName = $routeInfo->className() ?: '';
 
-        // Using route name as operation ID if set.
-        if ($name = $routeInfo->route->getName()) {
-            return $name;
-        }
+        return new UniqueNameOptions(
+            eloquent: (function () use ($routeInfo) {
+                // Manual operation ID setting.
+                if (
+                    ($operationId = $routeInfo->phpDoc()->getTagsByName('@operationId'))
+                    && ($value = trim(Arr::first($operationId)?->value?->value))
+                ) {
+                    return $value;
+                }
 
-        // If no name and no operationId manually set, falling back to controller and method name.
-        return Str::camel(Str::replaceLast('Controller', '', $routeInfo->className() ?: ''))
-            .'.'
-            .Str::camel($routeInfo->methodName());
+                // Using route name as operation ID if set.
+                if ($name = $routeInfo->route->getName()) {
+                    return Str::startsWith($name, 'api.') ? Str::replaceFirst('api.', '', $name) : $name;
+                }
+
+                // If no name and no operationId manually set, falling back to controller and method name (unique implementation).
+                return null;
+            })(),
+            unique: collect(explode('\\', Str::endsWith($routeClassName, 'Controller') ? Str::replaceLast('Controller', '', $routeClassName) : $routeClassName))
+                ->filter()
+                ->push($routeInfo->methodName())
+                ->map(function ($part) {
+                    if ($part === Str::upper($part)) {
+                        return Str::lower($part);
+                    }
+                    return Str::camel($part);
+                })
+                ->reject(fn ($p) => in_array(Str::lower($p), ['app', 'http', 'api', 'controllers', 'invoke']))
+                ->values()
+                ->toArray(),
+        );
     }
 }

--- a/src/Support/OperationExtensions/RequestEssentialsExtension.php
+++ b/src/Support/OperationExtensions/RequestEssentialsExtension.php
@@ -268,6 +268,7 @@ class RequestEssentialsExtension extends OperationExtension
                     if ($part === Str::upper($part)) {
                         return Str::lower($part);
                     }
+
                     return Str::camel($part);
                 })
                 ->reject(fn ($p) => in_array(Str::lower($p), ['app', 'http', 'api', 'controllers', 'invoke']))

--- a/tests/Generator/Operation/OperationIdTest.php
+++ b/tests/Generator/Operation/OperationIdTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Dedoc\Scramble\Scramble;
+use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Route as RouteFacade;
 
 it('documents operation id based on controller base name if no route name and not set manually', function () {
@@ -28,11 +30,39 @@ it('documents operation id based on route name if not set manually', function ()
     });
 
     expect($openApiDocument['paths']['/test']['get'])
-        ->toHaveKey('operationId', 'api.namedOperationIdA');
+        ->toHaveKey('operationId', 'namedOperationIdA');
 });
 class NamedOperationIdDocumentationTestController extends \Illuminate\Routing\Controller
 {
     public function a(): Illuminate\Http\Resources\Json\JsonResource
+    {
+        return $this->unknown_fn();
+    }
+}
+
+it('ensures operation id is unique if not set manually', function () {
+    /*
+     * This is the setup that can make operationId not unique as name for both routes
+     * is `api.`.
+     */
+    RouteFacade::name('api.')->group(function () use (&$route) {
+        RouteFacade::get('api/test/a', [UniqueOperationIdDocumentationTestController::class, 'a']);
+        RouteFacade::get('api/test/b', [UniqueOperationIdDocumentationTestController::class, 'b']);
+    });
+    Scramble::routes(fn (Route $r) => str_contains($r->uri, 'test/'));
+    $openApiDocument = app()->make(\Dedoc\Scramble\Generator::class)();
+
+    expect($openApiDocument['paths']['/test/a']['get']['operationId'])
+        ->not->toBe($openApiDocument['paths']['/test/b']['get']['operationId']);
+});
+class UniqueOperationIdDocumentationTestController extends \Illuminate\Routing\Controller
+{
+    public function a()
+    {
+        return $this->unknown_fn();
+    }
+
+    public function b()
     {
         return $this->unknown_fn();
     }

--- a/tests/__snapshots__/ValidationRulesDocumentingTest__it_supports_manual_authentication_info__1.yml
+++ b/tests/__snapshots__/ValidationRulesDocumentingTest__it_supports_manual_authentication_info__1.yml
@@ -7,6 +7,6 @@ servers:
 security:
     - { apiKey: {  } }
 paths:
-    /test: { get: { operationId: withoutSecurity.index, tags: [WithoutSecurity], responses: { 200: { description: '', content: { application/json: { schema: { type: string } } } } }, security: [{  }] } }
+    /test: { get: { operationId: controllerWithoutSecurity.index, tags: [WithoutSecurity], responses: { 200: { description: '', content: { application/json: { schema: { type: string } } } } }, security: [{  }] } }
 components:
     securitySchemes: { apiKey: { type: apiKey, in: query, name: api_token } }


### PR DESCRIPTION
https://spec.openapis.org/oas/v3.1.0#fixed-fields-7

`operationId` MUST be unique, and this PR makes sure that generated ids are indeed unique.

This PR also gives a better way to select unique name of class-based instances which will be useful for naming components.