### PR TITLE
Added support for `min` and `max` rules on arrays

### DIFF
--- a/src/Support/Generator/Types/ArrayType.php
+++ b/src/Support/Generator/Types/ArrayType.php
@@ -9,17 +9,42 @@ class ArrayType extends Type
     /** @var Type|Schema */
     public $items;
 
+    private $minItems = null;
+
+    private $maxItems = null;
+
     public function __construct()
     {
         parent::__construct('array');
         $this->items = new StringType;
     }
 
+    public function setMin($min)
+    {
+        $this->minItems = $min;
+
+        return $this;
+    }
+
+    public function setMax($max)
+    {
+        $this->maxItems = $max;
+
+        return $this;
+    }
+
     public function toArray()
     {
-        return array_merge(parent::toArray(), [
-            'items' => $this->items->toArray(),
-        ]);
+        return array_merge(
+            parent::toArray(),
+            [
+                'items' => $this->items->toArray(),
+            ],
+            array_filter([
+                'minItems' => $this->minItems,
+                'maxItems' => $this->maxItems,
+            ], fn ($v) => $v !== null)
+        );
     }
 
     public function setItems($items)

--- a/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
@@ -115,7 +115,7 @@ class RulesMapper
 
     public function min(Type $type, $params)
     {
-        if ($type instanceof NumberType) {
+        if ($type instanceof NumberType || $type instanceof ArrayType) {
             $type->setMin((float) $params[0]);
         }
 
@@ -124,7 +124,7 @@ class RulesMapper
 
     public function max(Type $type, $params)
     {
-        if ($type instanceof NumberType) {
+        if ($type instanceof NumberType || $type instanceof ArrayType) {
             $type->setMax((float) $params[0]);
         }
 

--- a/tests/ValidationRulesDocumentingTest.php
+++ b/tests/ValidationRulesDocumentingTest.php
@@ -156,6 +156,62 @@ it('supports file rule', function () {
         ->and($type->format)->toBe('binary');
 });
 
+it('converts min rule into "minimum" for numeric fields', function () {
+    $rules = [
+        'num' => ['int', 'min:8',],
+    ];
+
+    $params = app()->make(RulesToParameters::class, ['rules' => $rules])->handle();
+
+    expect($params = collect($params)->all())
+        ->toHaveCount(1)
+        ->and($params[0]->schema->type)
+        ->toBeInstanceOf(\Dedoc\Scramble\Support\Generator\Types\NumberType::class)
+        ->toHaveKey('minimum', 8);
+});
+
+it('converts max rule into "maximum" for numeric fields', function () {
+    $rules = [
+        'num' => ['int', 'max:8',],
+    ];
+
+    $params = app()->make(RulesToParameters::class, ['rules' => $rules])->handle();
+
+    expect($params = collect($params)->all())
+        ->toHaveCount(1)
+        ->and($params[0]->schema->type)
+        ->toBeInstanceOf(\Dedoc\Scramble\Support\Generator\Types\NumberType::class)
+        ->toHaveKey('maximum', 8);
+});
+
+it('converts min rule into "minItems" for array fields', function () {
+    $rules = [
+        'num' => ['array', 'min:8',],
+    ];
+
+    $params = app()->make(RulesToParameters::class, ['rules' => $rules])->handle();
+
+    expect($params = collect($params)->all())
+        ->toHaveCount(1)
+        ->and($params[0]->schema->type)
+        ->toBeInstanceOf(\Dedoc\Scramble\Support\Generator\Types\ArrayType::class)
+        ->toHaveKey('minItems', 8);
+});
+
+it('converts max rule into "maxItems" for array fields', function () {
+    $rules = [
+        'num' => ['array', 'max:8',],
+    ];
+
+    $params = app()->make(RulesToParameters::class, ['rules' => $rules])->handle();
+
+    expect($params = collect($params)->all())
+        ->toHaveCount(1)
+        ->and($params[0]->schema->type)
+        ->toBeInstanceOf(\Dedoc\Scramble\Support\Generator\Types\ArrayType::class)
+        ->toHaveKey('maxItems', 8);
+});
+
 it('extracts rules from request->validate call', function () {
     RouteFacade::get('api/test', [ValidationRulesDocumenting_Test::class, 'index']);
 


### PR DESCRIPTION
This PR implements maxItems and minItems support for array type. It kinda lead to some duplicated (and maybe clumsy) code, so feel free to ask me to refactor or whatever (if you intend to merge it, of course). Congrats for the great repo.