### PR TITLE
Allow multiple model ressource names and fix model name detection on linebreak crlf

### DIFF
--- a/src/Support/Helpers/JsonResourceHelper.php
+++ b/src/Support/Helpers/JsonResourceHelper.php
@@ -50,7 +50,7 @@ class JsonResourceHelper
             ->first(fn ($str) => Str::is(['*@property*$resource', '*@mixin*'], $str));
 
         if ($mixinOrPropertyLine) {
-            $modelName = Str::replace(['@property', '$resource', '@mixin', ' ', '*'], '', $mixinOrPropertyLine);
+            $modelName = Str::replace(['@property', '$resource', '@mixin', ' ', '*', "\r"], '', $mixinOrPropertyLine);
 
             $modelClass = $getFqName($modelName);
 
@@ -62,10 +62,17 @@ class JsonResourceHelper
         $modelName = (string) Str::of(Str::of($jsonResourceClassName)->explode('\\')->last())->replace('Resource', '')->singular();
 
         $modelClass = 'App\\Models\\'.$modelName;
-        if (! class_exists($modelClass)) {
-            return null;
+        if (class_exists($modelClass)) {
+            return $modelClass;
+        }
+		
+		$modelName = (string) Str::of(Str::of(Str::beforeLast($jsonResourceClassName,'Resource'))->explode('\\')->last())->replace('Resource', '');
+
+        $modelClass = 'App\\Models\\'.$modelName;
+        if (class_exists($modelClass)) {
+            return $modelClass;
         }
 
-        return $modelClass;
+        return null;
     }
 }


### PR DESCRIPTION
In some situations I saw that JsonResourceHelper -> getModelName was not working as expected, so I'd like to add two fixes to improve the situation:

Fix 1:
If the file was encoded with line ending CRLF (on windows) the $modelName variable had something like "User+\r" in it and therfore was never detected.

Fix 2:
I am using multiple resources per model, for example UserRessourceSmall, UserResourceDefault, UserResourceAdmin and so on. Therfore I made a fallback mapping that UserResourceXXX will be still mapped on model User.