### PR TITLE
Remove request body from `HEAD` and `DELETE`  by default

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -80,4 +80,17 @@ return [
     ],
 
     'extensions' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Disallow Request Body
+    |--------------------------------------------------------------------------
+    |
+    | Disallow request body for specific HTTP methods. Scramble allows every
+    | HTTP method to have a request body by default except GET. However,
+    | HEAD, OPTIONS, DELETE, etc. you might want to include in this
+    | list to prevent empty request body for these methods.
+    |
+    */
+    'disallow_request_body' => ['get'],
 ];

--- a/config/scramble.php
+++ b/config/scramble.php
@@ -80,17 +80,4 @@ return [
     ],
 
     'extensions' => [],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Disallow Request Body
-    |--------------------------------------------------------------------------
-    |
-    | Disallow request body for specific HTTP methods. Scramble allows every
-    | HTTP method to have a request body by default except GET. However,
-    | HEAD, OPTIONS, DELETE, etc. you might want to include in this
-    | list to prevent empty request body for these methods.
-    |
-    */
-    'disallow_request_body' => ['get'],
 ];

--- a/src/Support/OperationExtensions/RequestBodyExtension.php
+++ b/src/Support/OperationExtensions/RequestBodyExtension.php
@@ -31,14 +31,14 @@ class RequestBodyExtension extends OperationExtension
             $mediaType = $this->getMediaType($operation, $routeInfo, $bodyParams);
 
             if (count($bodyParams)) {
-                if (! in_array($operation->method, ['get', 'head', 'delete'])) {
+                if (! in_array($operation->method, config('scramble.disallow_request_body'))) {
                     $operation->addRequestBodyObject(
                         RequestBodyObject::make()->setContent($mediaType, Schema::createFromParameters($bodyParams))
                     );
                 } else {
                     $operation->addParameters($bodyParams);
                 }
-            } elseif (! in_array($operation->method, ['get', 'head', 'delete'])) {
+            } elseif (! in_array($operation->method, config('scramble.disallow_request_body'))) {
                 $operation
                     ->addRequestBodyObject(
                         RequestBodyObject::make()

--- a/src/Support/OperationExtensions/RequestBodyExtension.php
+++ b/src/Support/OperationExtensions/RequestBodyExtension.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use PhpParser\Node\Stmt\ClassMethod;
 use Throwable;
+use function in_array;
 
 class RequestBodyExtension extends OperationExtension
 {
@@ -30,14 +31,14 @@ class RequestBodyExtension extends OperationExtension
             $mediaType = $this->getMediaType($operation, $routeInfo, $bodyParams);
 
             if (count($bodyParams)) {
-                if ($operation->method !== 'get') {
+                if (! in_array($operation->method, ['get', 'head', 'delete'])) {
                     $operation->addRequestBodyObject(
                         RequestBodyObject::make()->setContent($mediaType, Schema::createFromParameters($bodyParams))
                     );
                 } else {
                     $operation->addParameters($bodyParams);
                 }
-            } elseif ($operation->method !== 'get') {
+            } elseif (! in_array($operation->method, ['get', 'head', 'delete'])) {
                 $operation
                     ->addRequestBodyObject(
                         RequestBodyObject::make()

--- a/src/Support/OperationExtensions/RequestBodyExtension.php
+++ b/src/Support/OperationExtensions/RequestBodyExtension.php
@@ -17,10 +17,11 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use PhpParser\Node\Stmt\ClassMethod;
 use Throwable;
-use function in_array;
 
 class RequestBodyExtension extends OperationExtension
 {
+    const HTTP_METHODS_WITHOUT_REQUEST_BODY = ['get', 'delete', 'head'];
+
     public function handle(Operation $operation, RouteInfo $routeInfo)
     {
         $description = Str::of($routeInfo->phpDoc()->getAttribute('description'));
@@ -31,14 +32,14 @@ class RequestBodyExtension extends OperationExtension
             $mediaType = $this->getMediaType($operation, $routeInfo, $bodyParams);
 
             if (count($bodyParams)) {
-                if (! in_array($operation->method, config('scramble.disallow_request_body'))) {
+                if (! in_array($operation->method, static::HTTP_METHODS_WITHOUT_REQUEST_BODY)) {
                     $operation->addRequestBodyObject(
                         RequestBodyObject::make()->setContent($mediaType, Schema::createFromParameters($bodyParams))
                     );
                 } else {
                     $operation->addParameters($bodyParams);
                 }
-            } elseif (! in_array($operation->method, config('scramble.disallow_request_body'))) {
+            } elseif (! in_array($operation->method, static::HTTP_METHODS_WITHOUT_REQUEST_BODY)) {
                 $operation
                     ->addRequestBodyObject(
                         RequestBodyObject::make()

--- a/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
+++ b/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
@@ -19,25 +19,29 @@ class RequestBodyExtensionTest__uses_application_json_as_default
     }
 }
 
-it('does not generate for delete by default', function () {
+it('does generate for delete by default', function () {
     $openApiDocument = generateForRoute(function () {
-        return RouteFacade::delete('api/test', [RequestBodyExtensionTest__does_not_generate_by_default_delete::class, 'index']);
+        return RouteFacade::delete('api/test', [RequestBodyExtensionTest__does_generate_by_default_delete::class, 'index']);
     });
 
     expect($openApiDocument['paths']['/test']['delete'])
-        ->not()->toHaveKey('requestBody');
+        ->toHaveKey('requestBody')
+        ->and($openApiDocument['paths']['/test']['delete'])
+        ->not()->toHaveKey('parameters')
+        ->and($openApiDocument['paths']['/test']['delete']['requestBody']['content'])
+        ->toHaveKey('application/json')
+        ->toHaveLength(1)
+        ->and(
+            data_get(
+                $openApiDocument,
+                'paths./test.delete.requestBody.content.application/json.schema.properties'
+            )
+        )
+        ->toHaveKey('foo')
+        ->toHaveKey('foo.type', 'string');
 
-    expect($openApiDocument['paths']['/test']['delete'])
-        ->toHaveKey('parameters');
-
-    expect($openApiDocument['paths']['/test']['delete']['parameters'])
-        ->toHaveLength(1);
-
-    expect($openApiDocument['paths']['/test']['delete']['parameters']['0'])
-        ->toHaveKey('name', 'foo')
-        ->toHaveKey('in', 'query');
 });
-class RequestBodyExtensionTest__does_not_generate_by_default_delete
+class RequestBodyExtensionTest__does_generate_by_default_delete
 {
     public function index(Illuminate\Http\Request $request)
     {
@@ -45,25 +49,29 @@ class RequestBodyExtensionTest__does_not_generate_by_default_delete
     }
 }
 
-it('does not generate for head by default', function () {
+it('does generate for head by default', function () {
     $openApiDocument = generateForRoute(function () {
-        return RouteFacade::addRoute('head', 'api/test', [RequestBodyExtensionTest__does_not_generate_by_default_head::class, 'index']);
+        return RouteFacade::addRoute('head', 'api/test', [RequestBodyExtensionTest__does_generate_by_default_head::class, 'index']);
     });
 
     expect($openApiDocument['paths']['/test']['head'])
-        ->not()->toHaveKey('requestBody');
+        ->toHaveKey('requestBody')
+        ->and($openApiDocument['paths']['/test']['head'])
+        ->not()->toHaveKey('parameters')
+        ->and($openApiDocument['paths']['/test']['head']['requestBody']['content'])
+        ->toHaveKey('application/json')
+        ->toHaveLength(1)
+        ->and(
+            data_get(
+                $openApiDocument,
+                'paths./test.head.requestBody.content.application/json.schema.properties'
+            )
+        )
+        ->toHaveKey('foo')
+        ->toHaveKey('foo.type', 'string');
 
-    expect($openApiDocument['paths']['/test']['head'])
-        ->toHaveKey('parameters');
-
-    expect($openApiDocument['paths']['/test']['head']['parameters'])
-        ->toHaveLength(1);
-
-    expect($openApiDocument['paths']['/test']['head']['parameters']['0'])
-        ->toHaveKey('name', 'foo')
-        ->toHaveKey('in', 'query');
 });
-class RequestBodyExtensionTest__does_not_generate_by_default_head
+class RequestBodyExtensionTest__does_generate_by_default_head
 {
     public function index(Illuminate\Http\Request $request)
     {
@@ -77,19 +85,43 @@ it('does not generate for get by default', function () {
     });
 
     expect($openApiDocument['paths']['/test']['get'])
-        ->not()->toHaveKey('requestBody');
-
-    expect($openApiDocument['paths']['/test']['get'])
-        ->toHaveKey('parameters');
-
-    expect($openApiDocument['paths']['/test']['get']['parameters'])
-        ->toHaveLength(1);
-
-    expect($openApiDocument['paths']['/test']['get']['parameters']['0'])
+        ->not()->toHaveKey('requestBody')
+        ->and($openApiDocument['paths']['/test']['get'])
+        ->toHaveKey('parameters')
+        ->and($openApiDocument['paths']['/test']['get']['parameters'])
+        ->toHaveLength(1)
+        ->and($openApiDocument['paths']['/test']['get']['parameters']['0'])
         ->toHaveKey('name', 'foo')
         ->toHaveKey('in', 'query');
+
 });
 class RequestBodyExtensionTest__does_not_generate_by_default_get
+{
+    public function index(Illuminate\Http\Request $request)
+    {
+        $request->validate(['foo' => 'string']);
+    }
+}
+
+it('does not generate for delete when configured', function () {
+    config()->set('scramble.disallow_request_body', ['get', 'delete']);
+
+    $openApiDocument = generateForRoute(function () {
+        return RouteFacade::delete('api/test', [RequestBodyExtensionTest__does_not_generate_when_configured_delete::class, 'index']);
+    });
+
+    expect($openApiDocument['paths']['/test']['delete'])
+        ->not()->toHaveKey('requestBody')
+        ->and($openApiDocument['paths']['/test']['delete'])
+        ->toHaveKey('parameters')
+        ->and($openApiDocument['paths']['/test']['delete']['parameters'])
+        ->toHaveLength(1)
+        ->and($openApiDocument['paths']['/test']['delete']['parameters']['0'])
+        ->toHaveKey('name', 'foo')
+        ->toHaveKey('in', 'query');
+
+});
+class RequestBodyExtensionTest__does_not_generate_when_configured_delete
 {
     public function index(Illuminate\Http\Request $request)
     {

--- a/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
+++ b/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
@@ -19,6 +19,84 @@ class RequestBodyExtensionTest__uses_application_json_as_default
     }
 }
 
+it('does not generate for delete by default', function () {
+    $openApiDocument = generateForRoute(function () {
+        return RouteFacade::delete('api/test', [RequestBodyExtensionTest__does_not_generate_by_default_delete::class, 'index']);
+    });
+
+    expect($openApiDocument['paths']['/test']['delete'])
+        ->not()->toHaveKey('requestBody');
+
+    expect($openApiDocument['paths']['/test']['delete'])
+        ->toHaveKey('parameters');
+
+    expect($openApiDocument['paths']['/test']['delete']['parameters'])
+        ->toHaveLength(1);
+
+    expect($openApiDocument['paths']['/test']['delete']['parameters']['0'])
+        ->toHaveKey('name', 'foo')
+        ->toHaveKey('in', 'query');
+});
+class RequestBodyExtensionTest__does_not_generate_by_default_delete
+{
+    public function index(Illuminate\Http\Request $request)
+    {
+        $request->validate(['foo' => 'string']);
+    }
+}
+
+it('does not generate for head by default', function () {
+    $openApiDocument = generateForRoute(function () {
+        return RouteFacade::addRoute('head', 'api/test', [RequestBodyExtensionTest__does_not_generate_by_default_head::class, 'index']);
+    });
+
+    expect($openApiDocument['paths']['/test']['head'])
+        ->not()->toHaveKey('requestBody');
+
+    expect($openApiDocument['paths']['/test']['head'])
+        ->toHaveKey('parameters');
+
+    expect($openApiDocument['paths']['/test']['head']['parameters'])
+        ->toHaveLength(1);
+
+    expect($openApiDocument['paths']['/test']['head']['parameters']['0'])
+        ->toHaveKey('name', 'foo')
+        ->toHaveKey('in', 'query');
+});
+class RequestBodyExtensionTest__does_not_generate_by_default_head
+{
+    public function index(Illuminate\Http\Request $request)
+    {
+        $request->validate(['foo' => 'string']);
+    }
+}
+
+it('does not generate for get by default', function () {
+    $openApiDocument = generateForRoute(function () {
+        return RouteFacade::get('api/test', [RequestBodyExtensionTest__does_not_generate_by_default_get::class, 'index']);
+    });
+
+    expect($openApiDocument['paths']['/test']['get'])
+        ->not()->toHaveKey('requestBody');
+
+    expect($openApiDocument['paths']['/test']['get'])
+        ->toHaveKey('parameters');
+
+    expect($openApiDocument['paths']['/test']['get']['parameters'])
+        ->toHaveLength(1);
+
+    expect($openApiDocument['paths']['/test']['get']['parameters']['0'])
+        ->toHaveKey('name', 'foo')
+        ->toHaveKey('in', 'query');
+});
+class RequestBodyExtensionTest__does_not_generate_by_default_get
+{
+    public function index(Illuminate\Http\Request $request)
+    {
+        $request->validate(['foo' => 'string']);
+    }
+}
+
 it('allows manually defining a request media type', function () {
     $openApiDocument = generateForRoute(function () {
         return RouteFacade::post('api/test', [RequestBodyExtensionTest__allows_manual_request_media_type::class, 'index']);

--- a/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
+++ b/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
@@ -19,109 +19,24 @@ class RequestBodyExtensionTest__uses_application_json_as_default
     }
 }
 
-it('does generate for delete by default', function () {
-    $openApiDocument = generateForRoute(function () {
-        return RouteFacade::delete('api/test', [RequestBodyExtensionTest__does_generate_by_default_delete::class, 'index']);
+it('generates request body only for certain http methods', function (string $method, bool $isRequestBodyExpected) {
+    $openApiDocument = generateForRoute(function () use ($method) {
+        return RouteFacade::addRoute($method, 'api/test', [RequestBodyExtensionTest__generates_request_body_only_for_certain_http_methods::class, 'index']);
     });
 
-    expect($openApiDocument['paths']['/test']['delete'])
-        ->toHaveKey('requestBody')
-        ->and($openApiDocument['paths']['/test']['delete'])
-        ->not()->toHaveKey('parameters')
-        ->and($openApiDocument['paths']['/test']['delete']['requestBody']['content'])
-        ->toHaveKey('application/json')
-        ->toHaveLength(1)
-        ->and(
-            data_get(
-                $openApiDocument,
-                'paths./test.delete.requestBody.content.application/json.schema.properties'
-            )
-        )
-        ->toHaveKey('foo')
-        ->toHaveKey('foo.type', 'string');
-
-});
-class RequestBodyExtensionTest__does_generate_by_default_delete
-{
-    public function index(Illuminate\Http\Request $request)
-    {
-        $request->validate(['foo' => 'string']);
-    }
-}
-
-it('does generate for head by default', function () {
-    $openApiDocument = generateForRoute(function () {
-        return RouteFacade::addRoute('head', 'api/test', [RequestBodyExtensionTest__does_generate_by_default_head::class, 'index']);
-    });
-
-    expect($openApiDocument['paths']['/test']['head'])
-        ->toHaveKey('requestBody')
-        ->and($openApiDocument['paths']['/test']['head'])
-        ->not()->toHaveKey('parameters')
-        ->and($openApiDocument['paths']['/test']['head']['requestBody']['content'])
-        ->toHaveKey('application/json')
-        ->toHaveLength(1)
-        ->and(
-            data_get(
-                $openApiDocument,
-                'paths./test.head.requestBody.content.application/json.schema.properties'
-            )
-        )
-        ->toHaveKey('foo')
-        ->toHaveKey('foo.type', 'string');
-
-});
-class RequestBodyExtensionTest__does_generate_by_default_head
-{
-    public function index(Illuminate\Http\Request $request)
-    {
-        $request->validate(['foo' => 'string']);
-    }
-}
-
-it('does not generate for get by default', function () {
-    $openApiDocument = generateForRoute(function () {
-        return RouteFacade::get('api/test', [RequestBodyExtensionTest__does_not_generate_by_default_get::class, 'index']);
-    });
-
-    expect($openApiDocument['paths']['/test']['get'])
-        ->not()->toHaveKey('requestBody')
-        ->and($openApiDocument['paths']['/test']['get'])
-        ->toHaveKey('parameters')
-        ->and($openApiDocument['paths']['/test']['get']['parameters'])
-        ->toHaveLength(1)
-        ->and($openApiDocument['paths']['/test']['get']['parameters']['0'])
-        ->toHaveKey('name', 'foo')
-        ->toHaveKey('in', 'query');
-
-});
-class RequestBodyExtensionTest__does_not_generate_by_default_get
-{
-    public function index(Illuminate\Http\Request $request)
-    {
-        $request->validate(['foo' => 'string']);
-    }
-}
-
-it('does not generate for delete when configured', function () {
-    config()->set('scramble.disallow_request_body', ['get', 'delete']);
-
-    $openApiDocument = generateForRoute(function () {
-        return RouteFacade::delete('api/test', [RequestBodyExtensionTest__does_not_generate_when_configured_delete::class, 'index']);
-    });
-
-    expect($openApiDocument['paths']['/test']['delete'])
-        ->not()->toHaveKey('requestBody')
-        ->and($openApiDocument['paths']['/test']['delete'])
-        ->toHaveKey('parameters')
-        ->and($openApiDocument['paths']['/test']['delete']['parameters'])
-        ->toHaveLength(1)
-        ->and($openApiDocument['paths']['/test']['delete']['parameters']['0'])
-        ->toHaveKey('name', 'foo')
-        ->toHaveKey('in', 'query');
-
-});
-class RequestBodyExtensionTest__does_not_generate_when_configured_delete
+    expect($openApiDocument['paths']['/test'][$method])
+        ->toHaveKeys($isRequestBodyExpected ? ['requestBody'] : ['parameters'])
+        ->and($openApiDocument['paths']['/test'][$method])
+        ->not()->toHaveKeys($isRequestBodyExpected ? ['parameters'] : ['requestBody']);
+})->with([
+    ['post', true],
+    ['put', true],
+    ['patch', true],
+    ['get', false],
+    ['head', false],
+    ['delete', false],
+]);
+class RequestBodyExtensionTest__generates_request_body_only_for_certain_http_methods
 {
     public function index(Illuminate\Http\Request $request)
     {


### PR DESCRIPTION
For specific HTTP methods. For example, DELETE is not officially supported to have request body, however, only GET methods are prevented to have empty request bodies in the output.