### PR TITLE
Fixed the case when non-request class had rules method which resulted in error when extracting validation rules

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/FormRequestRulesExtractor.php
+++ b/src/Support/OperationExtensions/RulesExtractor/FormRequestRulesExtractor.php
@@ -52,6 +52,11 @@ class FormRequestRulesExtractor
 
         /** @var Request $request */
         $request = (new $requestClassName);
+
+        if (! method_exists($request, 'setMethod')) {
+            return [];
+        }
+
         $request->setMethod($route->methods()[0]);
 
         return $request->rules();

--- a/tests/Support/OperationExtensions/RequestEssentialsExtensionTest.php
+++ b/tests/Support/OperationExtensions/RequestEssentialsExtensionTest.php
@@ -28,6 +28,31 @@ class Foo_RequestEssentialsExtensionTest_Controller
     }
 }
 
+it('correctly handles not request class with rules method', function () {
+    $openApiDocument = generateForRoute(function () {
+        return RouteFacade::get('api/test/{model}', [Foo_RequestRulesTest_Controller::class, 'foo']);
+    });
+
+    expect($openApiDocument['paths']['/test/{model}']['get']['parameters'][0])
+        ->toHaveKey('schema.type', 'integer')
+        ->toHaveKey('description', 'The model ID');
+});
+class ModelWithRulesMethod extends \Illuminate\Database\Eloquent\Model
+{
+    protected $table = 'users';
+
+    public function rules()
+    {
+        return [];
+    }
+}
+class Foo_RequestRulesTest_Controller
+{
+    public function foo(ModelWithRulesMethod $model)
+    {
+    }
+}
+
 it('handles custom key from route to determine model route key type', function () {
     $openApiDocument = generateForRoute(function () {
         return RouteFacade::get('api/test/{user:name}', [CustomKey_RequestEssentialsExtensionTest_Controller::class, 'foo']);


### PR DESCRIPTION
fixes #304 