### PR TITLE
Support `Rule::enum()->except()`

### DIFF
--- a/src/Support/Generator/TypeTransformer.php
+++ b/src/Support/Generator/TypeTransformer.php
@@ -217,6 +217,10 @@ class TypeTransformer
             $openApiType->setAttribute('line', $type->getAttribute('line'));
         }
 
+        if ($type->hasAttribute('enumExcept')) {
+            $openApiType->setAttribute('enumExcept', $type->getAttribute('enumExcept'));
+        }
+
         return $openApiType;
     }
 

--- a/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
@@ -168,9 +168,11 @@ class RulesMapper
 
         $enumName = $getProtectedValue($rule, 'type');
 
-        return $this->openApiTransformer->transform(
-            new ObjectType($enumName)
-        );
+        $objectType = new ObjectType($enumName);
+
+        $objectType->setAttribute('enumExcept', $getProtectedValue($rule, 'except'));
+
+        return $this->openApiTransformer->transform($objectType);
     }
 
     public function image(Type $type)

--- a/src/Support/TypeToSchemaExtensions/EnumToSchema.php
+++ b/src/Support/TypeToSchemaExtensions/EnumToSchema.php
@@ -26,11 +26,18 @@ class EnumToSchema extends TypeToSchemaExtension
     {
         $name = $type->name;
 
-        if (! isset($name::cases()[0]->value)) {
-            return new UnknownType("$type->name enum doesnt have values");
+        $values = [];
+        $except = $type->hasAttribute('enumExcept') ? $type->getAttribute('enumExcept') : [];
+
+        foreach ($name::cases() as $case) {
+            if (!in_array($case, $except, true)) {
+                $values[] = $case->value;
+            }
         }
 
-        $values = array_map(fn ($s) => $s->value, $name::cases());
+        if ($values === []) {
+            return new UnknownType("$type->name enum doesnt have values");
+        }
 
         $schemaType = is_string($values[0]) ? new StringType : new IntegerType;
         $schemaType->enum($values);


### PR DESCRIPTION
Disclaimer: This is my first interaction with this repo. Feel free to change and use this code.

I however did not write new tests for it, I couldn't get pest to work locally (database issues?)

## Before

Using `Rule::enum(MyEnum::class)->except([MyEnum::EXCEPT_VALUE])` resulted in the full list of documented values,  
including all values contained in the `->except()` call

## After

Using `Rule::enum(MyEnum::class)->except([MyEnum::EXCEPT_VALUE])` results in a restricted list of options,  
excluding all values contained in the `->except()` call