### PR TITLE
adds check for HasVersion4Uuids and test

### DIFF
--- a/src/Support/OperationExtensions/ParameterExtractor/PathParametersExtractor.php
+++ b/src/Support/OperationExtensions/ParameterExtractor/PathParametersExtractor.php
@@ -19,6 +19,7 @@ use Dedoc\Scramble\Support\Type\Union;
 use Dedoc\Scramble\Support\Type\UnknownType;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
@@ -180,7 +181,7 @@ class PathParametersExtractor implements ParameterExtractor
         }
 
         $modelTraits = class_uses($type->name);
-        if ($routeKeyName === $modelKeyName && Arr::has($modelTraits, HasUuids::class)) {
+        if ($routeKeyName === $modelKeyName && Arr::hasAny($modelTraits, [HasUuids::class, HasVersion4Uuids::class])) {
             return [(new StringType)->format('uuid'), $description];
         }
 

--- a/tests/Generator/Request/ParametersDocumentationTest.php
+++ b/tests/Generator/Request/ParametersDocumentationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route as RouteFacade;
 
@@ -35,6 +36,40 @@ if (trait_exists(HasUuids::class)) {
     class DocumentsModelKeysUuidParametersAsUuids_Model extends \Illuminate\Database\Eloquent\Model
     {
         use HasUuids;
+    }
+}
+
+if (trait_exists(HasVersion4Uuids::class)) {
+    it('documents model keys uuid v4 parameters as uuids', function () {
+        $openApiDocument = generateForRoute(fn () => RouteFacade::get('api/test/{model}', [
+            DocumentsModelKeysUuidV4ParametersAsUuids_Test::class, 'index',
+        ]));
+
+        expect($params = $openApiDocument['paths']['/test/{model}']['get']['parameters'])
+            ->toHaveCount(1)
+            ->and($params[0])
+            ->toMatchArray([
+                'name' => 'model',
+                'in' => 'path',
+                'required' => true,
+                'schema' => [
+                    'type' => 'string',
+                    'format' => 'uuid',
+                ],
+            ]);
+    });
+
+    class DocumentsModelKeysUuidV4ParametersAsUuids_Test
+    {
+        public function index(DocumentsModelKeysUuidV4ParametersAsUuids_Model $model)
+        {
+            return response()->json();
+        }
+    }
+
+    class DocumentsModelKeysUuidV4ParametersAsUuids_Model extends \Illuminate\Database\Eloquent\Model
+    {
+        use HasVersion4Uuids;
     }
 }
 


### PR DESCRIPTION
This MR adds explicit check for `HasVersion4Uuids` that has replaced `HasUuids` in Laravel 12:
https://laravel.com/docs/12.x/upgrade#models-and-uuidv7