### PR TITLE
Add Contribution Guide and Update README

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contribution Guide
+
+Thank you for considering contributing to this project! Contributions of all kinds are welcome and appreciated. To ensure a smooth and productive collaboration, please follow the guidelines below.
+
+## How to Contribute
+
+## General Guidelines
+1. **Respect Existing Issues and PRs**: Before starting work, check the open issues and PRs to avoid duplicating efforts.
+2. **Open a Discussion First**: Before starting any significant work, open a discussion to share your plans. This helps align your efforts with the project's goals and avoid potential frustration.
+3. **Follow the Code Style**: Ensure your code follows the project's code style and conventions. This helps maintain consistency and readability.
+4. **Keep Changes Small**: Break down large changes into smaller, manageable tasks. This makes it easier to review and merge your changes.
+5. **Write Tests**: Write tests for your changes to ensure they work as expected and to prevent regressions.
+6. **Follow the Pull Request Template**: When submitting a PR, follow the provided template to ensure a smooth review process.
+
+## Types of Contributions
+
+### Bug Fixes
+- Bug fixes are always welcome! Feel free to submit a Pull Request (PR) with your changes.
+- Clearly describe the issue in your PR and provide steps to reproduce it if applicable.
+
+### New Features
+- If you want to add a new feature, **[please create a discussion](https://github.com/dedoc/scramble/issues)** first. This allows us to:
+    - Review the proposed feature.
+    - Provide feedback.
+    - Avoid a situation where your PR might not be accepted.
+
+### Refactoring
+- Refactoring code purely for the sake of refactoring is **not accepted**.
+- If your refactoring is part of a bug fix or feature implementation, include a clear explanation in your discussion or PR.
+
+## Submitting a Pull Request
+1. Fork the repository and create your branch: `git checkout -b feature/your-feature-name`.
+2. Make your changes and commit them with descriptive messages.
+3. Push your branch to your fork: `git push origin feature/your-feature-name`.
+4. Open a Pull Request to the main repository, explaining:
+    - The issue your PR addresses (if applicable).
+    - The solution you've implemented.
+    - Any remaining questions or considerations.
+
+We appreciate your contributions and are excited to collaborate with you. If you have any questions, feel free to ask in the discussions or reach out through the appropriate channels.
+
+Thank you for your contribution!
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
   </a>
 </p>
 
+<p align="center">
+    <a href="https://github.com/dedoc/scramble/actions"><img src="https://github.com/dedoc/scramble/actions/workflows/run-tests.yml/badge.svg" alt="Build Status"></a>
+    <a href="https://packagist.org/packages/dedoc/scramble"><img src="https://img.shields.io/packagist/dt/dedoc/scramble" alt="Total Downloads"></a>
+    <a href="https://packagist.org/packages/dedoc/scramble"><img src="https://img.shields.io/packagist/v/dedoc/scramble" alt="Latest Stable Version"></a>
+    <a href="https://packagist.org/packages/dedoc/scramble"><img src="https://img.shields.io/packagist/l/dedoc/scramble" alt="License"></a>
+</p>
+
 # Scramble
 
 Scramble generates API documentation for Laravel project. Without requiring you to manually write PHPDoc annotations. Docs are generated in OpenAPI 3.1.0 format.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ After install you will have 2 routes added to your application:
 
 By default, these routes are available only in `local` environment. You can change this behavior by defining `viewApiDocs` gate.
 
+## Contributing
+
+We appreciate your feedback and contributions to this library! Before you get started, please review following guidelines.
+
+### Reporting Issues or Bugs
+If you've encountered a bug or have suggestions for improvement, [please raise an issue](https://github.com/dedoc/scramble/issues). Provide as much detail as possible to help us address the issue efficiently.
+
+### Submitting Changes
+To contribute code changes or enhancements, follow the guidelines in the [Contribution Guide](./.github/CONTRIBUTING.md). This ensures your contributions align with the pr
+
 ---
 
 <p>


### PR DESCRIPTION
## Description  
This PR introduces a Contribution Guide to help contributors understand how to engage with the project effectively. It also updates the README file with a section on contributing, linking to the new guide and providing guidance on reporting issues or bugs and status badges.

## Changes
1. **Added**: `CONTRIBUTING.md` in the `.github` directory with clear guidelines for contributing to the project.
2. **Updated**: README with a new "Contributing" section that:
   - Links to the Contribution Guide.
   - Provides instructions for raising issues and submitting feedback.
3. **Updated**: README with status badges that display:
   - `run-tests` workflow status
   - Total of downloads
   - Latest version
   - License

## Why These Changes?  
- To improve the onboarding experience for contributors.  
- To clarify expectations and streamline the contribution process.  
- To encourage community involvement and maintain quality standards.

## Checklist
- [x] The contribution guide was created and formatted in Markdown.  
- [x] README updated with a "Contributing" section.  
- [x] Links verified to ensure correctness.

## Feedback  
I’d love feedback on the tone and clarity of the Contribution Guide and the new README section. Let me know if additional changes are needed!
