### PR TITLE
fix: undefined array index 0 due to array_filter()

### DIFF
--- a/src/Support/TypeToSchemaExtensions/FlattensMergeValues.php
+++ b/src/Support/TypeToSchemaExtensions/FlattensMergeValues.php
@@ -64,7 +64,9 @@ trait FlattensMergeValues
                     $item->value instanceof Union
                     && (new TypeWalker)->first($item->value, fn (Type $t) => $t->isInstanceOf(MissingValue::class))
                 ) {
-                    $newType = array_filter($item->value->types, fn (Type $t) => ! $t->isInstanceOf(MissingValue::class));
+                    $newType = array_values(
+                        array_filter($item->value->types, fn (Type $t) => ! $t->isInstanceOf(MissingValue::class))
+                    );
 
                     if (! count($newType)) {
                         return [];


### PR DESCRIPTION
Just a few lines after the `array_filter()`, there is a line like `$item->value = $newType[0];` which can be unreliable as `array_filter` does not reset the keys.