### PR TITLE
Validation parsing: ignore required on sometimes rule

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/RulesToParameter.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesToParameter.php
@@ -57,7 +57,7 @@ class RulesToParameter
 
         $parameter = Parameter::make($this->name, 'query')
             ->setSchema(Schema::fromType($type))
-            ->required($rules->contains('required'))
+            ->required($rules->contains('required') && $rules->doesntContain('sometimes'))
             ->description($description);
 
         return $this->applyDocsInfo($parameter);


### PR DESCRIPTION
Hi, thanks for this great package, i've been using it and it is awesome!

This PR add additional check for marking a validation required.

Context: in laravel we have `sometimes` validation rule which makes the field required only if the field are present. Atm, scramble parsed `sometimes|required` as required, it should be parsed as optional.

Reference: https://laravel.com/docs/11.x/validation#validating-when-present

Feel free to accept or drop this PR, thank you!