### PR TITLE
Default classes in service provider retrieval via DI container

### DIFF
--- a/src/Configuration/DefaultExceptionToResponseExtensionClasses.php
+++ b/src/Configuration/DefaultExceptionToResponseExtensionClasses.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dedoc\Scramble\Configuration;
+
+use Dedoc\Scramble\Extensions\ExceptionToResponseExtension;
+use Dedoc\Scramble\Support\ExceptionToResponseExtensions\AuthorizationExceptionToResponseExtension;
+use Dedoc\Scramble\Support\ExceptionToResponseExtensions\HttpExceptionToResponseExtension;
+use Dedoc\Scramble\Support\ExceptionToResponseExtensions\NotFoundExceptionToResponseExtension;
+use Dedoc\Scramble\Support\ExceptionToResponseExtensions\ValidationExceptionToResponseExtension;
+
+class DefaultExceptionToResponseExtensionClasses
+{
+    /**
+     * @return array<class-string<ExceptionToResponseExtension>>
+     */
+    public function get(): array
+    {
+        return [
+            ValidationExceptionToResponseExtension::class,
+            AuthorizationExceptionToResponseExtension::class,
+            NotFoundExceptionToResponseExtension::class,
+            HttpExceptionToResponseExtension::class,
+        ];
+    }
+}

--- a/src/Configuration/DefaultOperationBuilderExtensionClasses.php
+++ b/src/Configuration/DefaultOperationBuilderExtensionClasses.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Dedoc\Scramble\Configuration;
+
+use Dedoc\Scramble\Extensions\OperationExtension;
+use Dedoc\Scramble\Support\OperationExtensions\ErrorResponsesExtension;
+use Dedoc\Scramble\Support\OperationExtensions\RequestBodyExtension;
+use Dedoc\Scramble\Support\OperationExtensions\RequestEssentialsExtension;
+use Dedoc\Scramble\Support\OperationExtensions\ResponseExtension;
+
+class DefaultOperationBuilderExtensionClasses
+{
+    /**
+     * @return array<class-string<OperationExtension>>
+     */
+    public function get(): array {
+        return [
+            RequestEssentialsExtension::class,
+            RequestBodyExtension::class,
+            ErrorResponsesExtension::class,
+            ResponseExtension::class,
+        ];
+    }
+}

--- a/src/Configuration/DefaultTypeToSchemaExtensionClasses.php
+++ b/src/Configuration/DefaultTypeToSchemaExtensionClasses.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dedoc\Scramble\Configuration;
+
+use Dedoc\Scramble\Extensions\TypeToSchemaExtension;
+use Dedoc\Scramble\Support\TypeToSchemaExtensions\AnonymousResourceCollectionTypeToSchema;
+use Dedoc\Scramble\Support\TypeToSchemaExtensions\EloquentCollectionToSchema;
+use Dedoc\Scramble\Support\TypeToSchemaExtensions\EnumToSchema;
+use Dedoc\Scramble\Support\TypeToSchemaExtensions\JsonResourceTypeToSchema;
+use Dedoc\Scramble\Support\TypeToSchemaExtensions\LengthAwarePaginatorTypeToSchema;
+use Dedoc\Scramble\Support\TypeToSchemaExtensions\ModelToSchema;
+use Dedoc\Scramble\Support\TypeToSchemaExtensions\ResponseTypeToSchema;
+
+class DefaultTypeToSchemaExtensionClasses
+{
+    /**
+     * @return array<class-string<TypeToSchemaExtension>>
+     */
+    public function get(): array
+    {
+        return [
+            EnumToSchema::class,
+            JsonResourceTypeToSchema::class,
+            ModelToSchema::class,
+            EloquentCollectionToSchema::class,
+            AnonymousResourceCollectionTypeToSchema::class,
+            LengthAwarePaginatorTypeToSchema::class,
+            ResponseTypeToSchema::class,
+        ];
+    }
+}


### PR DESCRIPTION
Hello,

I have a use case where I would like to override the default classes and extensions which are registered without having to mess with the bootstrapping of the package itself (read: "I don't want to copy over the `$this->app->when(...` part).

