### PR TITLE
Fix model name detection on linebreak crlf

### DIFF
--- a/src/Support/Helpers/JsonResourceHelper.php
+++ b/src/Support/Helpers/JsonResourceHelper.php
@@ -50,7 +50,7 @@ class JsonResourceHelper
             ->first(fn ($str) => Str::is(['*@property*$resource', '*@mixin*'], $str));
 
         if ($mixinOrPropertyLine) {
-            $modelName = Str::replace(['@property', '$resource', '@mixin', ' ', '*'], '', $mixinOrPropertyLine);
+            $modelName = Str::replace(['@property', '$resource', '@mixin', ' ', '*', "\r"], '', $mixinOrPropertyLine);
 
             $modelClass = $getFqName($modelName);
 


### PR DESCRIPTION
Fix of JsonResourceHelper -> getModelName. If the file was encoded with line ending CRLF (on windows) the $modelName variable had something like "User+\r" in it and therfore was never detected.