### PR TITLE
feat(operations): support OperationId via attribute

### DIFF
--- a/src/Attributes/OperationId.php
+++ b/src/Attributes/OperationId.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Dedoc\Scramble\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class OperationId
+{
+    public function __construct(
+        public readonly string $operationId,
+    ) {}
+}

--- a/src/Support/OperationExtensions/RequestEssentialsExtension.php
+++ b/src/Support/OperationExtensions/RequestEssentialsExtension.php
@@ -3,6 +3,7 @@
 namespace Dedoc\Scramble\Support\OperationExtensions;
 
 use Dedoc\Scramble\Attributes\Group;
+use Dedoc\Scramble\Attributes\OperationId;
 use Dedoc\Scramble\Extensions\OperationExtension;
 use Dedoc\Scramble\GeneratorConfig;
 use Dedoc\Scramble\Infer;
@@ -151,6 +152,16 @@ class RequestEssentialsExtension extends OperationExtension
         return new UniqueNameOptions(
             eloquent: (function () use ($routeInfo) {
                 // Manual operation ID setting.
+                // Check if OperationId attribute is present
+                $operationId = ($routeInfo->reflectionMethod()->getAttributes(OperationId::class)[0] ?? null)
+                    ?->newInstance()
+                    ?->operationId;
+
+                if ($operationId) {
+                    return $operationId;
+                }
+
+                // Failing that, lets look for the annotation
                 if (
                     ($operationId = $routeInfo->phpDoc()->getTagsByName('@operationId'))
                     && ($value = trim(Arr::first($operationId)?->value?->value))

--- a/tests/Attributes/OperationIdTest.php
+++ b/tests/Attributes/OperationIdTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Dedoc\Scramble\Tests\Attributes;
+
+use Dedoc\Scramble\Attributes\OperationId;
+use Illuminate\Support\Facades\Route;
+
+it('attaches operation ID to controller action', function () {
+    $openApiDocument = generateForRoute(fn () => Route::get('test', AController_OperationTest::class));
+
+    expect($openApiDocument['paths']['/test']['get']['operationId'])
+        ->toBe('do_something_magic');
+});
+class AController_OperationTest
+{
+    #[OperationId('do_something_magic')]
+    public function __invoke()
+    {
+        return something_unknown();
+    }
+}


### PR DESCRIPTION
This PR adds the ability to generate an operation ID via an Attribute, similar to some of the other attributes supported :)