### PR TITLE
Add a new configuration.

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -15,6 +15,15 @@ return [
      */
     'api_domain' => null,
 
+
+    /*
+     * This is the URI path where scramble will be accessible from.
+     * Feel free to change this path to anything you like.
+     * Note that the URI will not affect the paths of its internal API that aren't exposed to users.
+    */
+
+    'path' => env('SCRAMBLE_PATH', 'docs/api'),
+
     /*
      * The path where your OpenAPI specification will be exported.
      */

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,6 @@
 
 use Dedoc\Scramble\Scramble;
 
-Scramble::registerUiRoute(path: 'docs/api')->name('scramble.docs.ui');
+Scramble::registerUiRoute(config('scramble.path', 'docs/api'))->name('scramble.docs.ui');
 
 Scramble::registerJsonSpecificationRoute(path: 'docs/api.json')->name('scramble.docs.document');


### PR DESCRIPTION
Add a new configuration.
This new configuration will allow users of the package to change the default route that allows access to the API documentation. 
Which will bring more flexibility and some security or confidentiality.