### PR TITLE
Prevent failing when analyzing `__invoke` call on `\Closure`

### DIFF
--- a/src/Infer/Reflector/MethodReflector.php
+++ b/src/Infer/Reflector/MethodReflector.php
@@ -48,7 +48,10 @@ class MethodReflector
 
     public function getReflection(): ReflectionMethod
     {
-        return new ReflectionMethod($this->className, $this->name);
+        /**
+         * \ReflectionMethod could've been used here, but for `\Closure::__invoke` it fails when constructed manually
+         */
+        return (new \ReflectionClass($this->className))->getMethod($this->name);
     }
 
     /**

--- a/tests/Infer/ReferenceResolutionTest.php
+++ b/tests/Infer/ReferenceResolutionTest.php
@@ -243,3 +243,9 @@ it('resolves invokable call from parent class', function () {
 
     expect($type->toString())->toBe('string(foo)');
 });
+
+it('handles invokable call to Closure type without failing (#636)', function () {
+    $type = getStatementType('(new \Closure)("foo")');
+
+    expect($type->toString())->toBe('unknown');
+});


### PR DESCRIPTION
¯\_(ツ)_/¯

![telegram-cloud-photo-size-2-5341434450334049491-y](https://github.com/user-attachments/assets/208cf9a5-dc61-4204-b007-9fe6ffd384cd)
