### PR TITLE
Add `operationId` attribute support

### DIFF
--- a/src/Attributes/OperationId.php
+++ b/src/Attributes/OperationId.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dedoc\Scramble\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class OperationId
+{
+    public function __construct(public readonly string $id) {}
+}

--- a/tests/Generator/Operation/OperationIdTest.php
+++ b/tests/Generator/Operation/OperationIdTest.php
@@ -76,12 +76,30 @@ it('documents operation id based phpdoc param', function () {
     expect($openApiDocument['paths']['/test']['get'])
         ->toHaveKey('operationId', 'manualOperationId');
 });
+
+it('documents operation id based attribute', function () {
+    $openApiDocument = generateForRoute(function () {
+        return RouteFacade::get('api/test', [ManualOperationIdDocumentationTestController::class, 'b'])->name('someNameOfRoute');
+    });
+
+    expect($openApiDocument['paths']['/test']['get'])
+        ->toHaveKey('operationId', 'manualOperationId');
+});
 class ManualOperationIdDocumentationTestController extends \Illuminate\Routing\Controller
 {
     /**
      * @operationId manualOperationId
      */
     public function a(): Illuminate\Http\Resources\Json\JsonResource
+    {
+        return $this->unknown_fn();
+    }
+
+    /**
+     * @operationId manualOperationId
+     */
+    #[\Dedoc\Scramble\Attributes\OperationId('manualOperationId')]
+    public function b(): Illuminate\Http\Resources\Json\JsonResource
     {
         return $this->unknown_fn();
     }


### PR DESCRIPTION
Improves #153 

Added the ability to set the `operationId` using the new `#[OperationId(...)]` attribute.
Attribute definitions will take precedence before phpdoc definitions.