### PR TITLE
feat: add option to hide schemas in the Table of Contents

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -52,6 +52,11 @@ return [
         'hide_try_it' => false,
 
         /*
+         * Hide the schemas in the Table of Contents. Enabled by default.
+         */
+        'hide_schemas' => false,
+
+        /*
          * URL to an image that displays as a small square logo next to the title, above the table of contents.
          */
         'logo' => '',

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -54,6 +54,7 @@
     tryItCredentialsPolicy="{{ $config->get('ui.try_it_credentials_policy', 'include') }}"
     router="hash"
     @if($config->get('ui.hide_try_it')) hideTryIt="true" @endif
+    @if($config->get('ui.hide_schemas')) hideSchemas="true" @endif
     logo="{{ $config->get('ui.logo') }}"
 />
 <script>


### PR DESCRIPTION
**Problem:**
Currently, the `docs.blade.php` must be manually modified to hide the schemas section in the docs UI as mentioned here in the [issue #741](https://github.com/dedoc/scramble/issues/741#issuecomment-2685115514).

**Solution:**
This PR adds a config option `hide_schemas` to control the visibility of the schemas section via the package's config file.

resolves #741