### PR TITLE
Add ability to customize doc url using config

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -15,6 +15,11 @@ return [
      */
     'api_domain' => null,
 
+    /**
+     * Home page path
+     */
+    'doc_path' => 'docs/api',
+
     'info' => [
         /*
          * API version.

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,9 +4,9 @@ use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(config('scramble.middleware', [RestrictedDocsAccess::class]))->group(function () {
-    Route::get('docs/api.json', function (Dedoc\Scramble\Generator $generator) {
+    Route::get(config('scramble.doc_path').'.json', function (Dedoc\Scramble\Generator $generator) {
         return $generator();
     })->name('scramble.docs.index');
 
-    Route::view('docs/api', 'scramble::docs')->name('scramble.docs.api');
+    Route::view(config('scramble.doc_path'), 'scramble::docs')->name('scramble.docs.api');
 });


### PR DESCRIPTION
This PR will give users the ability to change the default doc url.

For example, from http://example.com/docs/api to http://example.com/new/api.

**Why:**

Sometimes, the url conflicts with other packages' default urls, such as [Enlighten](https://github.com/StydeNet/enlighten). 
