### PR TITLE
Added configuration to enable Subresource Integrity (SRI) check

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -40,6 +40,21 @@ return [
          * URL to an image that displays as a small square logo next to the title, above the table of contents.
          */
         'logo' => '',
+
+        /*
+         * Configuration to enable Subresource Integrity (SRI)
+         * https://developer.mozilla.org/fr/docs/Web/Security/Subresource_Integrity
+         */
+        'sri' => [
+            'enabled' => true,
+            'version' => '@7.9.0',
+            'hash' => [
+                // https://unpkg.com/@stoplight/elements@7.9.0/web-components.min.js?meta
+                'script' => 'sha384-lBoWYy+Eptz3g7n79Y4x0OKeG7AeE+wpQjji/y2F5LlyYXEKG672w06xkyGwRCin',
+                // https://unpkg.com/@stoplight/elements@7.9.0/styles.min.css?meta
+                'style' => 'sha384-1lLf7J28IOR7k5RlItk6Y+G3hDgVB3y4RCgWNq6ZSwjYfvJXPtZAdW0uklsAZbGW',
+            ],
+        ],
     ],
 
     /*

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -5,8 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>{{ config('app.name') }} - API Docs</title>
 
-    <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+    @if(config('scramble.ui.sri.enabled'))
+        <script
+            src="https://unpkg.com/@stoplight/elements{{ config('scramble.ui.sri.version') }}/web-components.min.js"
+            integrity="{{ config('scramble.ui.sri.hash.script') }}"
+            crossorigin="anonymous"></script>
+        <link
+            rel="stylesheet"
+            href="https://unpkg.com/@stoplight/elements{{ config('scramble.ui.sri.version') }}/styles.min.css"
+            integrity="{{ config('scramble.ui.sri.hash.style') }}"
+            crossorigin="anonymous" />
+    @else
+        <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+    @endif
 </head>
 <body style="height: 100vh; overflow-y: hidden">
 <elements-api


### PR DESCRIPTION
This PR add a configuration to enable Subresource Integrity (SRI) for `stoplight/elements` assets.

As it could be a security issue, I enabled it by default.
Unfortunately, you have to edit the configuration to update UI. _(version and both hash keys)_