### PR TITLE
Add support for wildcard array keys in validation rules

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/DeepParametersMerger.php
+++ b/src/Support/OperationExtensions/RulesExtractor/DeepParametersMerger.php
@@ -137,7 +137,7 @@ class DeepParametersMerger
 
         if ($isSettingArrayItems && $containingType instanceof ObjectType) {
             $containingType->properties = collect($containingType->properties)
-                ->map(fn($prop) => $prop instanceof UnknownType ? $typeToSet : $prop)
+                ->map(fn ($prop) => $prop instanceof UnknownType ? $typeToSet : $prop)
                 ->all();
         }
     }

--- a/tests/ValidationRulesDocumentingTest.php
+++ b/tests/ValidationRulesDocumentingTest.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Route as RouteFacade;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Enum;
+
 use function Spatie\Snapshots\assertMatchesSnapshot;
 
 beforeEach(function () {


### PR DESCRIPTION
Issue #977 

When using rules in FormRequest like

```php
public function rules(): array
    {
        return [
            "items.*" => "integer", // ignored
            "items.b" => "integer",
            "items" => "array:a,b,c,d",
        ];
    }
```

`items.*` gets ignored.

This PR adds support for it.

I added a test for it without snapshots, to make it clearer. If needed I will use snapshots

