### PR TITLE
Update docs.blade.php

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -37,7 +37,7 @@
             const csrfToken = getCookieValue(CSRF_TOKEN_COOKIE_KEY);
             if (csrfToken) {
                 const { headers = new Headers() } = options || {};
-                updateFetchHeaders(headers, CSRF_TOKEN_HEADER_KEY, decodeURI(csrfToken));
+                updateFetchHeaders(headers, CSRF_TOKEN_HEADER_KEY, decodeURIComponent(csrfToken));
                 return originalFetch(url, {
                     ...options,
                     headers,


### PR DESCRIPTION
As stated in last post here: https://github.com/dedoc/scramble/pull/336, decodeURIComponent should be used instead of decodeURI, because idecodeURI doesn't decode '%3D' (last 3 characters) and CSRF validation in Laravel doesn't pass.