### PR TITLE
Handle multi-method routes, improve rules parsing, properly document HEAD

### DIFF
--- a/src/Exceptions/InvalidSchema.php
+++ b/src/Exceptions/InvalidSchema.php
@@ -44,7 +44,7 @@ class InvalidSchema extends Exception implements ConsoleRenderable, RouteAware
 
     public function getRouteAwareMessage(Route $route, string $msg): string
     {
-        $method = $route->methods()[0];
+        $method = implode(', ', $route->methods());
         $action = $route->getAction('uses');
 
         return "'$method $route->uri' ($action): ".$msg;

--- a/src/Support/OperationBuilder.php
+++ b/src/Support/OperationBuilder.php
@@ -13,9 +13,9 @@ use InvalidArgumentException;
 /** @internal */
 class OperationBuilder
 {
-    public function build(RouteInfo $routeInfo, OpenApi $openApi, GeneratorConfig $config, TypeTransformer $typeTransformer)
+    public function build(RouteInfo $routeInfo, OpenApi $openApi, GeneratorConfig $config, TypeTransformer $typeTransformer, string $method)
     {
-        $operation = new Operation('get');
+        $operation = new Operation(strtolower($method));
 
         foreach ($config->operationTransformers->all() as $operationTransformerClass) {
             $instance = is_callable($operationTransformerClass)

--- a/src/Support/OperationExtensions/ParameterExtractor/MethodCallsParametersExtractor.php
+++ b/src/Support/OperationExtensions/ParameterExtractor/MethodCallsParametersExtractor.php
@@ -2,6 +2,7 @@
 
 namespace Dedoc\Scramble\Support\OperationExtensions\ParameterExtractor;
 
+use Dedoc\Scramble\Support\Generator\Operation;
 use Dedoc\Scramble\Support\Generator\TypeTransformer;
 use Dedoc\Scramble\Support\OperationExtensions\RequestBodyExtension;
 use Dedoc\Scramble\Support\OperationExtensions\RulesExtractor\ParametersExtractionResult;
@@ -11,6 +12,7 @@ class MethodCallsParametersExtractor implements ParameterExtractor
 {
     public function __construct(
         private TypeTransformer $openApiTransformer,
+        private Operation $operation
     ) {}
 
     public function handle(RouteInfo $routeInfo, array $parameterExtractionResults): array
@@ -30,7 +32,7 @@ class MethodCallsParametersExtractor implements ParameterExtractor
         $parameters = array_map(function (InferredParameter $p) use ($routeInfo) {
             $parameter = $p->toOpenApiParameter($this->openApiTransformer);
 
-            $parameter->in = in_array(mb_strtolower($routeInfo->route->methods()[0]), RequestBodyExtension::HTTP_METHODS_WITHOUT_REQUEST_BODY)
+            $parameter->in = in_array(mb_strtolower($this->operation->method), RequestBodyExtension::HTTP_METHODS_WITHOUT_REQUEST_BODY)
                 ? 'query'
                 : 'body';
 

--- a/src/Support/OperationExtensions/RequestEssentialsExtension.php
+++ b/src/Support/OperationExtensions/RequestEssentialsExtension.php
@@ -71,7 +71,6 @@ class RequestEssentialsExtension extends OperationExtension
         $uriWithoutOptionalParams = Str::replace('?}', '}', $routeInfo->route->uri);
 
         $operation
-            ->setMethod(strtolower($routeInfo->route->methods()[0]))
             ->setPath(Str::replace(
                 collect($pathAliases)->keys()->map(fn ($k) => '{'.$k.'}')->all(),
                 collect($pathAliases)->values()->map(fn ($v) => '{'.$v.'}')->all(),

--- a/src/Support/OperationExtensions/ResponseExtension.php
+++ b/src/Support/OperationExtensions/ResponseExtension.php
@@ -23,6 +23,10 @@ class ResponseExtension extends OperationExtension
 {
     public function handle(Operation $operation, RouteInfo $routeInfo): void
     {
+        if ($operation->method === 'head') {
+            return;
+        }
+
         $inferredResponses = $this->collectInferredResponses($routeInfo);
 
         $responses = $this->applyResponsesAttributes($inferredResponses, $routeInfo);

--- a/src/Support/OperationExtensions/RulesEvaluator/ComposedFormRequestRulesEvaluator.php
+++ b/src/Support/OperationExtensions/RulesEvaluator/ComposedFormRequestRulesEvaluator.php
@@ -3,7 +3,7 @@
 namespace Dedoc\Scramble\Support\OperationExtensions\RulesEvaluator;
 
 use Dedoc\Scramble\Infer\Reflector\ClassReflector;
-use Illuminate\Routing\Route;
+use Dedoc\Scramble\Support\Generator\Operation;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeFinder;
@@ -14,7 +14,7 @@ class ComposedFormRequestRulesEvaluator implements RulesEvaluator
     public function __construct(
         private PrettyPrinter $printer,
         private ClassReflector $classReflector,
-        private Route $route,
+        private Operation $operation
     ) {}
 
     public function handle(): array
@@ -27,8 +27,8 @@ class ComposedFormRequestRulesEvaluator implements RulesEvaluator
         )?->expr ?? null;
 
         $evaluators = [
-            new FormRequestRulesEvaluator($this->classReflector, $this->route),
-            new NodeRulesEvaluator($this->printer, $rulesMethodNode, $returnNode, $this->classReflector->className),
+            new FormRequestRulesEvaluator($this->classReflector, $this->operation),
+            new NodeRulesEvaluator($this->printer, $rulesMethodNode, $returnNode, $this->operation, $this->classReflector->className),
         ];
 
         foreach ($evaluators as $evaluator) {

--- a/src/Support/OperationExtensions/RulesEvaluator/FormRequestRulesEvaluator.php
+++ b/src/Support/OperationExtensions/RulesEvaluator/FormRequestRulesEvaluator.php
@@ -3,22 +3,22 @@
 namespace Dedoc\Scramble\Support\OperationExtensions\RulesEvaluator;
 
 use Dedoc\Scramble\Infer\Reflector\ClassReflector;
+use Dedoc\Scramble\Support\Generator\Operation;
 use Illuminate\Http\Request;
-use Illuminate\Routing\Route;
 
 class FormRequestRulesEvaluator implements RulesEvaluator
 {
     public function __construct(
         private ClassReflector $classReflector,
-        private Route $route,
+        private Operation $operation
     ) {}
 
     public function handle(): array
     {
-        return $this->rules($this->classReflector->className, $this->route);
+        return $this->rules($this->classReflector->className);
     }
 
-    protected function rules(string $requestClassName, Route $route)
+    protected function rules(string $requestClassName)
     {
         /** @var Request $request */
         $request = (new $requestClassName);
@@ -26,7 +26,7 @@ class FormRequestRulesEvaluator implements RulesEvaluator
         $rules = [];
 
         if (method_exists($request, 'setMethod')) {
-            $request->setMethod($route->methods()[0]);
+            $request->setMethod(strtoupper($this->operation->method));
         }
 
         if (method_exists($request, 'rules')) {


### PR DESCRIPTION
We frequently use PATCH and PUT in REST APIs defined via `Route::apiResource('path', ControllerName)`. Laravel maps update to both `PATCH `and `PUT`, but Scramble currently generates docs only for `PUT`, which is incorrect and prevents us from documenting endpoints properly.

This PR contains:

1. Correctly handles routes that map to multiple methods.
2. Improves request rules parsing.
3. Properly documents the HEAD method.