### PR TITLE
Fixed duplicated schemas in generated spec when using FQN with leading slash in PHPDoc

### DIFF
--- a/src/Infer/Services/FileNameResolver.php
+++ b/src/Infer/Services/FileNameResolver.php
@@ -56,7 +56,7 @@ class FileNameResolver
         $name = $this->nameContext->getResolvedName(new Name([$shortName]), 1)->toString();
 
         // By definition, the returned class name here is FQN, so like *::class or get_class(*)
-        // invoking name resolver returnes the class name without leading slash.
+        // invoking name resolver returns the class name without leading slash.
         return ltrim(class_exists($name) || interface_exists($name) ? $name : $shortName, '\\');
     }
 }


### PR DESCRIPTION
fixes #919 