### PR TITLE
Excluding false positives in route filtering in Generator@getRoutes

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -141,7 +141,10 @@ class Generator
                 $routeResolver = Scramble::$routeResolver ?? function (Route $route) {
                     $expectedDomain = config('scramble.api_domain');
 
-                    return Str::startsWith($route->uri, config('scramble.api_path', 'api'))
+                    $routePrefix = trim(config('scramble.api_path', 'api'), '/');
+                    $routeRegex = '/^' . preg_quote($routePrefix, '/') . '((\/.+)|$)/';
+
+                    return preg_match($routeRegex, $route->uri)
                         && (! $expectedDomain || $route->getDomain() === $expectedDomain);
                 };
 

--- a/tests/Generator/Routes/RoutesFilteringTest.php
+++ b/tests/Generator/Routes/RoutesFilteringTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Dedoc\Scramble\Generator;
+use Dedoc\Scramble\Scramble;
+use Illuminate\Support\Facades\Route as RouteFacade;
+
+beforeEach(function () {
+    Scramble::$routeResolver = null;
+});
+
+it('includes routes that share same prefix', function () {
+
+    config()->set('scramble.api_path', 'api/v1');
+
+    $fooController = new class
+    {
+        public function __invoke()
+        {
+            return 1;
+        }
+    };
+
+    $included = 'api/v1/foo';
+
+    RouteFacade::post($included, $fooController::class);
+
+    $openApiDocument = app()->make(Generator::class)();
+
+    expect($openApiDocument)->toHaveKey('paths')
+        ->and($openApiDocument['paths'])
+        ->toHaveCount(1)
+        ->and($openApiDocument['paths'])->ToHaveKey('/foo');
+});
+
+it('filters routes with different prefix', function () {
+
+    config()->set('scramble.api_path', 'api/v1');
+
+    $fooController = new class
+    {
+        public function __invoke()
+        {
+            return 1;
+        }
+    };
+
+    $included = 'api/v2/foo';
+
+    RouteFacade::post($included, $fooController::class);
+
+    $openApiDocument = app()->make(Generator::class)();
+
+    expect($openApiDocument)->not->toHaveKey('paths');
+});
+
+it('includes routes with uri == prefix,', function () {
+
+    config()->set('scramble.api_path', 'api/v1');
+
+    $fooController = new class
+    {
+        public function __invoke()
+        {
+            return 1;
+        }
+    };
+
+    $included = 'api/v1';
+
+    RouteFacade::post($included, $fooController::class);
+
+    $openApiDocument = app()->make(Generator::class)();
+
+    expect($openApiDocument)->toHaveKey('paths')
+        ->and($openApiDocument['paths'])
+        ->toHaveCount(1)
+        ->and($openApiDocument['paths'])->ToHaveKey('/');});
+
+it('filters false positives', function () {
+
+    $fooController = new class
+    {
+        public function __invoke()
+        {
+            return 1;
+        }
+    };
+
+    // starts with api, but not as route prefix
+    $excluded = 'apicoltore';
+
+    RouteFacade::post($excluded, $fooController::class);
+
+    $openApiDocument = app()->make(Generator::class)();
+
+    expect($openApiDocument)->not->toHaveKey('paths');
+});


### PR DESCRIPTION
Str::startsWith($route->uri, config('scramble.api_path', 'api') may actually includes web routes (I.E.: '/apicoltore').
Kinda preventing that, plus making config('scramble.api_path') a little more error forgiving (by trimming leading and trailing slashes before matching it with route URIs).