### PR TITLE
Replace api path only if it appears at the beginning

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -91,7 +91,7 @@ class Generator
             ->each(fn (Operation $operation) => $openApi->addPath(
                 Path::make(
                     (string) Str::of($operation->path)
-                        ->replaceFirst($config->get('api_path', 'api'), '')
+                        ->replaceStart($config->get('api_path', 'api'), '')
                         ->trim('/')
                 )->addOperation($operation)
             ))


### PR DESCRIPTION
I think it is not a bug, but rather misleading behaviour in a specific case. If you register an endpoint that includes phrase 'api', but does not start with it - for example:

`/application/dogs-api/index`

in the generated documentation this will appear as `/application/dogs-/index`. This happens because the default value of `scramble.api_path` config is set to 'api', and the Generator class removes the first occurrence from endpoint. It can be fixed quickly by changing config to an empty string or prefix, but within the config file is also misleading info 

`If you need to change this behaviour, you can add your custom routes resolver using Scramble::routes().` - that has no effect for this particular behaviour.