### PR TITLE
Match namespace|use only on begining of line

### DIFF
--- a/src/Infer/Reflector/ClassReflector.php
+++ b/src/Infer/Reflector/ClassReflector.php
@@ -60,7 +60,7 @@ class ClassReflector
             // Removes all comments.
             $code = preg_replace('/\/\*(?:[^*]|\*+[^*\/])*\*+\/|(?<![:\'"])\/\/.*|(?<![:\'"])#.*/', '', $code);
 
-            $re = '/(namespace|use) ([.\s\S]*?);/m';
+            $re = '/^(namespace|use) ([.\s\S]*?);/m';
             preg_match_all($re, $code, $matches);
 
             $code = "<?php\n".implode("\n", $matches[0]);


### PR DESCRIPTION
Ensure use matches are only on begining of lines to prevent conflicts with use keyword for traits.