### PR TITLE
Improce doc sort order

### DIFF
--- a/src/DocumentTransformers/AddDocumentTags.php
+++ b/src/DocumentTransformers/AddDocumentTags.php
@@ -54,8 +54,8 @@ class AddDocumentTags implements DocumentTransformer
 
         return $tags
             ->sort(function (Tag $a, Tag $b) {
-                $weightA = $a->getAttribute('weight') ?? INF;
-                $weightB = $b->getAttribute('weight') ?? INF;
+                $weightA = $a->getAttribute('weight') ?? PHP_INT_MAX;
+                $weightB = $b->getAttribute('weight') ?? PHP_INT_MAX;
 
                 return ($weightA <=> $weightB) ?: strcasecmp($a->name, $b->name);
             })

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -136,10 +136,10 @@ class Generator
         $defaultSortValue = fn (Operation $o) => $o->tags[0] ?? null;
 
         return [
-            fn (Operation $a, Operation $b) => $a->getAttribute('groupWeight', INF) <=> $b->getAttribute('groupWeight', INF),
-            fn (Operation $a, Operation $b) => $a->getAttribute('weight', INF) <=> $b->getAttribute('weight', INF), // @todo manual endpoint sorting
+            fn (Operation $a, Operation $b) => $a->getAttribute('groupWeight', PHP_INT_MAX) <=> $b->getAttribute('groupWeight', PHP_INT_MAX),
+            fn (Operation $a, Operation $b) => $a->getAttribute('weight', PHP_INT_MAX) <=> $b->getAttribute('weight', PHP_INT_MAX), // @todo manual endpoint sorting
             fn (Operation $a, Operation $b) => $defaultSortValue($a) <=> $defaultSortValue($b),
-            fn (Operation $a, Operation $b) => $a->getAttribute('index', INF) <=> $b->getAttribute('index', INF),
+            fn (Operation $a, Operation $b) => $a->getAttribute('index', PHP_INT_MAX) <=> $b->getAttribute('index', PHP_INT_MAX),
         ];
     }
 


### PR DESCRIPTION
### Problem

When a group does not have a weight defined, the sorting order becomes unpredictable.
As a result, the API documentation appears cluttered and difficult to navigate.

### Solution

Introduce a secondary sorting rule:
Primary: sort by weight (when defined)
Fallback: sort by group name when weight is not set

### Result

This change ensures a consistent and predictable order in the API documentation, making it cleaner, more readable, and significantly easier to find the required groups.