### PR TITLE
Add `AuthorizationException` when `Gate::authorize` is called

### DIFF
--- a/tests/ErrorsResponsesTest.php
+++ b/tests/ErrorsResponsesTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Routing\Controller;
 use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route as RouteFacade;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -66,6 +67,14 @@ it('doesnt add errors with custom request when errors producing methods are not 
 it('adds authorization error response', function () {
     $openApiDocument = generateForRoute(function () {
         return RouteFacade::get('api/test', [ErrorsResponsesTest_Controller::class, 'adds_authorization_error_response']);
+    });
+
+    assertMatchesSnapshot($openApiDocument);
+});
+
+it('adds authorization error response for gate authorize', function () {
+    $openApiDocument = generateForRoute(function () {
+        return RouteFacade::get('api/test', [ErrorsResponsesTest_Controller::class, 'adds_authorization_error_response_gate']);
     });
 
     assertMatchesSnapshot($openApiDocument);
@@ -174,6 +183,11 @@ class ErrorsResponsesTest_Controller extends Controller
     public function adds_authorization_error_response(Illuminate\Http\Request $request)
     {
         $this->authorize('read');
+    }
+
+    public function adds_authorization_error_response_gate()
+    {
+        Gate::authorize('read');
     }
 
     public function adds_authentication_error_response(Illuminate\Http\Request $request) {}

--- a/tests/__snapshots__/ErrorsResponsesTest__it_adds_authorization_error_response_for_gate_authorize__1.yml
+++ b/tests/__snapshots__/ErrorsResponsesTest__it_adds_authorization_error_response_for_gate_authorize__1.yml
@@ -1,0 +1,10 @@
+openapi: 3.1.0
+info:
+    title: Laravel
+    version: 0.0.1
+servers:
+    - { url: 'http://localhost/api' }
+paths:
+    /test: { get: { operationId: errorsResponsesTest.addsAuthorizationErrorResponseGate, tags: [ErrorsResponsesTest_], responses: { 200: { description: '' }, 403: { $ref: '#/components/responses/AuthorizationException' } } } }
+components:
+    responses: { AuthorizationException: { description: 'Authorization error', content: { application/json: { schema: { type: object, properties: { message: { type: string, description: 'Error overview.' } }, required: [message] } } } } }


### PR DESCRIPTION
Adds support for handling & documenting `403` responses when `Gate::authorize` is called

```php
class ListCommentsController {
    public function __invoke(Post $post)
    {
        Gate::authorize('view', $post);
        // ...
    }
}
```