### PR TITLE
Service ReflectionClass

### DIFF
--- a/src/Support/ReflectionClassWithDocBlock.php
+++ b/src/Support/ReflectionClassWithDocBlock.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Dedoc\Scramble\Support;
+
+use PhpParser\Node\Stmt;
+use PhpParser\NodeDumper;
+use PhpParser\ParserFactory;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+
+class ReflectionClassWithDocBlock extends \ReflectionClass
+{
+    public array $imports = [];
+
+    public function __construct($objectOrClass)
+    {
+        parent::__construct($objectOrClass);
+
+        $this->imports = $this->getClassImports();
+    }
+
+    /**
+     * Get parsed doc-block with resolved class-names.
+     */
+    public function getDocParsed(): ?PhpDocNode
+    {
+        if ($doc = $this->getDocComment()) {
+            return $this->resolveDocClasses(PhpDoc::parse($doc));
+        }
+
+        return null;
+    }
+
+    /**
+     * PhpStan doesn't resolve class-names of properties.
+     *
+     * use App\MyClass;
+     *
+     * // property MyClass $var
+     *
+     * We need to resolve property type to full-qualified class-name.
+     */
+    protected function resolveDocClasses(PhpDocNode $doc): PhpDocNode
+    {
+        foreach ($doc->children as $node) {
+            if ($node instanceof PhpDocTagNode) {
+                if ($node->value instanceof PropertyTagValueNode) {
+                    $node->value->type = $this->resolve($node->value->type);
+                }
+            }
+        }
+
+        return $doc;
+    }
+
+    protected function resolve(TypeNode $type): TypeNode
+    {
+        if ($type instanceof IdentifierTypeNode) {
+            $name = $type->name;
+            if (isset($this->imports[$name])) {
+                $type->name = $this->imports[$name];
+            }
+        }
+
+        if ($type instanceof UnionTypeNode || $type instanceof IntersectionTypeNode) {
+            foreach ($type->types as $i => $subtype) {
+                $type->types[$i] = $this->resolve($subtype);
+            }
+        }
+
+        if ($type instanceof ArrayTypeNode) {
+            $type->type = $this->resolve($type->type);
+        }
+
+        return $type;
+    }
+
+    protected function getClassImports(): array
+    {
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+
+        $parsed = $parser->parse(file_get_contents($this->getFileName()));
+
+        $uses = [];
+
+        /** @var Stmt $namespace */
+        $namespace = current($parsed);
+        /** @var Stmt $stmt */
+        foreach ($namespace->stmts as $stmt) {
+            if ($stmt instanceof Stmt\GroupUse) {
+                foreach ($stmt->uses as $use) {
+                    $alias = $use->alias?->name ?? str($use->name->name)->afterLast('\\')->toString();
+                    $uses[$alias] = $stmt->prefix->name.'\\'.$use->name->name;
+                }
+            }
+            if ($stmt instanceof Stmt\Use_) {
+                foreach ($stmt->uses as $use) {
+                    $alias = $use->alias?->name ?? str($use->name->name)->afterLast('\\')->toString();
+                    $uses[$alias] = $use->name->name;
+                }
+            }
+        }
+
+        // Classed from current namespace imported without declaration
+        $files = glob(dirname($this->getFileName()).'/*');
+
+        foreach ($files as $filename) {
+            $filename = basename($filename, '.php');
+            $uses[$filename] = $namespace->name.'\\'.$filename;
+        }
+
+        return $uses;
+    }
+}

--- a/tests/Support/MockEnum.php
+++ b/tests/Support/MockEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Dedoc\Scramble\Tests\Support;
+
+enum MockEnum: string
+{
+    case one = 'one';
+    case two = 'two';
+}

--- a/tests/Support/ReflectionClassWithDocBlockTest.php
+++ b/tests/Support/ReflectionClassWithDocBlockTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Dedoc\Scramble\Tests\Support;
+
+use Dedoc\Scramble\Support\ReflectionClassWithDocBlock;
+use Dedoc\Scramble\Tests\TestCase;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\TestCase as TestCaseAlias;
+
+/**
+ * @property null|(TestCaseAlias&TestCase) $intersection
+ * @property TestCaseAlias|TestCase $union
+ * @property array|TestCaseAlias[] $array
+ * @property TestCaseAlias $case
+ * @property array<int,TestCaseAlias> $generic
+ * @property array{"name":TestCaseAlias} $object
+ * @property int-mask<MockEnum> $bitmask
+ * @property Collection|TestCaseAlias[] $collection
+ */
+class ReflectionClassWithDocBlockTest extends TestCaseAlias
+{
+    public function test()
+    {
+        $reflection = new ReflectionClassWithDocBlock(self::class);
+
+        $docs = $reflection->getDocParsed();
+
+        $this->assertEquals('null', $docs->children[0]->value->type->types[0]->name);
+        $this->assertEquals(TestCaseAlias::class, $docs->children[0]->value->type->types[1]->types[0]->name);
+        $this->assertEquals(TestCase::class, $docs->children[0]->value->type->types[1]->types[1]->name);
+
+        $this->assertEquals(TestCaseAlias::class, $docs->children[1]->value->type->types[0]->name);
+        $this->assertEquals(TestCase::class, $docs->children[1]->value->type->types[1]->name);
+
+        $this->assertEquals('array', $docs->children[2]->value->type->types[0]->name);
+        $this->assertEquals(TestCaseAlias::class, $docs->children[2]->value->type->types[1]->type->name);
+
+        $this->assertEquals(TestCaseAlias::class, $docs->children[3]->value->type->name);
+
+        $this->assertEquals(TestCaseAlias::class, $docs->children[4]->value->type->genericTypes[1]->name);
+
+        $this->assertEquals(TestCaseAlias::class, $docs->children[5]->value->type->items[0]->valueType->name);
+
+        $this->assertEquals(MockEnum::class, $docs->children[6]->value->type->genericTypes[0]->name);
+
+        $this->assertEquals(Collection::class, $docs->children[7]->value->type->types[0]->name);
+        $this->assertEquals(TestCaseAlias::class, $docs->children[7]->value->type->types[1]->type->name);
+    }
+}


### PR DESCRIPTION
Many developers annotate model classes with phpdoc containing properties. I beleive it should be used to generate api-doc.

This p-r is a first step to achive it.

For now PhpStan doesn't resolve class-names of phpdoc properties. This p-r provides `ReflectionClassWithDocBlock`, that analizes class imports and modify parsed phpdoc section, replacing class short-names with fully-qualified class names.

Usage:

```php
$reflection = new \Dedoc\Scramble\Support\ReflectionClassWithDocBlock($className);
$docs = $reflection->getDocParsed();
```

I excpect this new docs may be used  to get types of properties in `ModelExtension` or something like that...

Tests included.