### PR TITLE
fix: issue with extensions being overwritten by built-in extensions

### DIFF
--- a/src/ScrambleServiceProvider.php
+++ b/src/ScrambleServiceProvider.php
@@ -172,7 +172,7 @@ class ScrambleServiceProvider extends PackageServiceProvider
             return new TypeTransformer(
                 app()->make(Infer::class),
                 new Components,
-                array_merge($typesToSchemaExtensions, [
+                array_merge([
                     EnumToSchema::class,
                     JsonResourceTypeToSchema::class,
                     ModelToSchema::class,
@@ -181,7 +181,7 @@ class ScrambleServiceProvider extends PackageServiceProvider
                     LengthAwarePaginatorTypeToSchema::class,
                     ResponseTypeToSchema::class,
                     VoidTypeToSchema::class,
-                ]),
+                ], $typesToSchemaExtensions),
                 array_merge($exceptionToResponseExtensions, [
                     ValidationExceptionToResponseExtension::class,
                     AuthorizationExceptionToResponseExtension::class,


### PR DESCRIPTION
This is a fix for this issue/question https://github.com/dedoc/scramble/discussions/442

The order of the types of extensions caused the issue. All the other extension types are merged by putting the custom ones at the end of the array. Still, in the case of `TypeTransformer` it was at the beginning which caused custom extensions to be overridden by the built-in extensions.