### PR TITLE
Change extensions order to handle custom inference extensions before default inference extensions

### DIFF
--- a/src/ScrambleServiceProvider.php
+++ b/src/ScrambleServiceProvider.php
@@ -117,13 +117,13 @@ class ScrambleServiceProvider extends PackageServiceProvider
                     fn ($e) => is_a($e, InferExtension::class, true),
                 ));
 
-                $inferExtensionsClasses = array_merge([
+                $inferExtensionsClasses = array_merge($inferExtensionsClasses, [
                     ResponseMethodReturnTypeExtension::class,
                     JsonResourceExtension::class,
                     ResourceResponseMethodReturnTypeExtension::class,
                     JsonResponseMethodReturnTypeExtension::class,
                     ModelExtension::class,
-                ], $inferExtensionsClasses);
+                ]);
 
                 return array_merge(
                     [


### PR DESCRIPTION
Small change. But I have certain extensions that override default behaviour, such as: Infer model properties from PHPDoc `@property` tags. As some columns are handled via custom casters. Previously, custom extensions were processed after defaults, thus making overrides impossible.