### PR TITLE
feat: allow customisation of docs path

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -3,6 +3,12 @@
 use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
 
 return [
+    /**
+     * This is the URI path where the docs will be accessible from. Feel free
+     * to change this path to anything you like.
+     */
+    'path' => env('SCRAMBLE_PATH', 'docs/api'),
+
     /*
      * Your API path. By default, all routes starting with this path will be added to the docs.
      * If you need to change this behavior, you can add your custom routes resolver using `Scramble::routes()`.

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,7 +4,7 @@ use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(config('scramble.middleware', [RestrictedDocsAccess::class]))->group(function () {
-    Route::get('docs/api.json', function (Dedoc\Scramble\Generator $generator) {
+    Route::get(config('scramble.path', 'docs/api') . '.json', function (Dedoc\Scramble\Generator $generator) {
         return $generator();
     })->name('scramble.docs.index');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,5 +8,5 @@ Route::middleware(config('scramble.middleware', [RestrictedDocsAccess::class]))-
         return $generator();
     })->name('scramble.docs.index');
 
-    Route::view('docs/api', 'scramble::docs')->name('scramble.docs.api');
+    Route::view(config('scramble.path', 'docs/api'), 'scramble::docs')->name('scramble.docs.api');
 });


### PR DESCRIPTION
This PR adds the ability to customize the route where documentation can be accessed. This is especially helpful when your base API is available at `https://api.example.com`.

Allowing users to change the path would make it possible to access docs from `https://api.example.com/docs` instead of `https://api.example.com/docs/api`.