### PR TITLE
Fixed error when trying to access tag data

### DIFF
--- a/src/Support/OperationExtensions/RequestEssentialsExtension.php
+++ b/src/Support/OperationExtensions/RequestEssentialsExtension.php
@@ -130,7 +130,7 @@ class RequestEssentialsExtension extends OperationExtension
             return [];
         }
 
-        return explode(',', $tagNodes[0]->value->value);
+        return explode(',', array_values($tagNodes)[0]->value->value);
     }
 
     private function getParametersFromString(?string $str)


### PR DESCRIPTION
Solves [Issue when grouping by tags.](https://github.com/dedoc/scramble/issues/269)

After debugging, I've found, that 
```php
$classPhpDoc->getTagsByName('@tags')
```
return array 
```
array:1 [▼
  1 => PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode {#5375 ▶}
]
```

So, simple array_values method should solve issue of grouping controllers by tags.