### PR TITLE
Fixed empty security descriptor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/contracts": "^10.0|^11.0",
-        "nikic/php-parser": "^5.0|^4.15",
+        "nikic/php-parser": "^5.0",
         "phpstan/phpdoc-parser": "^1.0",
         "spatie/laravel-package-tools": "^1.9.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/contracts": "^10.0|^11.0",
-        "nikic/php-parser": "^5.0",
+        "nikic/php-parser": "^5.0|^4.15",
         "phpstan/phpdoc-parser": "^1.0",
         "spatie/laravel-package-tools": "^1.9.2"
     },

--- a/src/Support/Generator/Operation.php
+++ b/src/Support/Generator/Operation.php
@@ -183,7 +183,7 @@ class Operation
         if (count($this->security)) {
             $securities = [];
             foreach ($this->security as $security) {
-                $securities[] = is_array($security) ? $security : $security->toArray();
+                $securities[] = (object) (is_array($security) ? $security : $security->toArray());
             }
             $result['security'] = $securities;
         }


### PR DESCRIPTION
Empty security descriptor must be an object (`{}`) instead of empty empty array (`[]`).

Closes: #329 