### PR TITLE
Feat: Allow closures to be registered as operation extensions

### DIFF
--- a/src/Scramble.php
+++ b/src/Scramble.php
@@ -106,7 +106,9 @@ class Scramble
      */
     public static function registerExtension(string|callable $extension): void
     {
-        static::$extensions[] = is_string($extension) ? $extension : $extension(...);
+        $extension = is_string($extension) ? $extension : $extension(...);
+
+        static::$extensions[] = array_merge(static::$extensions, [$extension]);
     }
 
     /**

--- a/src/ScrambleServiceProvider.php
+++ b/src/ScrambleServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Dedoc\Scramble;
 
+use Closure;
 use Dedoc\Scramble\Console\Commands\AnalyzeDocumentation;
 use Dedoc\Scramble\Console\Commands\ExportDocumentation;
 use Dedoc\Scramble\Extensions\ExceptionToResponseExtension;
@@ -128,13 +129,13 @@ class ScrambleServiceProvider extends PackageServiceProvider
             });
 
         $this->app->when(OperationBuilder::class)
-            ->needs('$extensionsClasses')
+            ->needs('$extensions')
             ->give(function () {
                 $extensions = array_merge(config('scramble.extensions', []), Scramble::$extensions);
 
                 $operationExtensions = array_values(array_filter(
                     $extensions,
-                    fn ($e) => is_a($e, OperationExtension::class, true),
+                    fn ($e) => is_a($e, OperationExtension::class, true) || is_a($e, Closure::class),
                 ));
 
                 return array_merge([

--- a/src/Support/RouteInfo.php
+++ b/src/Support/RouteInfo.php
@@ -2,6 +2,7 @@
 
 namespace Dedoc\Scramble\Support;
 
+use Closure;
 use Dedoc\Scramble\Infer;
 use Dedoc\Scramble\Infer\Reflector\MethodReflector;
 use Dedoc\Scramble\Infer\Services\FileParser;
@@ -44,6 +45,11 @@ class RouteInfo
     public function isClassBased(): bool
     {
         return is_string($this->route->getAction('uses'));
+    }
+
+    public function isClosureBased(): bool
+    {
+        return $this->route->getAction('uses')(...) instanceof Closure;
     }
 
     public function className(): ?string

--- a/tests/OperationExtensions/ClosureOperationExtensionsTest.php
+++ b/tests/OperationExtensions/ClosureOperationExtensionsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dedoc\Scramble\Tests\OperationExtensions;
+
+use Dedoc\Scramble\GeneratorConfig;
+use Dedoc\Scramble\Infer;
+use Dedoc\Scramble\Infer\Services\FileParser;
+use Dedoc\Scramble\Scramble;
+use Dedoc\Scramble\Support\Generator\InfoObject;
+use Dedoc\Scramble\Support\Generator\OpenApi;
+use Dedoc\Scramble\Support\Generator\Operation;
+use Dedoc\Scramble\Support\OperationBuilder;
+use Dedoc\Scramble\Support\RouteInfo;
+use Illuminate\Support\Facades\Route as RouteFacade;
+
+beforeEach(function () {
+    $route = RouteFacade::get('/test', fn () => 'test');
+    $this->routeInfo = new RouteInfo($route, app(FileParser::class), app(Infer::class));
+    $this->config = (new GeneratorConfig(config('scramble')));
+    $this->openApi = OpenApi::make('3.1.0')
+        ->setInfo(
+            InfoObject::make($this->config ->get('ui.title', $default = config('app.name')) ?: $default)
+                ->setVersion($this->config ->get('info.version', '0.0.1'))
+                ->setDescription($this->config ->get('info.description', ''))
+        );;
+});
+
+it('can register a closure as an extension', function () {
+    Scramble::registerExtension(function (Operation $operation, RouteInfo $routeInfo) {
+        expect($routeInfo->isClosureBased())->toBeTrue();
+    });
+
+    /** @var OperationBuilder $builder */
+    $builder = resolve(OperationBuilder::class);
+    $builder->build($this->routeInfo, $this->openApi, $this->config);
+});
+
+it('can register an array of closures as extensions', function () {
+    Scramble::registerExtensions([
+        function (Operation $operation, RouteInfo $routeInfo) {
+            expect($routeInfo->isClosureBased())->toBeTrue();
+        },
+        function (Operation $operation, RouteInfo $routeInfo) {
+            expect($routeInfo->isClosureBased())->toBeTrue();
+        },
+        function (Operation $operation, RouteInfo $routeInfo) {
+            expect($routeInfo->isClosureBased())->toBeTrue();
+        }
+    ]);
+
+    /** @var OperationBuilder $builder */
+    $builder = resolve(OperationBuilder::class);
+    $builder->build($this->routeInfo, $this->openApi, $this->config);
+});


### PR DESCRIPTION
## TL;DR

This PR makes it possible for developers to define a closure as an `OperationExtension` versus having to create class that extends the abstract.

## How it works
I've updated the `Scramble::registerExtension` method to accept both `string` and `callable` scalar types as the `$extension` parameter (renamed as appropriate). We then do a type check inside this method to cast callable as instances of `\Closure` and then register the extension:

```php
$extension = is_string($extension) ? $extension : $extension(...);

static::$extensions = array_merge(static::$extensions, [$extension]);
```

For the `registerExtensions` method, I've simply replaced the `array_merge` with a foreach and a call to `registerExtension`. This is a little bit less performant than previously, but unless an application is registering an ungodly number of extensions, the difference is negligible.

> [!NOTE]
> I've also updated the PHPDoc's on these methods and the `Scramble::$extensions` property.

## Example
To register an operation extension as a closure, add the following code to the `boot` method of your applications `AppServiceProvider`:

```php
Scramble::registerExtension(function(Operation $operation, RouteInfo $routeInfo): void {
    // ...
});
```

If you wish to register multiple extensions as closures, you can do so by calling `Scramble ::registerExtensions(...)`:

```php
Scramble::registerExtensions([
    function(Operation $operation, RouteInfo $routeInfo): void {
        // Extension 1
    },
    function(Operation $operation, RouteInfo $routeInfo): void {
        // Extension 2
    }
    ...
]);
```