### PR TITLE
Support configurable guard for viewApiDocs

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -88,5 +88,7 @@ return [
         RestrictedDocsAccess::class,
     ],
 
+    'guard' => 'web',
+
     'extensions' => [],
 ];

--- a/src/Http/Middleware/RestrictedDocsAccess.php
+++ b/src/Http/Middleware/RestrictedDocsAccess.php
@@ -2,6 +2,7 @@
 
 namespace Dedoc\Scramble\Http\Middleware;
 
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 
 class RestrictedDocsAccess
@@ -12,7 +13,8 @@ class RestrictedDocsAccess
             return $next($request);
         }
 
-        if (Gate::allows('viewApiDocs')) {
+        $user = Auth::guard(config('scramble.guard'))->user();
+        if (Gate::forUser($user)->allows('viewApiDocs')) {
             return $next($request);
         }
 


### PR DESCRIPTION
Adds configuration for the guard used for checking the viewApiDocs ability.
THis is useful if the application has a dedicated guard for admin sessions.