### PR TITLE
Optionally expose excluded routes

### DIFF
--- a/src/Console/Commands/ExportDocumentation.php
+++ b/src/Console/Commands/ExportDocumentation.php
@@ -12,6 +12,7 @@ class ExportDocumentation extends Command
     protected $signature = 'scramble:export
         {--path= : The path to save the exported JSON file}
         {--api=default : The API to export a documentation for}
+        {--all : Ignore exclude attributes, export all routes}
     ';
 
     protected $description = 'Export the OpenAPI document to a JSON file.';
@@ -19,6 +20,10 @@ class ExportDocumentation extends Command
     public function handle(Generator $generator): void
     {
         $config = Scramble::getGeneratorConfig($api = $this->option('api'));
+
+        if ($this->option('all')) {
+            $config->set('ignore_exclude_attributes', true);
+        }
 
         $specification = json_encode($generator($config), JSON_PRETTY_PRINT);
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -185,8 +185,12 @@ class Generator
             })
             ->filter($config->routes())
             ->filter(fn (Route $r) => $r->getAction('controller'))
-            ->filter(function (Route $route) {
+            ->filter(function (Route $route) use ($config) {
                 if (! is_string($route->getAction('uses'))) {
+                    return true;
+                }
+
+                if ($config->get('ignore_exclude_attributes')) {
                     return true;
                 }
 

--- a/src/GeneratorConfig.php
+++ b/src/GeneratorConfig.php
@@ -183,4 +183,9 @@ class GeneratorConfig
     {
         return Arr::get($this->config, $key, $default);
     }
+
+    public function set(string $key, mixed $value): void
+    {
+        $this->config[$key] = $value;
+    }
 }

--- a/src/Scramble.php
+++ b/src/Scramble.php
@@ -14,6 +14,7 @@ use Dedoc\Scramble\Support\Generator\Types\Type as OpenApiType;
 use Dedoc\Scramble\Support\RouteInfo;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Route as RouteFacade;
 
 class Scramble
@@ -148,6 +149,10 @@ class Scramble
     public static function registerUiRoute(string $path, string $api = 'default'): Route
     {
         $config = static::getGeneratorConfig($api);
+
+        if (Context::hasHidden('scramble-all-access')) {
+            $config->set('ignore_exclude_attributes', true);
+        }
 
         return RouteFacade::get($path, function (Generator $generator) use ($api) {
             $config = static::getGeneratorConfig($api);

--- a/src/Scramble.php
+++ b/src/Scramble.php
@@ -169,6 +169,10 @@ class Scramble
     {
         $config = static::getGeneratorConfig($api);
 
+        if (Context::hasHidden('scramble-all-access')) {
+            $config->set('ignore_exclude_attributes', true);
+        }
+
         return RouteFacade::get($path, function (Generator $generator) use ($api) {
             $config = static::getGeneratorConfig($api);
 


### PR DESCRIPTION
Addresses Issue #751

- Adds an `--all` option to the export command that ignores `ExcludeRouteFromDocs` and `ExcludeAllRoutesFromDocs` attributes
- Also ignores `ExcludeRouteFromDocs` and `ExcludeAllRoutesFromDocs` in the UI if the request has the hiddenContext `scramble-all-access`:

    One need simply set the hidden context for appropriate users' requests, thusly:

    ```php
    Context::addHidden('scramble-all-access', true);
    ```