### PR TITLE
Fixed: use container to make requests for extraction

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/FormRequestRulesExtractor.php
+++ b/src/Support/OperationExtensions/RulesExtractor/FormRequestRulesExtractor.php
@@ -71,7 +71,7 @@ class FormRequestRulesExtractor
         $requestClassName = $this->getFormRequestClassName();
 
         /** @var Request $request */
-        $request = (new $requestClassName);
+        $request = app($requestClassName);
 
         $rules = [];
 


### PR DESCRIPTION
FormRequest that have a binding in container will not be properly instantiated when the docs are being generated.

![Screen Shot 2024-08-30 at 11 18 16 AM](https://github.com/user-attachments/assets/01e590c9-9167-487c-b83c-1cbfff282089)

The solution proposed in this comment seems to work for me:

https://github.com/dedoc/scramble/pull/399#issuecomment-2134314719

Resolving the class from the container instead of _newing_ it up, works.

I don't see the other error where "it evaluates the request rendering".

The change to using `app` breaks the tests though. It tries to actually create the FormRequest which causes the validation to trigger. At least that is what it seems like.

Any thoughts on how to proceed here? I can take a crack at a PR, if that helps. But I'm not sure what to fix....