### PR TITLE
Fixed incorrect data wrap key when using `AnonymousResourceCollection` and redefining it in collected resource

### DIFF
--- a/src/Support/TypeToSchemaExtensions/AnonymousResourceCollectionTypeToSchema.php
+++ b/src/Support/TypeToSchemaExtensions/AnonymousResourceCollectionTypeToSchema.php
@@ -62,7 +62,7 @@ class AnonymousResourceCollectionTypeToSchema extends TypeToSchemaExtension
 
         $jsonResourceOpenApiType = $this->openApiTransformer->transform($collectingResourceType);
 
-        $shouldWrap = ($wrapKey = AnonymousResourceCollection::$wrap ?? null) !== null
+        $shouldWrap = ($wrapKey = $collectingResourceType->name::$wrap ?? null) !== null
             || $additional instanceof KeyedArrayType;
         $wrapKey = $wrapKey ?: 'data';
 


### PR DESCRIPTION
Accesses the `$wrap` property on the `$collectingResourceType` directly to decide whether to wrap a resource collection in a `data` array or not.