### PR TITLE
Allow Spotlight to be customized (`Try It` disabled and logo)

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -28,6 +28,21 @@ return [
     ],
 
     /*
+     * Customize Stoplight Elements UI
+     */
+    'ui' => [
+        /*
+         * Hide the `Try It` feature. Enabled by default.
+         */
+        'hide_try_it' => false,
+
+        /*
+         * URL to an image that displays as a small square logo next to the title, above the table of contents.
+         */
+        'logo' => '',
+    ],
+
+    /*
      * The list of servers of the API. By default, when `null`, server URL will be created from
      * `scramble.api_path` and `scramble.api_domain` config variables. When providing an array, you
      * will need to specify the local server URL manually (if needed).

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -12,6 +12,8 @@
 <elements-api
     apiDescriptionUrl="{{ route('scramble.docs.index') }}"
     router="hash"
+    @if(config('scramble.ui.hide_try_it')) hideTryIt="true" @endif
+    logo="{{ config('scramble.ui.logo') }}"
 />
 </body>
 </html>


### PR DESCRIPTION
This PR allow Spotlight Elements UI to be customized.

According to the [Spotlight Doc](https://github.com/stoplightio/elements/blob/main/docs/getting-started/elements/elements-options.md), we can disable `Try It` feature and add a square logo with the title.

With this PR, you've the control on which environnement you want to allow `Try It` feature:
```php
    'ui' => [
        /*
         * Hide the `Try It` feature. Enabled by default.
         */
        'hide_try_it' => match (env('APP_ENV')) {
            'production' => true,
            default => false,
        },

        /*
         * URL to an image that displays as a small square logo next to the title, above the table of contents.
         */
        'logo' => 'https://scramble.dedoc.co/images/favicon/favicon-32x32.png',
    ],
```

Logo preview:
<img width="295" alt="Scramble Doc logo" src="https://github.com/dedoc/scramble/assets/12150996/b38bd8e3-ce95-4b4a-9b9e-e61e9a571187">

---

_I tried to set `hideTryIt="{{ config('scramble.ui.hide_try_it') }}"` but it doesn't work_