### PR TITLE
Using the same config for altering OpenAPI document after generation for all APIs

### DIFF
--- a/src/Scramble.php
+++ b/src/Scramble.php
@@ -61,6 +61,9 @@ class Scramble
             config: array_merge(config('scramble'), $config),
         );
 
+        // By default, afterOpenApiGenerated is the same for all APIs.
+        $generatorConfig->afterOpenApiGenerated(Scramble::$openApiExtender);
+
         return $generatorConfig;
     }
 


### PR DESCRIPTION
fixed #419 