### PR TITLE
Add NullType & LiteralBooleanType support to TypeHelper::createTypeFromTypeNode()

### DIFF
--- a/src/Support/Type/TypeHelper.php
+++ b/src/Support/Type/TypeHelper.php
@@ -64,6 +64,14 @@ class TypeHelper
                 );
             }
 
+            if ($typeNode->name === 'null') {
+                return new NullType;
+            }
+
+            if (in_array($typeNode->name, ['true', 'false'])) {
+                return new LiteralBooleanType($typeNode->name === 'true');
+            }
+
             return new ObjectType($typeNode->toString());
         }
 

--- a/tests/Support/Type/TypeHelperTest.php
+++ b/tests/Support/Type/TypeHelperTest.php
@@ -3,6 +3,7 @@
 namespace Dedoc\Scramble\Tests\Support\Type;
 
 use Dedoc\Scramble\Support\Type\TypeHelper;
+use PhpParser\Node;
 
 test('create type from value', function ($value, string $expectedType) {
     $type = TypeHelper::createTypeFromValue($value);
@@ -22,6 +23,28 @@ test('create type from enum value', function () {
 
     expect($type->toString())->toBe('list{Dedoc\Scramble\Tests\Support\Type\Foo_TypeHelperTest::Foo, Dedoc\Scramble\Tests\Support\Type\Foo_TypeHelperTest::Bar}');
 });
+
+test('create type from type node', function ($node, string $expectedType) {
+    $type = TypeHelper::createTypeFromTypeNode($node);
+
+    expect($type->toString())->toBe($expectedType);
+})->with([
+    [new Node\Identifier('int'), 'int'],
+    [new Node\Identifier('string'), 'string'],
+    [new Node\Identifier('bool'), 'boolean'],
+    [new Node\Identifier('true'), 'boolean(true)'],
+    [new Node\Identifier('false'), 'boolean(false)'],
+    [new Node\Identifier('float'), 'float'],
+    [new Node\Identifier('array'), 'array<mixed>'],
+    [new Node\Identifier('null'), 'null'],
+    [new Node\Name('App\\Models\\User'), 'App\\Models\\User'],
+    [new Node\NullableType(new Node\Identifier('string')), 'null|string'],
+    [new Node\UnionType([
+        new Node\Identifier('int'),
+        new Node\Identifier('string'),
+        new Node\Identifier('null'),
+    ]), 'int|string|null'],
+]);
 
 enum Foo_TypeHelperTest: string
 {


### PR DESCRIPTION
`null` `true` `false` can be used in [Union type](https://php.watch/versions/8.0/union-types)