### PR TITLE
Improved documentation of complex query parameters (arrays, objects)

### DIFF
--- a/src/Support/OperationExtensions/RequestBodyExtension.php
+++ b/src/Support/OperationExtensions/RequestBodyExtension.php
@@ -173,7 +173,7 @@ class RequestBodyExtension extends OperationExtension
     }
 
     /**
-     * @param Parameter[] $params
+     * @param  Parameter[]  $params
      * @return Parameter[]
      */
     protected function convertDotNamedParamsToQueryParams(array $params): array
@@ -235,8 +235,8 @@ class RequestBodyExtension extends OperationExtension
                     return null;
                 }
 
-                if (Str::endsWith($parameter->name, '[]') && !$parameter->schema->type instanceof ArrayType) {
-                    $parameter->schema->type = (new ArrayType())
+                if (Str::endsWith($parameter->name, '[]') && ! $parameter->schema->type instanceof ArrayType) {
+                    $parameter->schema->type = (new ArrayType)
                         ->setItems($parameter->schema->type)
                         ->addProperties($parameter->schema->type);
                 }

--- a/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
+++ b/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
@@ -604,7 +604,7 @@ class RequestBodyExtensionTest_DeepQueryParametersController
     public function __invoke(Request $request)
     {
         $request->validate([
-            'filter.accountable' => 'integer'
+            'filter.accountable' => 'integer',
         ]);
     }
 }
@@ -647,7 +647,7 @@ it('documents array query parameters as arrays of some type', function () {
                 'type' => 'array',
                 'items' => [
                     'type' => 'string',
-                ]
+                ],
             ],
         ]);
 });
@@ -674,7 +674,7 @@ it('documents array query parameters as arrays of specific type', function () {
                 'type' => 'array',
                 'items' => [
                     'type' => 'integer',
-                ]
+                ],
             ],
         ]);
 });


### PR DESCRIPTION
This PR improves documentation of complex query parameters (arrays and objects) so it better suits available OpenAPI tools. Currently OpenAPI specification (3.1) and available tools don't allow to easily document complex query parameters (see https://github.com/OAI/OpenAPI-Specification/issues/1706).

Particularly, this PR adds handling of 2 cases. 

**1. Objects and nested objects (fixes #650)**

Imagine you have the following validation rule for your query parameters:
```php
$request->validate([
    'filter.name' => ['string'],
]);
```

You can then pass some value with the following query string:
```
?filter[name]=something
```

Previously Scramble documented this as `filter` parameter that is an `object` with the `name` property:
```json
{
  "name": "filter", 
  "in": "query", 
  "schema": {
    "type": "object", 
    "properties": {
      "name": {"type": "string"}
    }
  }
}
``` 
This seems okay, but it didn't work properly in `Try it out` section in Stoplight Elements (you've got `name=something` in the example CURL section when provided `{"name":"something"}` for `filter` parameter). Yes, you could've used `deepObject` for `style` in this specific case, but not all existing tools will serialize it correctly even with `deepObject`! For example, Stoplight Elements which Scramble uses by default will not properly serialize it.

With this PR, Scramble will document such query parameters like this:
```json
{"name": "filter[name]", "in": "query", "schema": {"type": "string"}}
```

This makes documentation clear and `Try it out` section work properly in all OpenAPI tools. Also this is how Scramble PRO documents filters for Spatie Query Builder package.

This also fixes #879 by not keeping duplicated query parameters.

**2. Array of scalars (fixes #767)**

This is the case when you have a query parameter defined by the following rules:
```php
$request->validate([
    'tags.*' => ['string']
]);
```

`tags` parameter now can be passed via this query string:
```
?tags[]=foo&tags[]=bar
```

Previously Scramble documented such parameter as `tags` parameter which is an `array` of `string`:
```json
{"name": "tags", "in": "query", "schema": {"type": "array", "items": {"type": "string"}}}
``` 

Again, this wasn't properly handled by existing OpenAPI tooling. Not cool! So now Scramble documents it in a way that is understandable by tools (meaning that they produce a correct query string):
```json
{"name": "tags[]", "in": "query", "schema": {"type": "array", "items": {"type": "string"}}}
```

As you can see, Scramble adds `[]` suffix to the parameter name. You can see the discussion about this in this issue's comments #767.

**What is not handled in this PR**

Even more complex structures for query parameters, such as arrays of objects, etc., are left intact (*almost*). There is simply no good way to document them for the existing OpenAPI tooling. 

Scramble, however, marks them with `"x-deepObject-style": "qs"` ("qs" because `qs` library serializes deep objects in the way that is understood by PHP). It is not used by any tools out there but *it can be used* either by tools, or by a developer who uses Scramble. 

In [operation transformer](https://scramble.dedoc.co/developers/customize-openapi-documents#operation-transformers) you can iterate over parameters and if any parameter has this extension set to `qs` you can do whatever you want. For example, you can add a description helping your users to understand how to properly pass the parameter. Or you can flatten it. Let me know if you do something cool with it!

🥴