### PR TITLE
Fixed 'Try it' not working with Laravel Sanctum (cookies)

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -42,9 +42,9 @@ return [
         'logo' => '',
 
         /*
-         * Use to fetch the credential policy for the Try It feature. Options are: omit (default), include, and same-origin
+         * Use to fetch the credential policy for the Try It feature. Options are: omit, include (default), and same-origin
          */
-        'try_it_credentials_policy' => 'omit'
+        'try_it_credentials_policy' => 'include',
     ],
 
     /*

--- a/config/scramble.php
+++ b/config/scramble.php
@@ -40,6 +40,11 @@ return [
          * URL to an image that displays as a small square logo next to the title, above the table of contents.
          */
         'logo' => '',
+
+        /*
+         * Use to fetch the credential policy for the Try It feature. Options are: omit (default), include, and same-origin
+         */
+        'try_it_credentials_policy' => 'omit'
     ],
 
     /*

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -11,7 +11,7 @@
 <body style="height: 100vh; overflow-y: hidden">
 <elements-api
     apiDescriptionUrl="{{ route('scramble.docs.index') }}"
-    tryItCredentialsPolicy="{{ config('scramble.ui.try_it_credentials_policy', 'omit') }}"
+    tryItCredentialsPolicy="{{ config('scramble.ui.try_it_credentials_policy', 'include') }}"
     router="hash"
     @if(config('scramble.ui.hide_try_it')) hideTryIt="true" @endif
     logo="{{ config('scramble.ui.logo') }}"

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -11,6 +11,7 @@
 <body style="height: 100vh; overflow-y: hidden">
 <elements-api
     apiDescriptionUrl="{{ route('scramble.docs.index') }}"
+    tryItCredentialsPolicy="{{ config('scramble.ui.try_it_credentials_policy', 'omit') }}"
     router="hash"
     @if(config('scramble.ui.hide_try_it')) hideTryIt="true" @endif
     logo="{{ config('scramble.ui.logo') }}"


### PR DESCRIPTION
## Problem:
It is not possible to authorize sanctum-protected endpoints via cookies, because cookies aren't included in the requests that are made via 'Try It'
## Solution:
Make 'Try It' automatically include cookies in requests it's making
```html
<elements-api tryItCredentialsPolicy="include"...
```
Don't worry, above code is just an example. I made the `tryItCredentialsPolicy` option configurable, by default this option is  set to `omit`, which is a default behaviour
