### PR TITLE
Swap order of default extensions and configured extensions

### DIFF
--- a/src/ScrambleServiceProvider.php
+++ b/src/ScrambleServiceProvider.php
@@ -132,7 +132,7 @@ class ScrambleServiceProvider extends PackageServiceProvider
             return new TypeTransformer(
                 $this->app->make(Infer::class),
                 new Components,
-                array_merge($typesToSchemaExtensions, [
+                array_merge([
                     EnumToSchema::class,
                     JsonResourceTypeToSchema::class,
                     ModelToSchema::class,
@@ -140,13 +140,13 @@ class ScrambleServiceProvider extends PackageServiceProvider
                     AnonymousResourceCollectionTypeToSchema::class,
                     LengthAwarePaginatorTypeToSchema::class,
                     ResponseTypeToSchema::class,
-                ]),
-                array_merge($exceptionToResponseExtensions, [
+                ], $typesToSchemaExtensions),
+                array_merge([
                     ValidationExceptionToResponseExtension::class,
                     AuthorizationExceptionToResponseExtension::class,
                     NotFoundExceptionToResponseExtension::class,
                     HttpExceptionToResponseExtension::class,
-                ]),
+                ], $exceptionToResponseExtensions),
             );
         });
     }


### PR DESCRIPTION
This allows overriding default extension responses, in case of multiple `shouldHandle` calls returning true.

We have a different set of pagination properties than the Laravel default, which currently forces us to use a customized fork of Scramble. With this change we won't need the fork anymore and can simply add an extension.