### PR TITLE
feat: support `'present'` validation rule

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
@@ -113,6 +113,13 @@ class RulesMapper
         return $type->nullable(true);
     }
 
+    public function present(Type $type): Type
+    {
+        $type->setAttribute('required', true);
+
+        return $type;
+    }
+
     public function required(Type $type)
     {
         $type->setAttribute('required', true);

--- a/src/Support/OperationExtensions/RulesExtractor/RulesToParameter.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesToParameter.php
@@ -72,9 +72,15 @@ class RulesToParameter
         $description = $type->description;
         $type->setDescription('');
 
+        $containsRequiringRule = $rules->containsStrict('required')
+            || $rules->containsStrict('present');
+
         $parameter = Parameter::make($this->name, $this->in)
             ->setSchema(Schema::fromType($type))
-            ->required($rules->containsStrict('required') && ! $rules->containsStrict('sometimes'))
+            ->required(
+                $containsRequiringRule
+                && ! $rules->containsStrict('sometimes')
+            )
             ->description($description);
 
         return $this->applyDocsInfo($parameter);

--- a/tests/ValidationRulesDocumentingTest.php
+++ b/tests/ValidationRulesDocumentingTest.php
@@ -35,6 +35,68 @@ function validationRulesToDocumentationWithDeep($rulesToParameters)
 }
 
 // @todo: move rules from here to Generator/Request/ValidationRulesDocumentation test
+it('supports present rule', function () {
+    $rules = [
+        'password' => ['present'],
+    ];
+
+    $params = ($this->buildRulesToParameters)($rules)->handle();
+
+    expect($params = collect($params)->map->toArray()->all())
+        ->toHaveCount(1)
+        ->and($params[0])
+        ->toMatchArray([
+            'name' => 'password',
+            'in' => 'query',
+            'required' => true,
+            'schema' => ['type' => 'string'],
+        ]);
+});
+
+it('supports present rule on array', function () {
+    $rules = [
+        'users' => ['present', 'array'],
+        'users.*' => ['string'],
+    ];
+
+    $params = validationRulesToDocumentationWithDeep(($this->buildRulesToParameters)($rules));
+
+    expect($params = collect($params)->map->toArray()->all())
+        ->toHaveCount(1)
+        ->and($params[0])
+        ->toMatchArray([
+            'name' => 'users',
+            'in' => 'query',
+            'schema' => [
+                'type' => 'array',
+                'items' => ['type' => 'string'],
+            ],
+            'required' => true,
+        ]);
+});
+
+it('supports present rule in array', function () {
+    $rules = [
+        'user.password' => ['present'],
+    ];
+
+    $params = validationRulesToDocumentationWithDeep(($this->buildRulesToParameters)($rules));
+
+    expect($params = collect($params)->map->toArray()->all())
+        ->toHaveCount(1)
+        ->and($params[0])
+        ->toMatchArray([
+            'name' => 'user',
+            'in' => 'query',
+            'schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'password' => ['type' => 'string'],
+                ],
+                'required' => ['password'],
+            ],
+        ]);
+});
 
 it('supports confirmed rule', function () {
     $rules = [


### PR DESCRIPTION
When the 'present' rule is used, the parameter should be marked as required in the request. Currently does nothing