### PR TITLE
Make RulesMapper class can be replaced

### DIFF
--- a/src/ScrambleServiceProvider.php
+++ b/src/ScrambleServiceProvider.php
@@ -36,6 +36,7 @@ use Dedoc\Scramble\Support\InferExtensions\ResponseFactoryTypeInfer;
 use Dedoc\Scramble\Support\InferExtensions\ResponseMethodReturnTypeExtension;
 use Dedoc\Scramble\Support\InferExtensions\TypeTraceInfer;
 use Dedoc\Scramble\Support\InferExtensions\ValidatorTypeInfer;
+use Dedoc\Scramble\Support\OperationExtensions\RulesExtractor\RulesMapper;
 use Dedoc\Scramble\Support\TypeToSchemaExtensions\AnonymousResourceCollectionTypeToSchema;
 use Dedoc\Scramble\Support\TypeToSchemaExtensions\CollectionToSchema;
 use Dedoc\Scramble\Support\TypeToSchemaExtensions\CursorPaginatorTypeToSchema;
@@ -181,6 +182,10 @@ class ScrambleServiceProvider extends PackageServiceProvider
                     HttpExceptionToResponseExtension::class,
                 ], $exceptionToResponseExtensions),
             );
+        });
+
+        $this->app->singleton(RulesMapper::class, function (Application $application, array $parameters): RulesMapper {
+            return new RulesMapper($parameters['typeTransformer']);
         });
     }
 

--- a/src/Support/OperationExtensions/RulesExtractor/RulesToParameter.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesToParameter.php
@@ -119,7 +119,9 @@ class RulesToParameter
 
     private function getTypeFromStringRule(OpenApiType $type, string $rule)
     {
-        $rulesHandler = new RulesMapper($this->openApiTransformer);
+        $rulesHandler = app(RulesMapper::class, [
+            'typeTransformer' => $this->openApiTransformer,
+        ]);
 
         $explodedRule = explode(':', $rule, 2);
 
@@ -133,7 +135,9 @@ class RulesToParameter
 
     private function getTypeFromObjectRule(OpenApiType $type, $rule)
     {
-        $rulesHandler = new RulesMapper($this->openApiTransformer);
+        $rulesHandler = app(RulesMapper::class, [
+            'typeTransformer' => $this->openApiTransformer,
+        ]);
 
         $methodName = Str::camel(class_basename(get_class($rule)));
 


### PR DESCRIPTION
Allow users of this package to use custom `RulesMapper` class, so the user can add below validation rules to  `RulesMapper` class.

- custom validation rules,
- validation rules not supported by this package

Example:

```
class RulesMapper extends \Dedoc\Scramble\Support\OperationExtensions\RulesExtractor\RulesMapper
{
    public function age(Type $type)
    {
        $integer_type = new IntegerType;
        $integer_type->min = 0;
        $integer_type->max = 18;

        return $integer_type;
    }
}
```