### PR TITLE
Allow operation extensions

### DIFF
--- a/src/Support/Generator/Operation.php
+++ b/src/Support/Generator/Operation.php
@@ -5,6 +5,7 @@ namespace Dedoc\Scramble\Support\Generator;
 class Operation
 {
     use WithAttributes;
+    use WithExtensions;
 
     public string $method;
 
@@ -138,12 +139,6 @@ class Operation
     {
         $result = [];
 
-        if ($this->attributes) {
-            foreach ($this->attributes as $key => $value) {
-                $result[$key] = $value;
-            }
-        }
-
         if ($this->operationId) {
             $result['operationId'] = $this->operationId;
         }
@@ -202,6 +197,9 @@ class Operation
             $result['servers'] = $servers;
         }
 
-        return $result;
+        return array_merge(
+            $result,
+            $this->extensionPropertiesToArray(),
+        );
     }
 }

--- a/tests/Generator/Operation/OperationTest.php
+++ b/tests/Generator/Operation/OperationTest.php
@@ -20,11 +20,11 @@ it('default deprecated key is false', function () {
         ->and($array)->not()->toHaveKey('deprecated');
 });
 
-it('set custom attribute key', function () {
+it('set extension property', function () {
     $operation = new \Dedoc\Scramble\Support\Generator\Operation('get');
-    $operation->setAttribute('custom-key', 'custom-value');
+    $operation->setExtensionProperty('custom-key', 'custom-value');
 
     $array = $operation->toArray();
 
-    expect($array)->toBe(['custom-key' => 'custom-value']);
+    expect($array)->toBe(['x-custom-key' => 'custom-value']);
 });


### PR DESCRIPTION
Some tools like Spotlight can accept custom attributes (e.g: x-internal).