### PR TITLE
`scopes` property in OAuth made required according spec

### DIFF
--- a/src/Support/Generator/SecuritySchemes/OAuthFlow.php
+++ b/src/Support/Generator/SecuritySchemes/OAuthFlow.php
@@ -49,7 +49,8 @@ class OAuthFlow
                 'tokenUrl' => $this->tokenUrl,
                 'refreshUrl' => $this->refreshUrl,
             ]),
-            'scopes' => $this->scopes,
+            // Never filter 'scopes' as it is allowed to be empty. If empty it must be an object
+            'scopes' => empty($this->scopes) ? new \stdClass() : $this->scopes,
         ];
     }
 }

--- a/src/Support/Generator/SecuritySchemes/OAuthFlow.php
+++ b/src/Support/Generator/SecuritySchemes/OAuthFlow.php
@@ -43,11 +43,13 @@ class OAuthFlow
 
     public function toArray()
     {
-        return array_filter([
-            'authorizationUrl' => $this->authorizationUrl,
-            'tokenUrl' => $this->tokenUrl,
-            'refreshUrl' => $this->refreshUrl,
+        return [
+            ...array_filter([
+                'authorizationUrl' => $this->authorizationUrl,
+                'tokenUrl' => $this->tokenUrl,
+                'refreshUrl' => $this->refreshUrl,
+            ]),
             'scopes' => $this->scopes,
-        ]);
+        ];
     }
 }

--- a/tests/OpenApiBuildersTest.php
+++ b/tests/OpenApiBuildersTest.php
@@ -56,5 +56,5 @@ it('builds oauth2 security scheme with empty scope map', function () {
     $document = $openApi->toArray();
 
     expect($document['components']['securitySchemes']['oauth2']['flows']['implicit']['scopes'])
-        ->toBe([]);
+        ->toBeObject();
 });

--- a/tests/OpenApiBuildersTest.php
+++ b/tests/OpenApiBuildersTest.php
@@ -40,3 +40,21 @@ it('builds oauth2 security scheme', function () {
 
     assertMatchesSnapshot($openApi->toArray());
 });
+
+it('builds oauth2 security scheme with empty scope map', function () {
+    $openApi = (new OpenApi('3.1.0'))
+        ->setInfo(InfoObject::make('API')->setVersion('0.0.1'));
+
+    $openApi->secure(
+        SecurityScheme::oauth2()
+            ->flow('implicit', function (OAuthFlow $flow) {
+                $flow
+                    ->refreshUrl('https://test.com')
+                    ->tokenUrl('https://test.com/token');
+            })
+    );
+    $document = $openApi->toArray();
+
+    expect($document['components']['securitySchemes']['oauth2']['flows']['implicit']['scopes'])
+        ->toBe([]);
+});

--- a/tests/__snapshots__/OpenApiBuildersTest__it_builds_oauth2_security_scheme_with_empty_scope_map__1.yml
+++ b/tests/__snapshots__/OpenApiBuildersTest__it_builds_oauth2_security_scheme_with_empty_scope_map__1.yml
@@ -1,0 +1,8 @@
+openapi: 3.1.0
+info:
+    title: API
+    version: 0.0.1
+security:
+    - { oauth2: {  } }
+components:
+    securitySchemes: { oauth2: { type: oauth2, flows: { implicit: { tokenUrl: 'https://test.com/token', refreshUrl: 'https://test.com', scopes: {  } } } } }


### PR DESCRIPTION
'scopes' is a required OAuth property as per https://spec.openapis.org/oas/v3.1.0#fixed-fields-24

In current `main`, the property is filtered out if empty, resulting in an invalid OpenAPI document.