### PR TITLE
"type" should be a single value and "nullable" is available

### DIFF
--- a/src/Support/Generator/Types/Type.php
+++ b/src/Support/Generator/Types/Type.php
@@ -84,7 +84,8 @@ abstract class Type
     {
         return array_merge(
             array_filter([
-                'type' => $this->nullable ? [$this->type, 'null'] : $this->type,
+                'type' => $this->type,
+                'nullable' => $this->nullable,
                 'format' => $this->format,
                 'contentMediaType' => $this->contentMediaType,
                 'contentEncoding' => $this->contentEncoding,


### PR DESCRIPTION
I had issues with the generated schema when trying to pull in to a client generator (jane-php) so I had a look around and it turned out the nullable types were causing things to kick off.

[The docs](https://swagger.io/docs/specification/v3_0/data-models/data-types/) say type" should be a single value and "nullable" is available.