### PR TITLE
Enhance documentation configuration with CDN options for offline access

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -73,6 +73,26 @@ return [
          * - stacked - Everything in a single column, making integrations with existing websites that have their own sidebar or other columns already.
          */
         'layout' => 'responsive',
+
+        /*
+         * CDN url for documentation rendering style
+         * 
+         * This can be useful if you need to access your documentation offline. 
+         * In this case, you need to download the file "https://unpkg.com/@stoplight/elements@8.3.4/styles.min.css" and save it locally.
+         * 
+         * @example /scramble/styles.min.css
+         */
+        // 'css' => ''
+
+        /*
+         * CDN url for documentation rendering script
+         * 
+         * This can be useful if you need to access your documentation offline. 
+         * In this case, you need to download the file "https://unpkg.com/@stoplight/elements@8.3.4/web-components.min.js" and save it locally.
+         * 
+         * @example /scramble/web-components.min.js
+         */
+        // 'js' => ''
     ],
 
     /*

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -6,8 +6,8 @@
     <meta name="color-scheme" content="{{ $config->get('ui.theme', 'light') }}">
     <title>{{ $config->get('ui.title', config('app.name') . ' - API Docs') }}</title>
 
-    <script src="https://unpkg.com/@stoplight/elements@8.3.4/web-components.min.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements@8.3.4/styles.min.css">
+    <script src="{{ $config->get('ui.js', 'https://unpkg.com/@stoplight/elements@8.3.4/web-components.min.js') }}"></script>
+    <link rel="stylesheet" href="{{ $config->get('ui.css', 'https://unpkg.com/@stoplight/elements@8.3.4/styles.min.css') }}">
 
     <script>
         const originalFetch = window.fetch;


### PR DESCRIPTION
This PR improves the documentation configuration by adding CDN support for offline access. The changes include:

- Added comments in `scramble.php` for CDN URLs of CSS and JS files, providing guidance for offline documentation access.
- Updated `docs.blade.php` to utilize configuration values for CDN resources, allowing for easier customization.
- Improved flexibility for custom configuration of documentation resources

### Why ?

These changes make it easier to maintain and customize the documentation resources while ensuring better offline access capabilities.

For example, an application may be available on a local network that's closed to the Internet. However, even offline, a collaborator with access to the local network needs to be able to access the API to design his front-end. With this PR, you simply download the resources from the online documentation (JavaScript and CSS) and add them as internal project assets.