### PR TITLE
fix: Ensure consistent class names and avoid schema duplication.

### DIFF
--- a/src/Support/Type/ObjectType.php
+++ b/src/Support/Type/ObjectType.php
@@ -11,9 +11,10 @@ use Dedoc\Scramble\Infer\Scope\Scope;
 
 class ObjectType extends AbstractType
 {
-    public function __construct(
-        public string $name,
-    ) {}
+    public function __construct(public string $name)
+    {
+        $this->name = ltrim($this->name, '\\');
+    }
 
     public function isInstanceOf(string $className)
     {


### PR DESCRIPTION
This PR fixed the schema duplication caused by inconsistent class name resolution when using the `@return` writing method:

> @return \Illuminate\Database\Eloquent\Collection<\Organization\Organization>

**controller**
```php
class ListOrganizations
{
    /**
     * List Organizations
     *
     * @param \Illuminate\Http\Request $request
     *
     * @return \Illuminate\Database\Eloquent\Collection<\Organization\Organization>
     */
    public function __invoke(Request $request): Collection
    {
        $user = $request->user();

        return Organization::query()->get();
    }
}
```

### Before
<img width="427" alt="Clipboard_Screenshot_1736227420" src="https://github.com/user-attachments/assets/003df3f8-c45d-49bc-9930-5af3bb0c1327" />

<img width="148" alt="Clipboard_Screenshot_1736227439" src="https://github.com/user-attachments/assets/a727e42e-20db-43a2-a524-6630f8cc4cdc" />

### After
<img width="793" alt="Clipboard_Screenshot_1736227531" src="https://github.com/user-attachments/assets/da4e2377-f004-4d9f-afbb-480afe0d36e6" />

<img width="285" alt="Clipboard_Screenshot_1736227485" src="https://github.com/user-attachments/assets/7d8f5e87-da46-40e6-bbc0-af72aa23f398" />
