### PR TITLE
Fix `confirmed` rule not working properly when it is used on multiple attributes

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/RulesToParameters.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesToParameters.php
@@ -93,19 +93,21 @@ class RulesToParameters
     {
         $confirmedParamNameRules = collect($this->rules)
             ->map(fn ($rules, $name) => [$name, Arr::wrap(is_string($rules) ? explode('|', $rules) : $rules)])
-            ->first(fn ($nameRules) => in_array('confirmed', $nameRules[1]));
+            ->filter(fn ($nameRules) => in_array('confirmed', $nameRules[1]));
 
         if (! $confirmedParamNameRules) {
             return $parameters;
         }
 
-        /** @var Parameter $confirmedParam */
-        $confirmedParam = $parameters->first(fn ($p) => $p->name === $confirmedParamNameRules[0]);
+        foreach ($confirmedParamNameRules as $confirmedParamNameRule) {
+            /** @var Parameter $confirmedParam */
+            $confirmedParam = $parameters->first(fn ($p) => $p->name === $confirmedParamNameRule[0]);
 
-        $parameters->offsetSet(
-            $name = "$confirmedParamNameRules[0]_confirmation",
-            (clone $confirmedParam)->setName($name),
-        );
+            $parameters->offsetSet(
+                $name = "$confirmedParamNameRule[0]_confirmation",
+                (clone $confirmedParam)->setName($name),
+            );
+        }
 
         return $parameters;
     }

--- a/tests/Generator/Request/ValidationRulesDocumentationTest.php
+++ b/tests/Generator/Request/ValidationRulesDocumentationTest.php
@@ -14,3 +14,19 @@ it('supports confirmed rule', function () {
         ->and($params[1])
         ->toMatchArray(['name' => 'password_confirmation']);
 });
+
+it('supports multiple confirmed rule', function () {
+    $rules = [
+        'password' => ['required', 'min:8', 'confirmed'],
+        'email' => ['required', 'email', 'confirmed'],
+    ];
+
+    $params = app()->make(RulesToParameters::class, ['rules' => $rules])->handle();
+
+    expect($params = collect($params)->map->toArray()->all())
+        ->toHaveCount(4)
+        ->and($params[2])
+        ->toMatchArray(['name' => 'password_confirmation'])
+        ->and($params[3])
+        ->toMatchArray(['name' => 'email_confirmation']);
+});


### PR DESCRIPTION
The [PR](https://github.com/dedoc/scramble/pull/124) added support for the confirmed rule, but when there are multiple confirmed rules, it only identifies one of the fields.

This PR aims to provide support for more than one confirmed rule.