### PR TITLE
feat(scope): infer null coalescing operator

### DIFF
--- a/src/Infer/Scope/Scope.php
+++ b/src/Infer/Scope/Scope.php
@@ -80,6 +80,13 @@ class Scope
             ]);
         }
 
+        if ($node instanceof Node\Expr\BinaryOp\Coalesce) {
+            return Union::wrap([
+                $this->getType($node->left),
+                $this->getType($node->right),
+            ]);
+        }
+
         if ($node instanceof Node\Expr\Match_) {
             return Union::wrap(array_map(fn (Node\MatchArm $arm) => $this->getType($arm->body), $node->arms));
         }

--- a/tests/Infer/Scope/ScopeTest.php
+++ b/tests/Infer/Scope/ScopeTest.php
@@ -27,6 +27,17 @@ it('infers ternary expressions nodes types', function ($code, $expectedTypeStrin
     ['unknown() ?: unknown() ?: unknown()', 'unknown'],
 ]);
 
+it('infers expressions from a null coalescing operator', function ($code, $expectedTypeString) {
+    expect(getStatementTypeForScopeTest($code)->toString())->toBe($expectedTypeString);
+})->with([
+    ['unknown() ?? 1', 'unknown|int(1)'],
+    ['(int) unknown() ?? 1', 'int|int(1)'],
+    ['1 ?? 1', 'int(1)'],
+    ['unknown() ?? unknown()', 'unknown'],
+    ['unknown() ?? true ?? 1', 'unknown|boolean(true)|int(1)'],
+    ['unknown() ?? unknown() ?? unknown()', 'unknown'],
+]);
+
 it('infers match node type', function ($code, $expectedTypeString) {
     expect(getStatementTypeForScopeTest($code)->toString())->toBe($expectedTypeString);
 })->with([


### PR DESCRIPTION
This PR adds the ability to infer types from the null coalescing operator `??` - previously would resolve to `UnknownType`.