### PR TITLE
make extension methods visible in extending class

### DIFF
--- a/src/Support/InferExtensions/JsonResourceCreationInfer.php
+++ b/src/Support/InferExtensions/JsonResourceCreationInfer.php
@@ -58,7 +58,7 @@ class JsonResourceCreationInfer implements ExpressionTypeInferExtension
     /**
      * @param  Node\Arg[]  $args
      */
-    private function setResourceType(Generic $obj, Scope $scope, array $args)
+    protected function setResourceType(Generic $obj, Scope $scope, array $args)
     {
         $obj->templateTypes[0] = TypeHelper::getArgType($scope, $args, ['resource', 0]);
 

--- a/src/Support/InferExtensions/JsonResourceExtension.php
+++ b/src/Support/InferExtensions/JsonResourceExtension.php
@@ -117,7 +117,7 @@ class JsonResourceExtension implements MethodReturnTypeExtension, PropertyTypeEx
      * now, when analyzing parent::toArray() call. `parent::` becomes `JsonResource::`. So this should be fixed in
      * future just for the sake of following how real code works.
      */
-    private function handleToArrayStaticCall(StaticMethodCallEvent $event): ?Type
+    protected function handleToArrayStaticCall(StaticMethodCallEvent $event): ?Type
     {
         $contextClassName = $event->scope->context->classDefinition->name ?? null;
 
@@ -128,12 +128,12 @@ class JsonResourceExtension implements MethodReturnTypeExtension, PropertyTypeEx
         return $this->getModelMethodReturn($contextClassName, 'toArray', $event->arguments, $event->scope);
     }
 
-    private function proxyMethodCallToModel(MethodCallEvent $event)
+    protected function proxyMethodCallToModel(MethodCallEvent $event)
     {
         return $this->getModelMethodReturn($event->getInstance()->name, $event->name, $event->arguments, $event->scope);
     }
 
-    private function getModelMethodReturn(string $resourceClassName, string $methodName, array $arguments, Scope $scope)
+    protected function getModelMethodReturn(string $resourceClassName, string $methodName, array $arguments, Scope $scope)
     {
         $modelType = JsonResourceHelper::modelType($scope->index->getClassDefinition($resourceClassName), $scope);
 
@@ -143,7 +143,7 @@ class JsonResourceExtension implements MethodReturnTypeExtension, PropertyTypeEx
         );
     }
 
-    private function value(Type $type)
+    protected function value(Type $type)
     {
         return $type instanceof FunctionType ? $type->getReturnType() : $type;
     }

--- a/src/Support/InferExtensions/ModelExtension.php
+++ b/src/Support/InferExtensions/ModelExtension.php
@@ -32,7 +32,7 @@ use Illuminate\Support\Str;
 
 class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
 {
-    private static $cache;
+    protected static $cache;
 
     public function shouldHandle(ObjectType $type): bool
     {
@@ -77,7 +77,7 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
      * MySQL/MariaDB decimal is mapped to a string by PDO.
      * Floating point numbers and decimals are all mapped to strings when using the pgsql driver.
      */
-    private function getAttributeTypeFromDbColumnType(?string $columnType, ?string $dbDriverName): ?AbstractType
+    protected function getAttributeTypeFromDbColumnType(?string $columnType, ?string $dbDriverName): ?AbstractType
     {
         if ($columnType === null) {
             return null;
@@ -106,7 +106,7 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
     /**
      * @todo Add support for custom castables.
      */
-    private function getAttributeTypeFromEloquentCasts(string $cast): ?AbstractType
+    protected function getAttributeTypeFromEloquentCasts(string $cast): ?AbstractType
     {
         if ($cast && enum_exists($cast)) {
             return new ObjectType($cast);
@@ -136,7 +136,7 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
         };
     }
 
-    private function getRelationType(array $relation)
+    protected function getRelationType(array $relation)
     {
         if ($isManyRelation = Str::contains($relation['type'], 'Many')) {
             return new Generic(
@@ -196,12 +196,12 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
         ]);
     }
 
-    private function getModelInfo(ObjectType $type)
+    protected function getModelInfo(ObjectType $type)
     {
         return static::$cache[$type->name] ??= (new ModelInfo($type->name))->handle();
     }
 
-    private function getProtectedValue($obj, $name)
+    protected function getProtectedValue($obj, $name)
     {
         $array = (array) $obj;
         $prefix = chr(0).'*'.chr(0);


### PR DESCRIPTION
It isn't possible to reuse private methods in extending class. So I changed them to protected.

```php
class CustomModelExtension extends ModelExtension {

    public function getPropertyType() {
        $this->getModelInfo(); // Error! Member has private visibility.
    }
} 
```