### PR TITLE
Fix form requests instantiation when request is type hinted using bound interface

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/FormRequestRulesExtractor.php
+++ b/src/Support/OperationExtensions/RulesExtractor/FormRequestRulesExtractor.php
@@ -10,6 +10,7 @@ use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
 use PhpParser\NodeFinder;
+use ReflectionClass;
 
 class FormRequestRulesExtractor
 {
@@ -78,6 +79,16 @@ class FormRequestRulesExtractor
         $requestParam = collect($this->handler->getParams())
             ->first(\Closure::fromCallable([$this, 'findCustomRequestParam']));
 
-        return (string) $requestParam->type;
+        $requestClassName = (string) $requestParam->type;
+
+        $reflectionClass = new ReflectionClass($requestClassName);
+
+        // If the classname is actually an interface, it might be bound to the container.
+        if (! $reflectionClass->isInstantiable() && app()->bound($requestClassName)) {
+            $classInstance = app()->getBindings()[$requestClassName]['concrete'](app());
+            $requestClassName = $classInstance::class;
+        }
+
+        return $requestClassName;
     }
 }

--- a/src/Support/OperationExtensions/RulesExtractor/FormRequestRulesExtractor.php
+++ b/src/Support/OperationExtensions/RulesExtractor/FormRequestRulesExtractor.php
@@ -27,8 +27,7 @@ class FormRequestRulesExtractor
             return false;
         }
 
-        return collect($this->handler->getParams())
-            ->contains(\Closure::fromCallable([$this, 'findCustomRequestParam']));
+        return collect($this->handler->getParams())->contains($this->findCustomRequestParam(...));
     }
 
     public function node()
@@ -76,8 +75,7 @@ class FormRequestRulesExtractor
 
     private function getFormRequestClassName()
     {
-        $requestParam = collect($this->handler->getParams())
-            ->first(\Closure::fromCallable([$this, 'findCustomRequestParam']));
+        $requestParam = collect($this->handler->getParams())->first($this->findCustomRequestParam(...));
 
         $requestClassName = (string) $requestParam->type;
 

--- a/tests/Support/OperationExtensions/RulesExtractor/FormRequestRulesExtractorTest.php
+++ b/tests/Support/OperationExtensions/RulesExtractor/FormRequestRulesExtractorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Dedoc\Scramble\Tests\Support\OperationExtensions\RulesExtractor;
+
+use Dedoc\Scramble\Scramble;
+use Dedoc\Scramble\Tests\TestCase;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+
+class FormRequestRulesExtractorTest extends TestCase
+{
+    /** @test */
+    #[DefineEnvironment('registerInterfaceBasedRequest')]
+    public function resolves_form_request_using_interface()
+    {
+        $openApi = $this->generateForRoute(function () {
+            return Route::post('/test', FormRequestRulesExtractorTestController::class);
+        });
+
+        expect($openApi['paths']['/test']['post']['requestBody']['content']['application/json']['schema']['properties'])
+            ->toHaveKey('foo');
+    }
+
+    protected function registerInterfaceBasedRequest(Application $app)
+    {
+        $app->bind(DataRequestContract::class, ConcreteDataRequest::class);
+    }
+}
+
+interface DataRequestContract {
+    public function rules();
+}
+
+class ConcreteDataRequest extends Request implements DataRequestContract
+{
+    public function rules()
+    {
+        return ['foo' => 'required'];
+    }
+}
+
+class FormRequestRulesExtractorTestController
+{
+    public function __invoke(DataRequestContract $request)
+    {
+
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,11 +2,13 @@
 
 namespace Dedoc\Scramble\Tests;
 
+use Closure;
 use Dedoc\Scramble\Infer\Context;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\ScrambleServiceProvider;
 use Dedoc\Scramble\Support\OperationExtensions\RulesExtractor\RulesToParameters;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Routing\Route;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
@@ -51,5 +53,14 @@ class TestCase extends Orchestra
     protected function defineDatabaseMigrations()
     {
         $this->loadMigrationsFrom(__DIR__.'/migrations');
+    }
+
+    public function generateForRoute(Closure $param)
+    {
+        $route = $param();
+
+        Scramble::routes(fn (Route $r) => $r->uri === $route->uri);
+
+        return app()->make(\Dedoc\Scramble\Generator::class)();
     }
 }


### PR DESCRIPTION
First of all, great package! 

#### Problem I faced
When I was implementing the repo, I noticed that some of the request details were not generated because the request object was being type-hinted using an interface. This can happen within packages when the request interface is bounded to the container through a service provider, allowing the user to then override the implementation through a config key. 

This was what the docs displayed:

![screenshot_2024-05-26 at 13 57 50](https://github.com/dedoc/scramble/assets/16125117/f0928012-4400-4736-a004-e20ddb56e824)

#### Solution
Playing with the source code I added a way to, in case it detects that it's not a class name but an interface one, it pulls it from the container (if mapped).

Now it handles this edge case gracefully:

![screenshot_2024-05-26 at 14 00 28](https://github.com/dedoc/scramble/assets/16125117/2781aee3-fca3-44f6-8cf9-8497051f83dd)