### PR TITLE
added support for 'multipart/form-data' in the requestBody

### DIFF
--- a/src/Support/OperationExtensions/RequestBodyExtension.php
+++ b/src/Support/OperationExtensions/RequestBodyExtension.php
@@ -4,6 +4,7 @@ namespace Dedoc\Scramble\Support\OperationExtensions;
 
 use Dedoc\Scramble\Extensions\OperationExtension;
 use Dedoc\Scramble\Support\Generator\Operation;
+use Dedoc\Scramble\Support\Generator\Parameter;
 use Dedoc\Scramble\Support\Generator\RequestBodyObject;
 use Dedoc\Scramble\Support\Generator\Schema;
 use Dedoc\Scramble\Support\Generator\Types\ObjectType;
@@ -27,8 +28,10 @@ class RequestBodyExtension extends OperationExtension
         try {
             if (count($bodyParams = $this->extractParamsFromRequestValidationRules($routeInfo->route, $routeInfo->methodNode()))) {
                 if ($method !== 'get') {
+                    $contentType = $this->hasBinary($bodyParams) ? 'multipart/form-data' : 'application/json';
+
                     $operation->addRequestBodyObject(
-                        RequestBodyObject::make()->setContent('application/json', Schema::createFromParameters($bodyParams))
+                        RequestBodyObject::make()->setContent($contentType, Schema::createFromParameters($bodyParams))
                     );
                 } else {
                     $operation->addParameters($bodyParams);
@@ -53,6 +56,17 @@ class RequestBodyExtension extends OperationExtension
         $operation
             ->summary(Str::of($routeInfo->phpDoc()->getAttribute('summary'))->rtrim('.'))
             ->description($description);
+    }
+
+    private function hasBinary($bodyParams): bool
+    {
+        return collect($bodyParams)->contains(function (Parameter $parameter) {
+            if (property_exists($parameter?->schema?->type, 'format')) {
+                return $parameter->schema->type->format === 'binary';
+            }
+
+            return false;
+        });
     }
 
     private function extractParamsFromRequestValidationRules(Route $route, ?ClassMethod $methodNode)

--- a/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
@@ -157,4 +157,18 @@ class RulesMapper
             new ObjectType($enumName)
         );
     }
+
+    public function image(Type $type)
+    {
+        return $this->file($type);
+    }
+
+    public function file(Type $type)
+    {
+        if ($type instanceof UnknownType) {
+            $type = $this->string($type);
+        }
+
+        return $type->format('binary');
+    }
 }

--- a/src/Support/OperationExtensions/RulesExtractor/RulesToParameter.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesToParameter.php
@@ -23,7 +23,7 @@ class RulesToParameter
     private ?PhpDocNode $docNode;
 
     const RULES_PRIORITY = [
-        'bool', 'boolean', 'numeric', 'int', 'integer', 'string', 'array', 'exists',
+        'bool', 'boolean', 'numeric', 'int', 'integer', 'file', 'image', 'string', 'array', 'exists',
     ];
 
     public function __construct(string $name, $rules, ?PhpDocNode $docNode, TypeTransformer $openApiTransformer)

--- a/tests/ValidationRulesDocumentingTest.php
+++ b/tests/ValidationRulesDocumentingTest.php
@@ -321,3 +321,52 @@ class ControllerWithoutSecurity
     {
     }
 }
+
+it('extracts file rule from Validator::make facade call', function () {
+    RouteFacade::post('api/test', [ValidationFacadeRulesFile_Test::class, 'index']);
+
+    Scramble::routes(fn (Route $r) => $r->uri === 'api/test');
+    $openApiDocument = app()->make(\Dedoc\Scramble\Generator::class)();
+
+    assertMatchesSnapshot($openApiDocument);
+});
+
+it('extracts image rule from form request', function () {
+    RouteFacade::post('api/test', [ValidationRulesImageFromRequest_Test::class, 'index']);
+
+    Scramble::routes(fn (Route $r) => $r->uri === 'api/test');
+    $openApiDocument = app()->make(\Dedoc\Scramble\Generator::class)();
+
+    expect($openApiDocument['paths']['/test']['post']['requestBody']['content'])
+        ->toHaveKey('multipart/form-data');
+
+    assertMatchesSnapshot($openApiDocument);
+});
+
+class ValidationRulesImage_TestFormRequest extends \Illuminate\Foundation\Http\FormRequest
+{
+    public function rules()
+    {
+        return [
+            'file' => 'image',
+        ];
+    }
+}
+
+class ValidationRulesImageFromRequest_Test
+{
+    public function index(ValidationRulesImage_TestFormRequest $request)
+    {
+        //
+    }
+}
+
+class ValidationFacadeRulesFile_Test
+{
+    public function index(Request $request)
+    {
+        Validator::make($request->all(), [
+            'file' => ['file'],
+        ]);
+    }
+}

--- a/tests/__snapshots__/ValidationRulesDocumentingTest__it_extracts_file_rule_from_Validatormake_facade_call__1.yml
+++ b/tests/__snapshots__/ValidationRulesDocumentingTest__it_extracts_file_rule_from_Validatormake_facade_call__1.yml
@@ -1,0 +1,8 @@
+openapi: 3.1.0
+info:
+    title: Laravel
+    version: 0.0.1
+servers:
+    - { url: 'http://localhost/api' }
+paths:
+    /test: { post: { operationId: validationFacadeRulesFileTest.index, tags: [ValidationFacadeRulesFile_Test], requestBody: { content: { multipart/form-data: { schema: { type: object, properties: { file: { type: string, format: binary } } } } } }, responses: { 200: { description: '', content: { application/json: { schema: { type: string } } } } } } }

--- a/tests/__snapshots__/ValidationRulesDocumentingTest__it_extracts_image_rule_from_form_request__1.yml
+++ b/tests/__snapshots__/ValidationRulesDocumentingTest__it_extracts_image_rule_from_form_request__1.yml
@@ -1,0 +1,10 @@
+openapi: 3.1.0
+info:
+    title: Laravel
+    version: 0.0.1
+servers:
+    - { url: 'http://localhost/api' }
+paths:
+    /test: { post: { operationId: validationRulesImageFromRequestTest.index, tags: [ValidationRulesImageFromRequest_Test], requestBody: { content: { multipart/form-data: { schema: { type: object, properties: { file: { type: string, format: binary } } } } } }, responses: { 200: { description: '', content: { application/json: { schema: { type: string } } } }, 422: { $ref: '#/components/responses/ValidationException' }, 403: { $ref: '#/components/responses/AuthorizationException' } } } }
+components:
+    responses: { ValidationException: { description: 'Validation error', content: { application/json: { schema: { type: object, properties: { message: { type: string, description: 'Errors overview.' }, errors: { type: object, description: 'A detailed description of each field that failed validation.', additionalProperties: { type: array, items: { type: string } } } }, required: [message, errors] } } } }, AuthorizationException: { description: 'Authorization error', content: { application/json: { schema: { type: object, properties: { message: { type: string, description: 'Error overview.' } }, required: [message] } } } } }


### PR DESCRIPTION
Added multipart/form-data substitution when there is a file or image rule

P.S. I know it looks clumsy. I think it will be necessary to consider supporting custom rules