### PR TITLE
Give preference to user-defined extensions over built-in extensions

### DIFF
--- a/src/ScrambleServiceProvider.php
+++ b/src/ScrambleServiceProvider.php
@@ -133,7 +133,7 @@ class ScrambleServiceProvider extends PackageServiceProvider
             return new TypeTransformer(
                 $this->app->make(Infer::class),
                 new Components,
-                array_merge($typesToSchemaExtensions, [
+                array_merge([
                     EnumToSchema::class,
                     JsonResourceTypeToSchema::class,
                     ModelToSchema::class,
@@ -141,13 +141,13 @@ class ScrambleServiceProvider extends PackageServiceProvider
                     AnonymousResourceCollectionTypeToSchema::class,
                     LengthAwarePaginatorTypeToSchema::class,
                     ResponseTypeToSchema::class,
-                ]),
-                array_merge($exceptionToResponseExtensions, [
+                ], $typesToSchemaExtensions),
+                array_merge([
                     ValidationExceptionToResponseExtension::class,
                     AuthorizationExceptionToResponseExtension::class,
                     NotFoundExceptionToResponseExtension::class,
                     HttpExceptionToResponseExtension::class,
-                ]),
+                ], $exceptionToResponseExtensions),
             );
         });
     }


### PR DESCRIPTION
**This PR solves the following problem:**

I tried to create an extension for specific `ResourceCollection`s that implement an interface. This was not possible without these changes since the built-in extensions are executed after the custom ones and the built-in `JsonResourceTypeToSchema` extension would overrule my custom extension. 