### PR TITLE
Add deprecation ability

### DIFF
--- a/src/Support/Generator/Operation.php
+++ b/src/Support/Generator/Operation.php
@@ -16,6 +16,8 @@ class Operation
 
     public string $summary = '';
 
+    public bool $deprecated = false;
+
     /** @var array<Security|array> */
     public array $security = [];
 
@@ -111,6 +113,13 @@ class Operation
         return $this;
     }
 
+    public function deprecated(bool $deprecated)
+    {
+        $this->deprecated = $deprecated;
+
+        return $this;
+    }
+
     public function setTags(array $tags)
     {
         $this->tags = array_map(fn ($t) => (string) $t, $tags);
@@ -139,6 +148,10 @@ class Operation
 
         if ($this->summary) {
             $result['summary'] = $this->summary;
+        }
+
+        if ($this->deprecated) {
+            $result['deprecated'] = $this->deprecated;
         }
 
         if (count($this->tags)) {

--- a/tests/Generator/Operation/OperationTest.php
+++ b/tests/Generator/Operation/OperationTest.php
@@ -1,0 +1,12 @@
+<?php
+
+it('deprecated key is properly set', function () {
+    $operation = new \Dedoc\Scramble\Support\Generator\Operation('get');
+    $operation->deprecated(true);
+
+    $array = $operation->toArray();
+
+    expect($operation->deprecated)->toBeTrue()
+        ->and($array)->toHaveKey('deprecated')
+        ->and($array['deprecated'])->toBeTrue();
+});

--- a/tests/Generator/Operation/OperationTest.php
+++ b/tests/Generator/Operation/OperationTest.php
@@ -10,3 +10,12 @@ it('deprecated key is properly set', function () {
         ->and($array)->toHaveKey('deprecated')
         ->and($array['deprecated'])->toBeTrue();
 });
+
+it('default deprecated key is false', function () {
+    $operation = new \Dedoc\Scramble\Support\Generator\Operation('get');
+
+    $array = $operation->toArray();
+
+    expect($operation->deprecated)->toBeFalse()
+        ->and($array)->not()->toHaveKey('deprecated');
+});


### PR DESCRIPTION
This change extends the ability of the `Generator` to accept the deprecation property in the `toArray` method.

I have extended the `Operation` class, I needed this in my custom extension that adds the ability to display a deprecation notice if the method or the class is deprecated with a `@deprecated` comment.