### PR TITLE
Fix anyOf being output as an object if some response type gets filtered out

### DIFF
--- a/src/Support/OperationExtensions/ResponseExtension.php
+++ b/src/Support/OperationExtensions/ResponseExtension.php
@@ -51,6 +51,7 @@ class ResponseExtension extends OperationExtension
                      */
                     ->map(fn ($type) => $type ?: new OpenApiTypes\StringType)
                     ->unique(fn ($type) => json_encode($type->toArray()))
+                    ->values()
                     ->all();
 
                 return Response::make((int) $code)


### PR DESCRIPTION
Inidices need to be reset, otherwise anyOf may be printed out as an object (instead of an array) in api.json.

Same approach is already used in ResponseExtension in lines 33-34 (->values() is called after ->unique(...) to ensure 'array' type in json).
