### PR TITLE
Adding the choice of light or dark theme

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -15,6 +15,12 @@ return [
      */
     'api_domain' => null,
 
+    /*
+     * Define the theme of the documentation.
+     * Available options are `light` and `dark`.
+     */
+    'theme' => 'dark',
+
     'info' => [
         /*
          * API version.

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="{{ config('scramble.theme', 'light') }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
Stoplight offers a light and dark theme. This PR adds a option to the config to make it configurable. 

`./config/scramble.php`
```php
/*
 * Define the theme of the documentation.
 * Available options are `light` and `dark`.
 */
'theme' => 'light',
```