### PR TITLE
 feat(docs): Make allowed environments configurable

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -108,4 +108,18 @@ return [
     ],
 
     'extensions' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allowed Environments
+    |--------------------------------------------------------------------------
+    |
+    | A list of environments where the API documentation should be accessible.
+    | This is read from the SCRAMBLE_ALLOWED_ENV in your .env file.
+    | By default, it's set to 'local', meaning the documentation is only accessible
+    | in the local development environment.
+    |
+    */
+    'allowed_environments' => explode(',', env('SCRAMBLE_ALLOWED_ENV', 'local')),
+
 ];

--- a/src/Http/Middleware/RestrictedDocsAccess.php
+++ b/src/Http/Middleware/RestrictedDocsAccess.php
@@ -1,14 +1,18 @@
 <?php
+declare(strict_types=1);
 
 namespace Dedoc\Scramble\Http\Middleware;
 
 use Illuminate\Support\Facades\Gate;
 
+/**
+ *
+ */
 class RestrictedDocsAccess
 {
     public function handle($request, \Closure $next)
     {
-        if (app()->environment('local')) {
+        if (app()->environment(config('scramble.allowed_environments'))) {
             return $next($request);
         }
 

--- a/tests/RestrictedDocsAccessTest.php
+++ b/tests/RestrictedDocsAccessTest.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
+use Illuminate\Support\Facades\Route;
+
+beforeEach(function () {
+    Route::get('/_test/docs', fn () => response('Access Granted.'))
+        ->middleware(RestrictedDocsAccess::class);
+    config(['scramble.allowed_environments' => ['local', 'development']]);
+});
+
+it('it allows access when the environment is in the configured list', function () {
+    $allowes_environments = config('scramble.allowed_environments');
+    app()->detectEnvironment(fn () => $allowes_environments[0]);
+    $this->get('/_test/docs')->assertOk();
+});


### PR DESCRIPTION
 Refactors the RestrictedDocsAccess middleware to read the list
 of allowed environments from the `scramble.allowed_environments`
 configuration key instead of using a hardcoded array or the default "local" environment specified. 
 
 This is particularly suitable for stateless apps.

 This allows developers to easily customize which environments can
 access the API documentation via their `.env` file.