### PR TITLE
Fix: Prevent secondary exception when route analysis fails

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -71,8 +71,28 @@ class Generator
                         $method = $route->methods()[0];
                         $action = $route->getAction('uses');
 
-                        dump("Error when analyzing route '$method $route->uri' ($action): {$e->getMessage()} – ".($e->getFile().' on line '.$e->getLine()));
-                        logger()->error("Error when analyzing route '$method $route->uri' ($action): {$e->getMessage()} – ".($e->getFile().' on line '.$e->getLine()));
+                       // Ensure $action is safely converted to a readable string
+                        if (is_string($action)) {
+                            $actionString = $action;
+                        } elseif (is_array($action) && isset($action[0], $action[1])) {
+                            $actionString = (is_object($action[0]) ? get_class($action[0]) : $action[0]) . '@' . $action[1];
+                        } elseif ($action instanceof \Closure) {
+                            $actionString = 'Closure';
+                        } elseif (is_object($action)) {
+                            $actionString = get_class($action);
+                        } else {
+                            $actionString = json_encode($action);
+                        }
+
+                        $errorMessage = sprintf(
+                            "Error when analyzing route '$method {$route->uri}' ($actionString): {$e->getMessage()} – %s on line %s",
+                            $e->getFile(),
+                            $e->getLine()
+                        );
+
+                        dump($errorMessage);
+
+                        logger()->error($errorMessage);
                     }
 
                     throw $e;


### PR DESCRIPTION
Hey 👋 

First of all I wanna thanks for this great project!

## Problem
When a route action is a Closure (in group of routes) or other callable, the debug logger tries to cast it to a string. This causes a second exception, making it impossible to see which exact route caused the original problem.

``` php
Route::prefix('payments')
    ->controller(PaymentController::class)
    ->group(function () {
        Route::post('link', 'getPaymentLink');

        Route::post('state', 'getPaymentState');

        // This route has a problem to analyze correctly 
        Route::get('mock-gateway', function () {
            return response()->json(['link' => 'www.mock-gateway.com']);
        });
    });
```

We expect to show the dump and notice us which route has problem but instead of that throws below exception

<img width="1904" height="927" alt="Screenshot from 2025-08-14 03-31-17" src="https://github.com/user-attachments/assets/1138b966-01d4-4833-b424-f34e57c9a4f6" />

### ChangeLog

- Adds safe stringification for $action so the error logs correctly without breaking the original exception.
- Makes it possible to identify the route that triggered the issue.
- Includes minor refactors to tidy up the error handling code.
- With this fix, the docs generator won’t explode twice, and problematic routes are now clearly visible in the logs.
