### PR TITLE
[change] Support enum names extension property

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -102,6 +102,15 @@ return [
      */
     'enum_cases_description_strategy' => 'description',
 
+    /**
+     * Determines how Scramble stores the names of enum cases.
+     * Available options:
+     * - 'names' – Case names are stored in the `x-enumNames` enum schema extension.
+     * - 'varnames' - Case names are stored in the `x-enum-varnames` enum schema extension.
+     * - false - Case names are not stored.
+     */
+    'enum_cases_names_strategy' => false,
+
     'middleware' => [
         'web',
         RestrictedDocsAccess::class,

--- a/tests/TypeToSchemaTransformerTest.php
+++ b/tests/TypeToSchemaTransformerTest.php
@@ -164,6 +164,51 @@ it('gets enum with values type and description with extensions', function () {
         ]);
 });
 
+it('gets enum with values type and names as varnames with extensions', function () {
+    config()->set('scramble.enum_cases_names_strategy', 'varnames');
+
+    $transformer = new TypeTransformer($infer = app(Infer::class), $this->context, [EnumToSchema::class]);
+    $extension = new EnumToSchema($infer, $transformer, $this->context->openApi->components);
+
+    $type = new ObjectType(InvalidEnumValues::class);
+
+    expect($extension->toSchema($type)->toArray()['x-enum-varnames'])
+        ->toBe([
+            'PLUS',
+            'MINUS',
+            'ONE',
+        ]);
+});
+
+it('gets enum with values type without names with extensions', function () {
+    config()->set('scramble.enum_cases_names_strategy', false);
+
+    $transformer = new TypeTransformer($infer = app(Infer::class), $this->context, [EnumToSchema::class]);
+    $extension = new EnumToSchema($infer, $transformer, $this->context->openApi->components);
+
+    $type = new ObjectType(InvalidEnumValues::class);
+
+    expect(array_keys($extension->toSchema($type)->toArray()))
+        ->not()
+        ->toContain('x-enumNames', 'x-enum-varnames');
+});
+
+it('gets enum with values type and names as enumNames with extensions', function () {
+    config()->set('scramble.enum_cases_names_strategy', 'names');
+
+    $transformer = new TypeTransformer($infer = app(Infer::class), $this->context, [EnumToSchema::class]);
+    $extension = new EnumToSchema($infer, $transformer, $this->context->openApi->components);
+
+    $type = new ObjectType(InvalidEnumValues::class);
+
+    expect($extension->toSchema($type)->toArray()['x-enumNames'])
+        ->toBe([
+            'PLUS',
+            'MINUS',
+            'ONE',
+        ]);
+});
+
 it('gets enum with values type and description without cases', function () {
     config()->set('scramble.enum_cases_description_strategy', false);
 
@@ -553,4 +598,11 @@ enum StatusFour: string
      * Drafts are the posts that are not visible by visitors.
      */
     case DRAFT = 'draft';
+}
+
+enum InvalidEnumValues: string
+{
+    case PLUS = '+';
+    case MINUS = '-';
+    case ONE = '1';
 }


### PR DESCRIPTION
Along with the currently supported `x-enumDescriptions`, some tooling that consumes OpenApi specs support extension properties for the names of enums.

The extension property `x-enum-varnames` is supported by tools like [Openapi Codegen](https://github.com/ferdikoomen/openapi-typescript-codegen/wiki/Enum-with-custom-names-and-descriptions), [OpenApi Generator](https://openapi-generator.tech/docs/templating/#enum) and [Scalar](https://guides.scalar.com/scalar/scalar-api-references/openapi#openapi-specification__x-enum-varnames)

The property `x-enumNames` is used by [NJsonSchema](https://github.com/RicoSuter/NJsonSchema/wiki/Enums#enum-names-and-descriptions)

Other tools like [OpenApi-TS support both](https://openapi-ts.dev/advanced#enum-extensions)