### PR TITLE
Determine eloquent attribute type from casts

### DIFF
--- a/src/Support/InferExtensions/ModelExtension.php
+++ b/src/Support/InferExtensions/ModelExtension.php
@@ -91,15 +91,21 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
         return $castedType ?? $attributeType;
     }
 
+    /**
+     * @todo Add support for custom castables.
+     */
     private function getEloquentCastAsType(array $attributeInfo): ?AbstractType
     {
         if ($attributeInfo['cast'] && enum_exists($attributeInfo['cast'])) {
             return new ObjectType($attributeInfo['cast']);
         }
 
-        $castAs = str($attributeInfo['cast']);
-        $castAsType = $castAs->before(':')->toString();
-        $castAsParameters = $castAs->after(':')->explode(',');
+        $castAsType = Str::before($attributeInfo['cast'], ':');
+        $castAsParameters = str($attributeInfo['cast'])->after("{$castAsType}:")->explode(',');
+
+        if ($castAsType === 'encrypted') {
+            $castAsType = $castAsParameters->first(); // array, collection, json, object
+        }
 
         return match ($castAsType) {
             'array',

--- a/src/Support/InferExtensions/ModelExtension.php
+++ b/src/Support/InferExtensions/ModelExtension.php
@@ -21,6 +21,7 @@ use Dedoc\Scramble\Support\Type\KeyedArrayType;
 use Dedoc\Scramble\Support\Type\NullType;
 use Dedoc\Scramble\Support\Type\ObjectType;
 use Dedoc\Scramble\Support\Type\StringType;
+use Dedoc\Scramble\Support\Type\TemplateType;
 use Dedoc\Scramble\Support\Type\Type;
 use Dedoc\Scramble\Support\Type\TypeWalker;
 use Dedoc\Scramble\Support\Type\Union;
@@ -96,11 +97,11 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
             return new ObjectType($attributeInfo['cast']);
         }
 
-        $castAs = str($attributeInfo['cast'])
-            ->before(':')
-            ->toString();
+        $castAs = str($attributeInfo['cast']);
+        $castAsType = $castAs->before(':')->toString();
+        $castAsParameters = $castAs->after(':')->explode(',');
 
-        return match ($castAs) {
+        return match ($castAsType) {
             'array',
             'json' => new ArrayType(),
             'real',
@@ -115,6 +116,9 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
             'decimal' => new StringType(),
             'object' => new ObjectType('\stdClass'),
             'collection' => new ObjectType(Collection::class),
+            'Illuminate\Database\Eloquent\Casts\AsEnumCollection' => new Generic(Collection::class, [
+                new TemplateType($castAsParameters->first())
+            ]),
             'date',
             'datetime',
             'custom_datetime' => new ObjectType(Carbon::class),

--- a/src/Support/InferExtensions/ModelExtension.php
+++ b/src/Support/InferExtensions/ModelExtension.php
@@ -107,29 +107,18 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
         }
 
         return match ($castAsType) {
-            'array',
-            'json' => new ArrayType(),
-            'real',
-            'float',
-            'double' => new FloatType(),
-            'int',
-            'integer',
-            'timestamp' => new IntegerType(),
-            'bool',
-            'boolean' => new BooleanType(),
-            'string',
-            'decimal' => new StringType(),
+            'array', 'json' => new ArrayType(),
+            'real', 'float', 'double' => new FloatType(),
+            'int', 'integer', 'timestamp' => new IntegerType(),
+            'bool', 'boolean' => new BooleanType(),
+            'string', 'decimal' => new StringType(),
             'object' => new ObjectType('\stdClass'),
             'collection' => new ObjectType(Collection::class),
             'Illuminate\Database\Eloquent\Casts\AsEnumCollection' => new Generic(Collection::class, [
                 new TemplateType($castAsParameters->first())
             ]),
-            'date',
-            'datetime',
-            'custom_datetime' => new ObjectType(Carbon::class),
-            'immutable_date',
-            'immutable_datetime',
-            'immutable_custom_datetime' => new ObjectType(CarbonImmutable::class),
+            'date', 'datetime', 'custom_datetime' => new ObjectType(Carbon::class),
+            'immutable_date', 'immutable_datetime', 'immutable_custom_datetime' => new ObjectType(CarbonImmutable::class),
             default => null,
         };
     }

--- a/tests/Files/Role.php
+++ b/tests/Files/Role.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Dedoc\Scramble\Tests\Files;
+
+enum Role: string
+{
+    case Admin = 'admin';
+    case TeamLead = 'team_lead';
+    case Developer = 'developer';
+}

--- a/tests/Files/SamplePostModel.php
+++ b/tests/Files/SamplePostModel.php
@@ -16,6 +16,7 @@ class SamplePostModel extends Model
 
     protected $casts = [
         'status' => Status::class,
+        'settings' => 'array'
     ];
 
     public function getReadTimeAttribute()

--- a/tests/Files/SampleUserModel.php
+++ b/tests/Files/SampleUserModel.php
@@ -2,6 +2,7 @@
 
 namespace Dedoc\Scramble\Tests\Files;
 
+use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Model;
 
 class SampleUserModel extends Model
@@ -11,4 +12,11 @@ class SampleUserModel extends Model
     protected $guarded = [];
 
     protected $table = 'users';
+
+    protected function casts(): array
+{
+    return [
+        'roles' => AsEnumCollection::of(Role::class),
+    ];
+}
 }

--- a/tests/Files/SampleUserModel.php
+++ b/tests/Files/SampleUserModel.php
@@ -14,9 +14,9 @@ class SampleUserModel extends Model
     protected $table = 'users';
 
     protected function casts(): array
-{
-    return [
-        'roles' => AsEnumCollection::of(Role::class),
-    ];
-}
+    {
+        return [
+            'roles' => AsEnumCollection::of(Role::class),
+        ];
+    }
 }

--- a/tests/InferExtensions/ModelExtensionTest.php
+++ b/tests/InferExtensions/ModelExtensionTest.php
@@ -5,6 +5,7 @@ use Dedoc\Scramble\Support\Type\ArrayItemType_;
 use Dedoc\Scramble\Support\Type\ObjectType;
 use Dedoc\Scramble\Tests\Files\SamplePostModel;
 use Dedoc\Scramble\Tests\Files\SampleUserModel;
+use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 
@@ -63,20 +64,18 @@ it('adds toArray method type the model class without defined toArray class', fun
         ]);
 });
 
-it('casts generic enum collections', function () {
-    $this->infer->analyzeClass(SampleUserModel::class);
+/*
+ * `AsEnumCollection::of` is added in Laravel 11, hence this check so tests are passing with Laravel 10.
+ */
+if (method_exists(AsEnumCollection::class, 'of')) {
+    it('casts generic enum collections', function () {
+        $this->infer->analyzeClass(SampleUserModel::class);
 
-    $object = new ObjectType(SampleUserModel::class);
+        $object = new ObjectType(SampleUserModel::class);
 
-    $expectedPropertiesTypes = [
-        'roles' => 'Illuminate\Support\Collection<Role>'
-        // other properties omitted for brevity
-    ];
-
-    foreach ($expectedPropertiesTypes as $name => $type) {
-        $propertyType = $object->getPropertyType($name);
+        $propertyType = $object->getPropertyType('roles');
 
         expect(Str::replace('Dedoc\\Scramble\\Tests\\Files\\', '', $propertyType->toString()))
-            ->toBe($type);
-    }
-});
+            ->toBe('Illuminate\Support\Collection<Role>');
+    });
+}

--- a/tests/InferExtensions/ModelExtensionTest.php
+++ b/tests/InferExtensions/ModelExtensionTest.php
@@ -62,3 +62,21 @@ it('adds toArray method type the model class without defined toArray class', fun
             'updated_at' => 'string|null',
         ]);
 });
+
+it('casts generic enum collections', function () {
+    $this->infer->analyzeClass(SampleUserModel::class);
+
+    $object = new ObjectType(SampleUserModel::class);
+
+    $expectedPropertiesTypes = [
+        'roles' => 'Illuminate\Support\Collection<Role>'
+        // other properties omitted for brevity
+    ];
+
+    foreach ($expectedPropertiesTypes as $name => $type) {
+        $propertyType = $object->getPropertyType($name);
+
+        expect(Str::replace('Dedoc\\Scramble\\Tests\\Files\\', '', $propertyType->toString()))
+            ->toBe($type);
+    }
+});

--- a/tests/InferExtensions/ModelExtensionTest.php
+++ b/tests/InferExtensions/ModelExtensionTest.php
@@ -3,7 +3,7 @@
 use Dedoc\Scramble\Infer;
 use Dedoc\Scramble\Support\Type\ArrayItemType_;
 use Dedoc\Scramble\Support\Type\ObjectType;
-use Dedoc\Scramble\Tests\Files\SamplePostModelWithToArray;
+use Dedoc\Scramble\Tests\Files\SamplePostModel;
 use Dedoc\Scramble\Tests\Files\SampleUserModel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -14,9 +14,9 @@ beforeEach(function () {
 });
 
 it('adds models attributes to the model class definition as properties', function () {
-    $this->infer->analyzeClass(SamplePostModelWithToArray::class);
+    $this->infer->analyzeClass(SamplePostModel::class);
 
-    $object = new ObjectType(SamplePostModelWithToArray::class);
+    $object = new ObjectType(SamplePostModel::class);
 
     $expectedPropertiesTypes = [
         /* Attributes from the DB */
@@ -24,6 +24,7 @@ it('adds models attributes to the model class definition as properties', functio
         'status' => 'Status',
         'user_id' => 'int',
         'title' => 'string',
+        'settings' => 'array<mixed>|null',
         'body' => 'string',
         'created_at' => 'Carbon\Carbon|null',
         'updated_at' => 'Carbon\Carbon|null',
@@ -31,8 +32,8 @@ it('adds models attributes to the model class definition as properties', functio
         'read_time' => 'unknown',
         /* Relations */
         'user' => 'SampleUserModel',
-        'parent' => 'SamplePostModelWithToArray',
-        'children' => 'Illuminate\Database\Eloquent\Collection<SamplePostModelWithToArray>',
+        'parent' => 'SamplePostModel',
+        'children' => 'Illuminate\Database\Eloquent\Collection<SamplePostModel>',
         /* other properties from model class are ommited here but exist on type */
     ];
 

--- a/tests/__snapshots__/InferTypesTest__it_infers_model_type__1.yml
+++ b/tests/__snapshots__/InferTypesTest__it_infers_model_type__1.yml
@@ -4,6 +4,7 @@ properties:
     status: { type: object }
     user_id: { type: integer }
     title: { type: string }
+    settings: { type: [array, 'null'], items: { type: string } }
     body: { type: string }
     created_at: { type: [string, 'null'], format: date-time }
     updated_at: { type: [string, 'null'], format: date-time }
@@ -15,6 +16,7 @@ required:
     - status
     - user_id
     - title
+    - settings
     - body
     - created_at
     - updated_at

--- a/tests/migrations/2016_01_01_000000_create_posts_table.php
+++ b/tests/migrations/2016_01_01_000000_create_posts_table.php
@@ -18,6 +18,7 @@ class CreatePostsTable extends Migration
             $table->enum('status', ['draft', 'published']);
             $table->integer('user_id');
             $table->string('title');
+            $table->json('settings')->nullable();
             $table->text('body');
             $table->timestamps();
         });

--- a/tests/migrations/2016_01_01_000000_create_users_table.php
+++ b/tests/migrations/2016_01_01_000000_create_users_table.php
@@ -18,6 +18,7 @@ class CreateUsersTable extends Migration
             $table->string('name');
             $table->string('email')->unique();
             $table->string('password');
+            $table->json('roles');
             $table->rememberToken();
             $table->timestamps();
         });


### PR DESCRIPTION
As mentioned in [this discussion](https://github.com/dedoc/scramble/discussions/278), the schema types differ slightly when generating the OpenAPI json, if using different databases, such as MySQL and SQLite.

This is to be expected if the idea is to rely on the DB schema alone to generate the API schema from Eloquent models.

This PR aims to add support for the various model casts that Laravel provides.