### PR TITLE
feat: support the decimal validation rule

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
@@ -46,6 +46,11 @@ class RulesMapper
         return (new NumberType)->addProperties($prevType);
     }
 
+    public function decimal(Type $prevType)
+    {
+        return (new NumberType)->addProperties($prevType);
+    }
+
     public function int(Type $prevType)
     {
         return (new IntegerType)->addProperties($prevType);


### PR DESCRIPTION
Adds support for Laravel's [`decimal`](https://laravel.com/docs/11.x/validation#rule-decimal) validation rule. Such parameters will be identified as `number` in the resulting api spec.

---

Also, there is a typo in the docs:

![Screenshot 28 12 2024 um 18 05 39 PM](https://github.com/user-attachments/assets/7bfd0623-1c0c-4dc5-a986-ef3a9ba35d9a)

Where it says `number` instead of [`numeric`](https://laravel.com/docs/11.x/validation#rule-numeric).