### PR TITLE
Fix throw statements showing as unknown "string" type in match expressions

### DIFF
--- a/src/Infer/Scope/Scope.php
+++ b/src/Infer/Scope/Scope.php
@@ -27,6 +27,7 @@ use Dedoc\Scramble\Support\Type\SelfType;
 use Dedoc\Scramble\Support\Type\Type;
 use Dedoc\Scramble\Support\Type\Union;
 use Dedoc\Scramble\Support\Type\UnknownType;
+use Dedoc\Scramble\Support\Type\VoidType;
 use PhpParser\Node;
 
 class Scope
@@ -65,6 +66,10 @@ class Scope
 
         if ($node instanceof Node\Expr\ConstFetch) {
             return (new ConstFetchTypeGetter)($node);
+        }
+
+        if ($node instanceof Node\Expr\Throw_) {
+            return new VoidType();
         }
 
         if ($node instanceof Node\Expr\Ternary) {

--- a/tests/Infer/Scope/ScopeTest.php
+++ b/tests/Infer/Scope/ScopeTest.php
@@ -37,3 +37,9 @@ match (unknown()) {
 }
 EOD, 'int(1)|null'],
 ]);
+
+it('infers throw node type', function ($code, $expectedTypeString) {
+    expect(getStatementTypeForScopeTest($code)->toString())->toBe($expectedTypeString);
+})->with([
+    ['throw new Exception("foo")', 'void'],
+]);

--- a/tests/InferExtensions/JsonResourceExtensionTest.php
+++ b/tests/InferExtensions/JsonResourceExtensionTest.php
@@ -80,3 +80,34 @@ class JsonResourceExtensionTest_WhenHas extends JsonResource
         ];
     }
 }
+
+class JsonResourceExtensionTest_MatchWithThrow extends JsonResource
+{
+    public function toArray(Request $request)
+    {
+        return [
+            'property' => match (rand(0, 2)) {
+                0 => 'foo',
+                1 => throw new Exception('foo'),
+                default => 123,
+            },
+        ];
+    }
+}
+
+it('supports match with throw', function () {
+    [$schema] = JsonResourceExtensionTest_analyze($this->infer, $this->context, JsonResourceExtensionTest_MatchWithThrow::class);
+
+    expect($schema->toArray())->toBe([
+        'type' => 'object',
+        'properties' => [
+            'property' => [
+                'anyOf' => [
+                    ['type' => 'string', 'enum' => ['foo']],
+                    ['type' => 'integer', 'enum' => [123]],
+                ],
+            ],
+        ],
+        'required' => ['property'],
+    ]);
+});


### PR DESCRIPTION
## Description
This PR fixes an issue where `throw` statements within match expressions were being inferred as unknown "string" types instead of being properly handled as void types.

### Problem
When using `throw` statements inside match expressions (particularly in JsonResource `toArray` methods), Scramble was incorrectly inferring them as unknown string types, leading to incorrect schema generation in the OpenAPI documentation.

### Solution
Added proper type inference for `Node\Expr\Throw_` nodes by:
1. Adding a check for throw expressions in the `Scope::getType()` method
2. Returning `VoidType` for throw expressions, which correctly excludes them from the union type calculation

### Changes
- **src/Infer/Scope/Scope.php**: Added handling for `Node\Expr\Throw_` to return `VoidType`
- **tests/Infer/Scope/ScopeTest.php**: Added test case to verify throw statements are inferred as void
- **tests/InferExtensions/JsonResourceExtensionTest.php**: Added test case for match expressions with throw statements in JsonResource

### Testing
The fix includes comprehensive tests demonstrating that:
- Throw statements are correctly typed as `void`
- Match expressions with throw arms properly exclude those branches from the resulting union type
- JsonResource schema generation correctly handles match expressions containing throw statements

This ensures that API documentation generated by Scramble accurately reflects the possible return values, excluding paths that throw exceptions.