### PR TITLE
Allow type inference for `@property-read` in JsonResource

### DIFF
--- a/src/Support/Helpers/JsonResourceHelper.php
+++ b/src/Support/Helpers/JsonResourceHelper.php
@@ -50,7 +50,7 @@ class JsonResourceHelper
             ->first(fn ($str) => Str::is(['*@property*$resource', '*@mixin*'], $str));
 
         if ($mixinOrPropertyLine) {
-            $modelName = Str::replace(['@property', '$resource', '@mixin', ' ', '*', "\r"], '', $mixinOrPropertyLine);
+            $modelName = Str::replace(['@property-read', '@property', '$resource', '@mixin', ' ', '*', "\r"], '', $mixinOrPropertyLine);
 
             $modelClass = $getFqName($modelName);
 

--- a/tests/Support/TypeToSchemaExtensions/JsonResourceTypeToSchemaTest.php
+++ b/tests/Support/TypeToSchemaExtensions/JsonResourceTypeToSchemaTest.php
@@ -84,7 +84,7 @@ it('supports parent toArray class', function (string $className, array $expected
     ]],
 ]);
 /**
- * @property JsonResourceTypeToSchemaTest_User $resource
+ * @property-read JsonResourceTypeToSchemaTest_User $resource
  */
 class JsonResourceTypeToSchemaTest_NoToArraySample extends JsonResource {}
 /**


### PR DESCRIPTION
Currently, `@property-read` annotations fail to properly infer the model class from JsonResource classes. This issue results in incomplete and/or inaccurate API documentation, despite `@property-read` being a valid PHPDoc annotation for read-only properties.

```
  Array &0 [
  -    'type' => 'object',
  -    'properties' => Array &1 [
  -        'id' => Array &2 [
  -            'type' => 'integer',
  -        ],
  -        'name' => Array &3 [
  -            'type' => 'string',
  -        ],
  -    ],
  -    'required' => Array &4 [
  -        0 => 'id',
  -        1 => 'name',
  -    ],
  +    'type' => 'string',
   ]
  ```
