### PR TITLE
feat: allow using a markdown file to manage the overview body

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -30,7 +30,10 @@ return [
          * Description rendered on the home page of the API documentation (`/docs/api`).
          */
         'description' => '',
+
+        'import_file' => '',
     ],
+
 
     /*
      * Customize Stoplight Elements UI

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -112,6 +112,20 @@ class Generator
         ];
     }
 
+    private function getDescriptionString(GeneratorConfig $config): string
+    {
+        $file = $config->get('info.import_file', '');
+        if(filled($file)){
+            $paths = config('view.paths');
+            foreach($paths as $path){
+                if(file_exists($path . '/' . $file)){
+                    return file_get_contents($path . '/' . $file);
+                }
+            }
+        }
+        return $config->get('info.description', '');
+    }
+
     private function makeOpenApi(GeneratorConfig $config)
     {
         $openApi = OpenApi::make('3.1.0')
@@ -119,7 +133,7 @@ class Generator
             ->setInfo(
                 InfoObject::make($config->get('ui.title', $default = config('app.name')) ?: $default)
                     ->setVersion($config->get('info.version', '0.0.1'))
-                    ->setDescription($config->get('info.description', ''))
+                    ->setDescription($this->getDescriptionString($config))
             );
 
         [$defaultProtocol] = explode('://', url('/'));


### PR DESCRIPTION
we have quite a lengthy introduction page planned for the project and storing this in the config file is a bit messy
being able to have the markdown in a file that can be imported makes this easier to setup, type and version on larger introductory pages.