### PR TITLE
Support more integer types

### DIFF
--- a/src/PhpDoc/PhpDocTypeHelper.php
+++ b/src/PhpDoc/PhpDocTypeHelper.php
@@ -9,6 +9,7 @@ use Dedoc\Scramble\Support\Type\FloatType;
 use Dedoc\Scramble\Support\Type\FunctionType;
 use Dedoc\Scramble\Support\Type\Generic;
 use Dedoc\Scramble\Support\Type\GenericClassStringType;
+use Dedoc\Scramble\Support\Type\IntegerRangeType;
 use Dedoc\Scramble\Support\Type\IntegerType;
 use Dedoc\Scramble\Support\Type\IntersectionType;
 use Dedoc\Scramble\Support\Type\KeyedArrayType;
@@ -42,6 +43,10 @@ class PhpDocTypeHelper
 {
     public static function toType(TypeNode $type)
     {
+        if ($type instanceof GenericTypeNode && $type->type->name === 'int') {
+            return static::handleGenericInteger($type->genericTypes);
+        }
+
         if ($type instanceof IdentifierTypeNode) {
             return static::handleIdentifierNode($type);
         }
@@ -169,7 +174,13 @@ class PhpDocTypeHelper
             'non-negative-int',
             'non-zero-int',
         ])) {
-            return new IntegerType;
+            return match ($type->name) {
+                'int', 'integer', 'non-zero-int' => new IntegerType,
+                'positive-int' => new IntegerRangeType(min: 1),
+                'negative-int' => new IntegerRangeType(max: -1),
+                'non-positive-int' => new IntegerRangeType(max: 0),
+                'non-negative-int' => new IntegerRangeType(min: 0),
+            };
         }
         if (in_array($type->name, ['bool', 'boolean'])) {
             return new BooleanType;
@@ -201,5 +212,54 @@ class PhpDocTypeHelper
         }
 
         return new ObjectType($type->name);
+    }
+
+    /**
+     * @param  list<\PHPStan\PhpDocParser\Ast\Type\TypeNode>  $genericTypes
+     */
+    private static function handleGenericInteger(array $genericTypes): IntegerType
+    {
+        if (count($genericTypes) !== 2) {
+            return new IntegerType;
+        }
+
+        if (! ($genericTypes[0] instanceof ConstTypeNode || $genericTypes[0] instanceof IdentifierTypeNode)) {
+            return new IntegerType;
+        }
+
+        if ($genericTypes[0] instanceof ConstTypeNode && ! $genericTypes[0]->constExpr instanceof ConstExprIntegerNode) {
+            return new IntegerType;
+        }
+
+        if ($genericTypes[0] instanceof IdentifierTypeNode && $genericTypes[0]->name !== 'min') {
+            return new IntegerType;
+        }
+
+        if (! ($genericTypes[1] instanceof ConstTypeNode || $genericTypes[1] instanceof IdentifierTypeNode)) {
+            return new IntegerType;
+        }
+
+        if ($genericTypes[1] instanceof ConstTypeNode && ! $genericTypes[1]->constExpr instanceof ConstExprIntegerNode) {
+            return new IntegerType;
+        }
+
+        if ($genericTypes[1] instanceof IdentifierTypeNode && $genericTypes[1]->name !== 'max') {
+            return new IntegerType;
+        }
+
+        $min = match (true) {
+            $genericTypes[0] instanceof ConstTypeNode => $genericTypes[0]->constExpr->value,
+            $genericTypes[0] instanceof IdentifierTypeNode => null,
+        };
+
+        $max = match (true) {
+            $genericTypes[1] instanceof ConstTypeNode => $genericTypes[1]->constExpr->value,
+            $genericTypes[1] instanceof IdentifierTypeNode => null,
+        };
+
+        return new IntegerRangeType(
+            min: $min,
+            max: $max,
+        );
     }
 }

--- a/src/Support/Generator/TypeTransformer.php
+++ b/src/Support/Generator/TypeTransformer.php
@@ -210,6 +210,16 @@ class TypeTransformer
             $openApiType = new StringType;
         } elseif ($type instanceof \Dedoc\Scramble\Support\Type\FloatType) {
             $openApiType = new NumberType;
+        } elseif ($type instanceof \Dedoc\Scramble\Support\Type\IntegerRangeType) {
+            $openApiType = new IntegerType;
+
+            if ($type->min !== null) {
+                $openApiType->setMin($type->min);
+            }
+
+            if ($type->max !== null) {
+                $openApiType->setMax($type->max);
+            }
         } elseif ($type instanceof \Dedoc\Scramble\Support\Type\IntegerType) {
             $openApiType = new IntegerType;
         } elseif ($type instanceof \Dedoc\Scramble\Support\Type\BooleanType) {

--- a/src/Support/Type/IntegerRangeType.php
+++ b/src/Support/Type/IntegerRangeType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Dedoc\Scramble\Support\Type;
+
+class IntegerRangeType extends IntegerType
+{
+    public ?int $min;
+
+    public ?int $max;
+
+    public function __construct(?int $min = null, ?int $max = null)
+    {
+        $this->min = $min;
+        $this->max = $max;
+    }
+
+    public function isSame(Type $type)
+    {
+        return parent::isSame($type) && $type->toString() === $this->toString();
+    }
+
+    public function toString(): string
+    {
+        if ($this->min !== null || $this->max !== null) {
+            $min = $this->min ?? 'min';
+            $max = $this->max ?? 'max';
+
+            return parent::toString()."<{$min}, {$max}>";
+        }
+
+        return parent::toString();
+    }
+}

--- a/tests/PhpDoc/PhpDocTypeHelperTest.php
+++ b/tests/PhpDoc/PhpDocTypeHelperTest.php
@@ -43,9 +43,14 @@ it('parses integers', function (string $phpDocType, string $expectedTypeString) 
 })->with([
     ['/** @var int */', 'int'],
     ['/** @var integer */', 'int'],
-    ['/** @var positive-int */', 'int'],
-    ['/** @var negative-int */', 'int'],
-    ['/** @var non-positive-int */', 'int'],
-    ['/** @var non-negative-int */', 'int'],
+    ['/** @var positive-int */', 'int<1, max>'],
+    ['/** @var negative-int */', 'int<min, -1>'],
+    ['/** @var non-positive-int */', 'int<min, 0>'],
+    ['/** @var non-negative-int */', 'int<0, max>'],
     ['/** @var non-zero-int */', 'int'],
+    ['/** @var int<10, 11> */', 'int<10, 11>'],
+    ['/** @var int<10, max> */', 'int<10, max>'],
+    ['/** @var int<min, 10> */', 'int<min, 10>'],
+    ['/** @var int<max, 10> */', 'int'],
+    ['/** @var int<10, min> */', 'int'],
 ]);

--- a/tests/TypeToSchemaTransformerTest.php
+++ b/tests/TypeToSchemaTransformerTest.php
@@ -379,17 +379,40 @@ it('supports integers', function () {
                 ],
                 'one' => [
                     'type' => 'integer',
+                    'minimum' => 1,
                 ],
                 'minus_one' => [
                     'type' => 'integer',
+                    'maximum' => -1,
                 ],
                 'minus_two' => [
                     'type' => 'integer',
+                    'maximum' => 0,
                 ],
                 'two' => [
                     'type' => 'integer',
+                    'minimum' => 0,
                 ],
                 'three' => [
+                    'type' => 'integer',
+                ],
+                'four' => [
+                    'type' => 'integer',
+                    'minimum' => 4,
+                    'maximum' => 5,
+                ],
+                'four_max' => [
+                    'type' => 'integer',
+                    'minimum' => 4,
+                ],
+                'min_to_five' => [
+                    'type' => 'integer',
+                    'maximum' => 5,
+                ],
+                'max_to_five' => [
+                    'type' => 'integer',
+                ],
+                'five_to_min' => [
                     'type' => 'integer',
                 ],
             ],
@@ -400,6 +423,11 @@ it('supports integers', function () {
                 'minus_two',
                 'two',
                 'three',
+                'four',
+                'four_max',
+                'min_to_five',
+                'max_to_five',
+                'five_to_min',
             ],
         ]);
 });
@@ -586,6 +614,16 @@ class ApiResourceTest_ResourceWithIntegers extends JsonResource
             'two' => 2,
             /** @var non-zero-int */
             'three' => 3,
+            /** @var int<4, 5> */
+            'four' => 4,
+            /** @var int<4, max> */
+            'four_max' => 4,
+            /** @var int<min, 5> */
+            'min_to_five' => 4,
+            /** @var int<max, 5> */
+            'max_to_five' => 4,
+            /** @var int<5, min> */
+            'five_to_min' => 4,
         ];
     }
 }


### PR DESCRIPTION
I often use more strict integer types in my phpdocs where possible, but I've always had to document them as int because of Scramble: https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges