### PR TITLE
fix: allow custom ExceptionToResponseExtension to override defaults

### DIFF
--- a/src/Support/Generator/TypeTransformer.php
+++ b/src/Support/Generator/TypeTransformer.php
@@ -317,8 +317,11 @@ class TypeTransformer
             );
         }
 
+        // We want latter registered extensions to have a higher priority to allow custom extensions to override default ones.
+        $priorityExtensions = array_reverse($this->exceptionToResponseExtensions);
+
         return array_reduce(
-            $this->exceptionToResponseExtensions,
+            $priorityExtensions,
             function ($acc, $extensionClass) use ($type) {
                 $extension = new $extensionClass($this->infer, $this, $this->getComponents(), $this->context);
 

--- a/tests/Support/ExceptionToResponseExtensions/CustomExceptionToResponseExtensionTest.php
+++ b/tests/Support/ExceptionToResponseExtensions/CustomExceptionToResponseExtensionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Dedoc\Scramble\Extensions\ExceptionToResponseExtension;
+use Dedoc\Scramble\GeneratorConfig;
+use Dedoc\Scramble\Infer;
+use Dedoc\Scramble\OpenApiContext;
+use Dedoc\Scramble\Support\ExceptionToResponseExtensions\AuthenticationExceptionToResponseExtension;
+use Dedoc\Scramble\Support\Generator\Components;
+use Dedoc\Scramble\Support\Generator\OpenApi;
+use Dedoc\Scramble\Support\Generator\Reference;
+use Dedoc\Scramble\Support\Generator\Response;
+use Dedoc\Scramble\Support\Generator\Schema;
+use Dedoc\Scramble\Support\Generator\TypeTransformer;
+use Dedoc\Scramble\Support\Type\ObjectType;
+use Dedoc\Scramble\Support\Type\Type;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Support\Str;
+use Dedoc\Scramble\Support\Generator\Types as OpenApiTypes;
+
+beforeEach(function () {
+    $this->components = new Components;
+    $this->context = new OpenApiContext((new OpenApi('3.1.0'))->setComponents($this->components), new GeneratorConfig);
+});
+
+it('correctly overrides default extension when custom extension exists', function () {
+    $type = new ObjectType(AuthenticationException::class);
+
+    $transformer = new TypeTransformer($infer = app(Infer::class), $this->context, [], [
+        AuthenticationExceptionToResponseExtension::class,
+        CustomAuthenticationExceptionToResponseExtension::class,
+    ]);
+    $extension = new CustomAuthenticationExceptionToResponseExtension($infer, $transformer, $this->components);
+
+    expect($extension->toResponse($type)->toArray())->toMatchArray($transformer->toResponse($type)->resolve()->toArray());
+});
+
+class CustomAuthenticationExceptionToResponseExtension extends ExceptionToResponseExtension {
+
+    public function shouldHandle(Type $type) {
+        return $type instanceof ObjectType
+               && $type->isInstanceOf(AuthenticationException::class);
+    }
+
+    public function toResponse(Type $type) {
+        return Response::make(401)
+                       ->description('Custom Unauthenticated')
+                       ->setContent(
+                           'application/json',
+                           Schema::fromType((new OpenApiTypes\ObjectType))
+                       );
+    }
+
+    public function reference(ObjectType $type) {
+        return new Reference('responses', Str::start($type->name, '\\'), $this->components);
+    }
+
+}


### PR DESCRIPTION
#### **Problem**  
Currently, custom `ExceptionToResponseExtensions` cannot override package-provided extensions because the package extensions are processed first. This means that if a package extension handles a given exception type, a custom extension for the same type is never considered.  

#### **Root Cause**  
In `TypeTransformer::handleResponseUsingExtensions()`, the method iterates over all registered extensions in order, selecting the first one that can handle the type. The list of extensions is structured with package extensions first, followed by custom ones, preventing custom extensions from taking effect when a package extension exists.  

#### **Solution**  
The fix reverses the order of iteration over `$this->exceptionToResponseExtensions`, ensuring that custom extensions are checked before package extensions. This allows custom error responses to properly override default package behavior.  

#### **Impact**  
- Enables full customization of exception-to-response transformations.  
- Maintains backward compatibility for projects not using custom extensions.  

fixes #698