### PR TITLE
Fix Enum rule handling for Laravel 12 compatibility

### DIFF
--- a/src/Support/RuleTransforming/RuleSetToSchemaTransformer.php
+++ b/src/Support/RuleTransforming/RuleSetToSchemaTransformer.php
@@ -2,6 +2,7 @@
 
 namespace Dedoc\Scramble\Support\RuleTransforming;
 
+use Illuminate\Validation\Rules\Enum;
 use Dedoc\Scramble\Configuration\RuleTransformers;
 use Dedoc\Scramble\Contracts\RuleTransformer;
 use Dedoc\Scramble\Support\Generator\Types\Type as OpenApiType;
@@ -35,6 +36,7 @@ class RuleSetToSchemaTransformer
         RequiredIf::class,
         ExcludeIf::class,
         ProhibitedIf::class,
+        Enum::class,
     ];
 
     public function __construct(


### PR DESCRIPTION
# Fix Enum rule handling for Laravel 12 compatibility

## Summary

Laravel 12.48.0 added a `__toString()` method to `Illuminate\Validation\Rules\Enum` that converts the rule to an `in:...` string format. This caused the `EnumRule` transformer to be bypassed, resulting in inline enum schemas instead of component `$ref`s.

## Problem

`Dedoc\Scramble\Support\RuleTransforming\RuleSetToSchemaTransformer::normalizeAndPrioritizeRules()` calls the newly added `__toString()` method on the `Illuminate\Validation\Rules\Enum` object used for request validation. This causes the rule to be evaluated as a string rule `in:a,b,c` instead of as a reference to the enum.

When using `Rule::enum(MyEnum::class)` in Laravel 12.48.0+:
- The `Enum` rule was converted to `"in:"foo","bar""` via `__toString()`
- The `EnumRule` transformer never received the original `Enum` object
- The schema was handled by the `in:` string rule handler instead
- Result: inline `{"type": "string", "enum": ["foo", "bar"]}` instead of `{"$ref": "#/components/schemas/MyEnum"}`

## Root cause

The `__toString()` method was added in Laravel 12.48.0:
- Commit: https://github.com/laravel/framework/commit/3026dc7a7cf24b413a34c14ea3da992d045cac66
- PR: https://github.com/laravel/framework/pull/58392

Note: Some CI test workers pass because they downgrade Laravel with `prefer-lowest`.

## Solution

Add `Enum::class` to `IGNORE_STRINGABLE_RULES` in `RuleSetToSchemaTransformer` to preserve the `Enum` object so it can be properly handled by the `EnumRule` transformer.