### PR TITLE
Fixed missing `required` info when `required` used with `enum` validation rule

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/DeepParametersMerger.php
+++ b/src/Support/OperationExtensions/RulesExtractor/DeepParametersMerger.php
@@ -60,7 +60,7 @@ class DeepParametersMerger
                     $this->setDeepType(
                         $baseParam->schema->type,
                         $param->name,
-                        $this->extractTypeFromParameter($param),
+                        $param,
                     );
                 }
 
@@ -72,8 +72,10 @@ class DeepParametersMerger
             ->merge($nested);
     }
 
-    private function setDeepType(Type &$base, string $key, Type $typeToSet)
+    private function setDeepType(Type &$base, string $key, Parameter $parameter)
     {
+        $typeToSet = $this->extractTypeFromParameter($parameter);
+
         $containingType = $this->getOrCreateDeepTypeContainer(
             $base,
             collect(explode('.', $key))->splice(1)->values()->all(),
@@ -105,7 +107,7 @@ class DeepParametersMerger
         if (! $isSettingArrayItems && $containingType instanceof ObjectType) {
             $containingType
                 ->addProperty($settingKey, $typeToSet)
-                ->addRequired($typeToSet->getAttribute('required') ? [$settingKey] : []);
+                ->addRequired($parameter->required ? [$settingKey] : []);
         }
     }
 

--- a/tests/ValidationRulesDocumentingTest.php
+++ b/tests/ValidationRulesDocumentingTest.php
@@ -398,6 +398,17 @@ it('documents nullable uri rule', function () {
         ->toHaveProperty('nullable', true);
 });
 
+it('documents required enum rule', function () {
+    $rules = [
+        'pizza.status' => ['required',  Rule::enum(StatusValidationEnum::class)],
+    ];
+
+    $params = ($this->buildRulesToParameters)($rules)->handle();
+
+    expect($params[0]->schema->type->required)
+        ->toBe(['status']);
+});
+
 it('documents date rule', function () {
     $rules = [
         'some_date' => 'date',


### PR DESCRIPTION
fixed #735 