### PR TITLE
Support response headers

### DIFF
--- a/src/Attributes/BodyHeader.php
+++ b/src/Attributes/BodyHeader.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Dedoc\Scramble\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_ALL)]
+class BodyHeader extends Parameter
+{
+    public function __construct(
+        string $name,
+        ?string $description = null,
+        ?string $type = null,
+        ?string $format = null
+    ) {
+        parent::__construct('body-header', $name, $description, false, false, $type, $format, true, new MissingValue, new MissingValue, []);
+    }
+}

--- a/src/Attributes/Parameter.php
+++ b/src/Attributes/Parameter.php
@@ -10,7 +10,7 @@ class Parameter
     public readonly bool $required;
 
     /**
-     * @param  'query'|'path'|'header'|'cookie'|'body'  $in
+     * @param  'query'|'path'|'header'|'cookie'|'body'|'body-header'  $in
      * @param  scalar|array|object|MissingValue  $example
      * @param  array<string, Example>  $examples  The key is a distinct name and the value is an example object.
      */

--- a/src/Support/Generator/Parameter.php
+++ b/src/Support/Generator/Parameter.php
@@ -10,9 +10,9 @@ class Parameter
     public string $name;
 
     /**
-     * Possible values are "query", "header", "path", or "cookie".
+     * Possible values are "query", "header", "body-header", "path", or "cookie".
      *
-     * @var "query"|"header"|"path"|"cookie".
+     * @var "query"|"header"|"path"|"cookie"|"body-header".
      */
     public string $in;
 

--- a/src/Support/Generator/Response.php
+++ b/src/Support/Generator/Response.php
@@ -36,11 +36,11 @@ class Response
         return $this;
     }
 
-    public function addHeader(string $name, ?string $description, Type $type)
+    public function registerHeader(string $name, ?string $description, Type $type)
     {
         $this->headers[$name] = Parameter::make($name, 'body-header')
             ->description($description)
-            ->schema(Schema::fromType($type));
+            ->setSchema(Schema::fromType($type));
 
         return $this;
     }

--- a/src/Support/OperationExtensions/ParameterExtractor/AttributesParametersExtractor.php
+++ b/src/Support/OperationExtensions/ParameterExtractor/AttributesParametersExtractor.php
@@ -125,7 +125,7 @@ class AttributesParametersExtractor implements ParameterExtractor
             ))
             ->required($attribute->required);
 
-        $parameter->setAttribute('nonBody', $attribute->in !== 'body');
+        $parameter->setAttribute('nonBody', $attribute->in !== 'body' && $attribute->in !== 'body-header');
 
         $parameter->deprecated = $attribute->deprecated;
 


### PR DESCRIPTION
I was sad to find out that response headers were not yet supported by scramble, so I created this POC PR to implement them.

I say POC, because my implementation feels a bit hack-y. I'm open to any feedback before I add tests.

OpenAPI 3.0 supports response headers: https://swagger.io/docs/specification/v3_0/describing-responses/#response-headers

## Sample case
[Laravel's ratelimiter](https://laravel.com/docs/12.x/routing#rate-limiting) adds the `X-Ratelimit-Limit` and `X-Ratelimit-Remaining` headers to all requests that implement the `throttle` middleware. When the rate limit is hit, the 429 request will also include the `X-Ratelimit-Remaining` header.

## Implementation

On controller-level, a developer can add #[BodyHeader('X-Rate-Limit', 'description', 'type', 'format')] -> I hacked something together so the header(s) get added to the response.

In `withOperationTransformers` it's possible to add/modify responses, adding headers through `registerHeader(string $name, ?string $description, Type $type)`
