### PR TITLE
Respect string type when parsing validation rules' examples

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/RulesToParameter.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesToParameter.php
@@ -5,6 +5,7 @@ namespace Dedoc\Scramble\Support\OperationExtensions\RulesExtractor;
 use Dedoc\Scramble\PhpDoc\PhpDocTypeHelper;
 use Dedoc\Scramble\Support\Generator\Parameter;
 use Dedoc\Scramble\Support\Generator\Schema;
+use Dedoc\Scramble\Support\Generator\Types\StringType;
 use Dedoc\Scramble\Support\Generator\Types\Type as OpenApiType;
 use Dedoc\Scramble\Support\Generator\Types\UnknownType;
 use Dedoc\Scramble\Support\Generator\TypeTransformer;
@@ -90,7 +91,7 @@ class RulesToParameter
                     $exampleValue = null;
                 } elseif (in_array($exampleValue, ['true', 'false'])) {
                     $exampleValue = $exampleValue === 'true';
-                } elseif (is_numeric($exampleValue)) {
+                } elseif (is_numeric($exampleValue) && !($parameter->schema->type instanceof StringType)) {
                     $exampleValue = floatval($exampleValue);
                 }
 


### PR DESCRIPTION
This PR implements @Tryfciu 's code that fixes the problem mentioned [here](https://github.com/dedoc/scramble/issues/145).

Now, when we have an `@example` doc specification with a numeric value, it treats this value according to the type specified for it right at the body request example. So, if this numeric value is a `string`, it will have quotation marks and won't be parsed into a number.

Here's a practical example:

```php
    /**
     * Get the validation rules that apply to the request.
     *
     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
     */
    public function rules(): array
    {
        return [
            // @example decade00-0000-4000-a000-000000000000
            'id' => 'uuid|required',
            // @example 700100201
            'phone_number' => 'string|digits:9',
            // @example +1
            'some_value' => 'string',
        ];
    }
```

Notice that `phone_number` and `some_value` both have numeric values but should be treated as strings because of the validation type.

So instead of being parsed right into numbers, they will be actual strings:
![image](https://github.com/dedoc/scramble/assets/40745225/8abfa7b8-6e17-4f39-bee6-dec968a98d4e)

This also fixes the fact that if we have a string like `"+1"`, it won't be parsed into just `1` like before :)

Now of course, if we specify that they are numbers, it treats them as so:
```php
    /**
     * Get the validation rules that apply to the request.
     *
     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
     */
    public function rules(): array
    {
        return [
            // @example decade00-0000-4000-a000-000000000000
            'id' => 'uuid|required',
            // @example 700100201
            'phone_number' => 'integer|digits:9',
            // @example +1
            'some_value' => 'integer',
        ];
    }
```
![image](https://github.com/dedoc/scramble/assets/40745225/387d3d3b-f089-4669-99ba-5b2930fd5ba1)

