### PR TITLE
add: Image and file validator support, request @mediaType tag support

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
@@ -92,6 +92,24 @@ class RulesMapper
         return $type->format('email');
     }
 
+    public function image(Type $type)
+    {
+        if ($type instanceof UnknownType) {
+            $type = $this->string($type);
+        }
+
+        return $type->format('binary');
+    }
+
+    public function file(Type $type)
+    {
+        if ($type instanceof UnknownType) {
+            $type = $this->string($type);
+        }
+
+        return $type->format('binary');
+    }
+
     public function uuid(Type $type)
     {
         if ($type instanceof UnknownType) {

--- a/tests/ValidationRulesDocumentingTest.php
+++ b/tests/ValidationRulesDocumentingTest.php
@@ -134,6 +134,28 @@ it('supports exists rule', function () {
         ->and($type->format)->toBe('email');
 });
 
+it('supports image rule', function () {
+    $rules = [
+        'image' => 'required|image',
+    ];
+
+    $type = app()->make(RulesToParameters::class, ['rules' => $rules])->handle()[0]->schema->type;
+
+    expect($type)->toBeInstanceOf(StringType::class)
+        ->and($type->format)->toBe('binary');
+});
+
+it('supports file rule', function () {
+    $rules = [
+        'file' => 'required|file',
+    ];
+
+    $type = app()->make(RulesToParameters::class, ['rules' => $rules])->handle()[0]->schema->type;
+
+    expect($type)->toBeInstanceOf(StringType::class)
+        ->and($type->format)->toBe('binary');
+});
+
 it('extracts rules from request->validate call', function () {
     RouteFacade::get('api/test', [ValidationRulesDocumenting_Test::class, 'index']);
 


### PR DESCRIPTION
This PR adds detection for 'image' and 'file' rules and setting their format as binary, in addition it also adds support for the @mediaType tag that will set the mediaType of the request closing discusttion #223 .