### PR TITLE
Support DBAL-unsupported Database Drivers. 

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -74,5 +74,7 @@ return [
         RestrictedDocsAccess::class,
     ],
 
+    'disable_model_attributes' => false,
+
     'extensions' => [],
 ];

--- a/src/Support/ResponseExtractor/ModelInfo.php
+++ b/src/Support/ResponseExtractor/ModelInfo.php
@@ -156,6 +156,10 @@ class ModelInfo
      */
     protected function getAttributes($model)
     {
+        if (config('scramble.disable_model_attributes')) {
+            return collect();
+        }
+
         $schema = $model->getConnection()->getDoctrineSchemaManager();
         $table = $model->getConnection()->getTablePrefix().$model->getTable();
 


### PR DESCRIPTION
As mentioned [here](https://github.com/dedoc/scramble/discussions/252) this package does not support database drivers that are not supported by Doctrine DBAL. 

The sole problem for this lies within the Model attributes functionality. In order to quickly circumvent this, this PR adds a config option that can disable this functionality. 

This way all the core functionality of this pretty package can be used in combination with for example [MongoDB](https://github.com/mongodb/laravel-mongodb).