### PR TITLE
Taking into account deeper binary fields in request body parameters when determining default request media type

### DIFF
--- a/src/Support/OperationExtensions/RequestBodyExtension.php
+++ b/src/Support/OperationExtensions/RequestBodyExtension.php
@@ -105,11 +105,10 @@ class RequestBodyExtension extends OperationExtension
     protected function hasBinary($bodyParams): bool
     {
         return collect($bodyParams)->contains(function (Parameter $parameter) {
-            if (property_exists($parameter?->schema?->type, 'format')) {
-                return $parameter->schema->type->format === 'binary';
-            }
+            // @todo: Use OpenApi document tree walker when ready
+            $parameterString = json_encode($parameter->toArray());
 
-            return false;
+            return Str::contains($parameterString, '"format":"binary"');
         });
     }
 

--- a/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
+++ b/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
@@ -95,7 +95,7 @@ class RequestBodyExtensionTest__automaticall_infers_form_data_from_deeper
     public function index(Illuminate\Http\Request $request)
     {
         $request->validate([
-            'foo.*' => 'file'
+            'foo.*' => 'file',
         ]);
     }
 }

--- a/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
+++ b/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
@@ -81,6 +81,25 @@ class RequestBodyExtensionTest__automaticall_infers_form_data
     }
 }
 
+it('automatically infers multipart/form-data as request media type when some of body params is binary on a deeper layers', function () {
+    $openApiDocument = generateForRoute(function () {
+        return RouteFacade::post('api/test', [RequestBodyExtensionTest__automaticall_infers_form_data_from_deeper::class, 'index']);
+    });
+
+    expect($openApiDocument['paths']['/test']['post']['requestBody']['content'])
+        ->toHaveKey('multipart/form-data')
+        ->toHaveLength(1);
+});
+class RequestBodyExtensionTest__automaticall_infers_form_data_from_deeper
+{
+    public function index(Illuminate\Http\Request $request)
+    {
+        $request->validate([
+            'foo.*' => 'file'
+        ]);
+    }
+}
+
 it('extracts parameters, their defaults, and descriptions from calling request parameters retrieving methods with scalar types', function () {
     $openApiDocument = generateForRoute(function () {
         return RouteFacade::post('api/test', [RequestBodyExtensionTest__extracts_parameters_from_retrieving_methods_with_scalar_types::class, 'index']);


### PR DESCRIPTION
fixes #260 