### PR TITLE
Added support to @schemaName for Enums

### DIFF
--- a/src/Support/TypeToSchemaExtensions/EnumToSchema.php
+++ b/src/Support/TypeToSchemaExtensions/EnumToSchema.php
@@ -3,16 +3,18 @@
 namespace Dedoc\Scramble\Support\TypeToSchemaExtensions;
 
 use Dedoc\Scramble\Extensions\TypeToSchemaExtension;
+use Dedoc\Scramble\Infer\Reflector\ClassReflector;
 use Dedoc\Scramble\Support\Generator\Reference;
 use Dedoc\Scramble\Support\Generator\Types\IntegerType;
 use Dedoc\Scramble\Support\Generator\Types\StringType;
 use Dedoc\Scramble\Support\Generator\Types\UnknownType;
+use Dedoc\Scramble\Support\SchemaClassDocReflector;
 use Dedoc\Scramble\Support\Type\ObjectType;
 use Dedoc\Scramble\Support\Type\Type;
 
 class EnumToSchema extends TypeToSchemaExtension
 {
-    public function shouldHandle(Type $type)
+    public function shouldHandle(Type $type): bool
     {
         return function_exists('enum_exists')
             && $type instanceof ObjectType
@@ -22,24 +24,33 @@ class EnumToSchema extends TypeToSchemaExtension
     /**
      * @param  ObjectType  $type
      */
-    public function toSchema(Type $type)
+    public function toSchema(Type $type): UnknownType|IntegerType|StringType
     {
-        $name = $type->name;
+        $enum = $type->name;
 
-        if (! isset($name::cases()[0]->value)) {
+        if (! isset($enum::cases()[0]->value)) {
             return new UnknownType("$type->name enum doesnt have values");
         }
 
-        $values = array_map(fn ($s) => $s->value, $name::cases());
+        $values = array_map(static fn ($s) => $s->value, $enum::cases());
 
-        $schemaType = is_string($values[0]) ? new StringType : new IntegerType;
-        $schemaType->enum($values);
+        $schemaType = is_string($values[0])
+            ? new StringType
+            : new IntegerType;
 
-        return $schemaType;
+        return $schemaType->enum($values);
     }
 
-    public function reference(ObjectType $type)
+    public function reference(ObjectType $type): Reference
     {
-        return new Reference('schemas', $type->name, $this->components);
+        $enum = $type->name;
+
+        $phpDocString = ClassReflector::make($enum)
+            ->getReflection()
+            ->getDocComment();
+
+        $fullName = SchemaClassDocReflector::createFromDocString($phpDocString)->getSchemaName($enum);
+
+        return new Reference('schemas', $fullName, $this->components);
     }
 }

--- a/tests/Support/TypeToSchemaExtensions/EnumToSchemaTest.php
+++ b/tests/Support/TypeToSchemaExtensions/EnumToSchemaTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use Dedoc\Scramble\Infer;
+use Dedoc\Scramble\Support\Generator\Components;
+use Dedoc\Scramble\Support\Generator\Reference;
+use Dedoc\Scramble\Support\Generator\Types\IntegerType as GeneratorIntegerType;
+use Dedoc\Scramble\Support\Generator\Types\StringType as GeneratorStringType;
+use Dedoc\Scramble\Support\Generator\Types\UnknownType as GeneratorUnknownType;
+use Dedoc\Scramble\Support\Generator\TypeTransformer;
+use Dedoc\Scramble\Support\Type\ObjectType;
+use Dedoc\Scramble\Support\Type\UnknownType;
+use Dedoc\Scramble\Support\TypeToSchemaExtensions\EnumToSchema;
+
+beforeEach(function () {
+    $this->infer = new Infer(new Infer\Scope\Index);
+
+    $transformer = new TypeTransformer($this->infer, new Components);
+    $this->extension = new EnumToSchema(
+        $this->infer,
+        $transformer,
+        $transformer->getComponents(),
+    );
+});
+
+it('should handle when is instance of ObjectType and exists', function () {
+    $type = new ObjectType(FooEnum::class);
+
+    expect($this->extension->shouldHandle($type))
+        ->toBeTrue();
+});
+
+it('should not handle when is instance of ObjectType and not exists', function () {
+    $type = new ObjectType(__CLASS__);
+
+    expect($this->extension->shouldHandle($type))
+        ->toBeFalse();
+});
+
+it('should not handle when is not instance of ObjectType', function () {
+    $type = new UnknownType;
+
+    expect($this->extension->shouldHandle($type))
+        ->toBeFalse();
+});
+
+it('should return UnknownType when enum does not have values', function () {
+    $type = new ObjectType(FooEnum::class);
+
+    expect($this->extension->toSchema($type))
+        ->toBeInstanceOf(GeneratorUnknownType::class)
+        ->enum
+        ->toBeEmpty();
+});
+
+it('should return StringType when is a string backed enum', function () {
+    $type = new ObjectType(StringEnum::class);
+
+    expect($this->extension->toSchema($type))
+        ->toBeInstanceOf(GeneratorStringType::class)
+        ->enum
+        ->toBe([
+            'foo',
+            'bar',
+        ]);
+});
+
+it('should return IntegerType when is a integer backed enum', function () {
+    $type = new ObjectType(IntegerEnum::class);
+
+    expect($this->extension->toSchema($type))
+        ->toBeInstanceOf(GeneratorIntegerType::class)
+        ->enum
+        ->toBe([
+            1,
+            2,
+        ]);
+});
+
+it('should return enum name as schema name when not annotated', function () {
+    $type = new ObjectType(NotAnnotatedEnum::class);
+
+    expect($this->extension->reference($type))
+        ->toBeInstanceOf(Reference::class)
+        ->getUniqueName()
+        ->toBe('NotAnnotatedEnum');
+});
+
+it('should return schema name equals to annotation when annotated', function () {
+    $type = new ObjectType(AnnotatedEnum::class);
+
+    expect($this->extension->reference($type))
+        ->toBeInstanceOf(Reference::class)
+        ->getUniqueName()
+        ->toBe('AnnotatedSchemaName');
+});
+
+enum FooEnum
+{
+    case Foo;
+    case Bar;
+}
+
+enum StringEnum: string
+{
+    case Foo = 'foo';
+    case Bar = 'bar';
+}
+
+enum IntegerEnum: int
+{
+    case Foo = 1;
+    case Bar = 2;
+}
+
+enum NotAnnotatedEnum {}
+
+/**
+ * @schemaName AnnotatedSchemaName
+ */
+enum AnnotatedEnum {}


### PR DESCRIPTION
## Changes
1. **Updated**: `EnumToSchema` extension to support the annotation `@schemaName`
2. **Added**: Tests to the `EnumToSchema` extension


## Why These Changes?  
- Allow the user to customize the schema names for the enums