### PR TITLE
Pin `@stoplight/elements` to 8.4.2 to avoid tags duplication

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -6,8 +6,8 @@
     <meta name="color-scheme" content="{{ $config->get('ui.theme', 'light') }}">
     <title>{{ $config->get('ui.title', config('app.name') . ' - API Docs') }}</title>
 
-    <script src="https://unpkg.com/@stoplight/elements@9.0.6/web-components.min.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements@9.0.6/styles.min.css">
+    <script src="https://unpkg.com/@stoplight/elements@8.4.2/web-components.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements@8.4.2/styles.min.css">
 
     <script>
         const originalFetch = window.fetch;


### PR DESCRIPTION
fixes #963 