### PR TITLE
`match` node type inference

### DIFF
--- a/src/Infer/Scope/Scope.php
+++ b/src/Infer/Scope/Scope.php
@@ -61,14 +61,11 @@ class Scope
         }
 
         if ($node instanceof Node\Expr\Match_) {
-            return match (get_class($node->cond)) {
-                Node\Expr\ArrayDimFetch::class, Node\Expr\Variable::class => Union::wrap(
-                    collect($node->arms)
-                        ->map(fn (Node\MatchArm $arm) => $this->getType($arm->body))
-                        ->toArray()
-                ),
-                default => new UnknownType('Cannot infer type of property fetch: not supported yet.'),
-            };
+            return Union::wrap(
+                collect($node->arms)
+                    ->map(fn (Node\MatchArm $arm) => $this->getType($arm->body))
+                    ->toArray()
+            );
         }
 
         if ($node instanceof Node\Expr\ClassConstFetch) {

--- a/src/Infer/Scope/Scope.php
+++ b/src/Infer/Scope/Scope.php
@@ -60,6 +60,17 @@ class Scope
             ]);
         }
 
+        if ($node instanceof Node\Expr\Match_) {
+            return match (get_class($node->cond)) {
+                Node\Expr\ArrayDimFetch::class, Node\Expr\Variable::class => Union::wrap(
+                    collect($node->arms)
+                        ->map(fn (Node\MatchArm $arm) => $this->getType($arm->body))
+                        ->toArray()
+                ),
+                default => new UnknownType('Cannot infer type of property fetch: not supported yet.'),
+            };
+        }
+
         if ($node instanceof Node\Expr\ClassConstFetch) {
             return (new ClassConstFetchTypeGetter)($node, $this);
         }

--- a/tests/Infer/Scope/ScopeTest.php
+++ b/tests/Infer/Scope/ScopeTest.php
@@ -26,3 +26,14 @@ it('infers ternary expressions nodes types', function ($code, $expectedTypeStrin
     ['unknown() ?: true ?: 1', 'unknown|boolean(true)|int(1)'],
     ['unknown() ?: unknown() ?: unknown()', 'unknown'],
 ]);
+
+it('infers match node type', function ($code, $expectedTypeString) {
+    expect(getStatementTypeForScopeTest($code)->toString())->toBe($expectedTypeString);
+})->with([
+    [<<<'EOD'
+match (unknown()) {
+    42 => 1,
+    default => null,
+}
+EOD, 'int(1)|null'],
+]);


### PR DESCRIPTION
This is a basic implementation of `match` parsing, I have no experience with testing stuff like this if there's a way to handle this better please do let me know.