### PR TITLE
fix: specify binary format for files

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
@@ -177,7 +177,7 @@ class RulesMapper
             $type = $this->string($type);
         }
 
-        return $type->contentMediaType('application/octet-stream');
+        return $type->contentMediaType('application/octet-stream')->format('binary');
     }
 
     public function url(Type $type)


### PR DESCRIPTION
## Description

This change adds the `format: binary` option to body parameters validated as `file` in Laravel.

## Additional context

I use @scalar as the OpenAPI frontend and it incorrectly show `file` parameters as `string` input. Specifying the `format` option as `binary` makes scalar recognize the parameter as an actual file and displays an upload button.