### PR TITLE
Fixed Scramble silently log error when `mixed` used in a function return type hint

### DIFF
--- a/src/Infer/Scope/Index.php
+++ b/src/Infer/Scope/Index.php
@@ -8,6 +8,8 @@ use Dedoc\Scramble\Infer\Definition\ClassDefinition;
 use Dedoc\Scramble\Infer\Definition\FunctionLikeDefinition;
 use Dedoc\Scramble\Infer\Extensions\Event\ClassDefinitionCreatedEvent;
 use Illuminate\Support\Str;
+use ReflectionClass;
+use ReflectionException;
 
 /**
  * Index stores type information about analyzed classes, functions, and constants.
@@ -32,7 +34,7 @@ class Index
             return $this->classesDefinitions[$className];
         }
 
-        $reflection = rescue(fn () => new \ReflectionClass($className)); // @phpstan-ignore argument.type
+        $reflection = $this->createClassReflection($className);
 
         if (! $reflection) {
             return null;
@@ -76,5 +78,14 @@ class Index
     public function getFunctionDefinition(string $fnName): ?FunctionLikeDefinition
     {
         return $this->functionsDefinitions[$fnName] ?? null;
+    }
+
+    private function createClassReflection(string $className): ?ReflectionClass
+    {
+        try {
+            return new ReflectionClass($className); // @phpstan-ignore argument.type
+        } catch (ReflectionException) {
+            return null;
+        }
     }
 }

--- a/src/Support/Type/TypeHelper.php
+++ b/src/Support/Type/TypeHelper.php
@@ -64,6 +64,10 @@ class TypeHelper
                 );
             }
 
+            if ($typeNode->name === 'mixed') {
+                return new MixedType;
+            }
+
             if ($typeNode->name === 'null') {
                 return new NullType;
             }

--- a/tests/ComplexInferTypesTest.php
+++ b/tests/ComplexInferTypesTest.php
@@ -102,3 +102,19 @@ EOD;
 
     expect($result->getFunctionDefinition('foo')->type->getReturnType()->toString())->toBe('string');
 });
+
+it('infers class fetch type (#912)', function () {
+    $code = <<<'EOD'
+<?php
+function bar (): mixed {
+    return unknown();
+}
+function foo () {
+    return bar()->sample();
+}
+EOD;
+
+    $result = analyzeFile($code);
+
+    expect($result->getFunctionDefinition('foo')->type->getReturnType()->toString())->toBe('unknown');
+});


### PR DESCRIPTION
fixes #912 