### PR TITLE
Make logo optional to prevent broken image

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -56,7 +56,7 @@
     router="hash"
     @if($config->get('ui.hide_try_it')) hideTryIt="true" @endif
     @if($config->get('ui.hide_schemas')) hideSchemas="true" @endif
-    logo="{{ $config->get('ui.logo') }}"
+    @if($config->get('ui.logo')) logo="{{ $config->get('ui.logo') }}" @endif
     @if($config->get('ui.layout')) layout="{{ $config->get('ui.layout') }}" @endif
 />
 <script>


### PR DESCRIPTION
Running Laravel 12.10.2 and Scramble 0.12.19. Made the logo optional if it doesn't exist in the config.

![CleanShot 2025-05-05 at 11 13 03@2x](https://github.com/user-attachments/assets/5f395cfd-4331-4e75-9248-e05906a68214)
