### PR TITLE
Extract Format in StringType using @format tag

### DIFF
--- a/src/ScrambleServiceProvider.php
+++ b/src/ScrambleServiceProvider.php
@@ -33,6 +33,7 @@ use Dedoc\Scramble\Support\ServerFactory;
 use Dedoc\Scramble\Support\TypeToSchemaExtensions\AnonymousResourceCollectionTypeToSchema;
 use Dedoc\Scramble\Support\TypeToSchemaExtensions\EloquentCollectionToSchema;
 use Dedoc\Scramble\Support\TypeToSchemaExtensions\EnumToSchema;
+use Dedoc\Scramble\Support\TypeToSchemaExtensions\FormatExtractorExtension;
 use Dedoc\Scramble\Support\TypeToSchemaExtensions\JsonResourceTypeToSchema;
 use Dedoc\Scramble\Support\TypeToSchemaExtensions\LengthAwarePaginatorTypeToSchema;
 use Dedoc\Scramble\Support\TypeToSchemaExtensions\ModelToSchema;
@@ -137,6 +138,7 @@ class ScrambleServiceProvider extends PackageServiceProvider
                     AnonymousResourceCollectionTypeToSchema::class,
                     LengthAwarePaginatorTypeToSchema::class,
                     ResponseTypeToSchema::class,
+                    FormatExtractorExtension::class
                 ]),
                 array_merge($exceptionToResponseExtensions, [
                     ValidationExceptionToResponseExtension::class,

--- a/src/Support/TypeToSchemaExtensions/FormatExtractorExtension.php
+++ b/src/Support/TypeToSchemaExtensions/FormatExtractorExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Dedoc\Scramble\Support\TypeToSchemaExtensions;
+
+use Dedoc\Scramble\Support\Type\Type;
+use Illuminate\Support\Str;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use Dedoc\Scramble\Extensions\TypeToSchemaExtension;
+use Dedoc\Scramble\Support\Generator\Types\StringType;
+
+class FormatExtractorExtension extends TypeToSchemaExtension
+{
+    public function getDescription(Type $type)
+    {
+        $docNode = $type->getAttribute("docNode");
+        if(!$docNode) return false;
+
+        $vars = $docNode->getTagsByName("@var");
+        foreach($vars as $var) {
+            $value = $var->value;
+            if(!($value instanceof VarTagValueNode)) return false;
+
+            return $value->description;
+        }
+    }
+
+    public function shouldHandle(Type $type): bool
+    {
+        $description = $this->getDescription($type);
+        if(!$description) return false;
+        return Str::of($description)->contains('@format');
+    }
+
+    public function toSchema(Type $type): StringType
+    {
+        $description = $this->getDescription($type);
+        $parts = explode('@format', $description);
+        $format = trim($parts[1]);
+        $description = trim($parts[0]);
+        return (new StringType)->format($format)->setDescription($description);
+    }
+}

--- a/src/Support/TypeToSchemaExtensions/FormatExtractorExtension.php
+++ b/src/Support/TypeToSchemaExtensions/FormatExtractorExtension.php
@@ -16,7 +16,10 @@ class FormatExtractorExtension extends TypeToSchemaExtension
     {
         $docNode = $type->getAttribute("docNode");
         if(!$docNode) return false;
-        $varNode = $docNode->getTagsByName("@var")[0];
+        $varNode = $docNode->getTagsByName("@var");
+        if(count($varNode) === 0) return false;
+        $varNode = reset($varNode);
+
         if(!($varNode instanceof PhpDocTagNode)) return false;
         if(!($varNode->value instanceof VarTagValueNode)) return false;
         if(!($varNode->value->type instanceof IdentifierTypeNode)) return false;
@@ -33,9 +36,9 @@ class FormatExtractorExtension extends TypeToSchemaExtension
     {
         $docNode = $type->getAttribute("docNode");
         $vars = $docNode->getTagsByName("@format");
-        $format = $vars[1]->value->value;
+        $format = reset($vars)->value->value;
         if(Str::contains($format, "|")) {
-            $format = explode("|", $format)[0];
+            $format = explode("|", $format);
         }
         if(Str::contains($format, ",")) {
             $format = explode(",", $format)[0];

--- a/tests/ResourceFormatTest.php
+++ b/tests/ResourceFormatTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Dedoc\Scramble\PhpDoc\PhpDocParser;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+
+function getFormatFromDoc(string $phpDoc)
+{
+    $lexer = new Lexer();
+    $tokenized = $lexer->tokenize($phpDoc);
+
+    $constExprParser = new ConstExprParser();
+    $typeParser = new TypeParser($constExprParser);
+    $phpDocParser = new PhpDocParser($typeParser, $constExprParser);
+
+    $tokens = new TokenIterator($tokenized);
+
+    $node = $phpDocParser->parse($tokens);
+    $withFormat = $node->getTagsByName("@format");
+    if(count($withFormat) === 0) return null;
+
+    $withFormat = reset($withFormat);
+
+    return $withFormat->value->value;
+}
+
+it('handles string type with format', function ($phpDoc, $expectedFormat) {
+    $result = getFormatFromDoc($phpDoc);
+
+    expect($result)->toBe($expectedFormat);
+})->with([
+    ["/** @var string \n * @format email */", "email"],
+    ["/** @var string \n * @format date-time */", "date-time"],
+    ["/** @var string \n * @format date */", "date"],
+    ["/** @var string \n * @format time */", "time"],
+    ["/** @var string \n * @format ipv4 */", "ipv4"],
+    ["/** @var string \n * @format ipv6 */", "ipv6"],
+    ["/** @var string \n * @format uri */", "uri"],
+    ["/** @var string \n * @format hostname */", "hostname"],
+    ["/** @var string \n * @format uuid */", "uuid"],
+    ["/** @var string \n * @format uri-reference */", "uri-reference"],
+    ["/** @var string \n * @format uri-template */", "uri-template"],
+    ["/** @var string \n * @format iri */", "iri"],
+    ["/** @var string \n * @format iri-reference */", "iri-reference"],
+    ["/** @var string \n * @format idn-email */", "idn-email"],
+    ["/** @var string \n * @format idn-hostname */", "idn-hostname"],
+    ["/** @var string \n * @format password */", "password"],
+]);


### PR DESCRIPTION
Hello,

I've made this contribution to add a `@format` tag in `Resource`.

Usage Format:
```php
/**
 * @var string $created_at The created time of the instance @format date-time
 */
'created_at' => $this->created_at,
```

Output:
<img width="648" alt="image" src="https://github.com/dedoc/scramble/assets/30431426/4700f6c3-ee43-41d1-87b4-1a044051aaa4">

Example response:
<img width="346" alt="image" src="https://github.com/dedoc/scramble/assets/30431426/a06ca6bb-56bc-480a-9f45-bf7a5812baf5">