### PR TITLE
Handle `@deprecated` in API resources

### DIFF
--- a/src/Support/Generator/TypeTransformer.php
+++ b/src/Support/Generator/TypeTransformer.php
@@ -30,6 +30,7 @@ use Dedoc\Scramble\Support\Type\TemplateType;
 use Dedoc\Scramble\Support\Type\Type;
 use Dedoc\Scramble\Support\Type\Union;
 use Illuminate\Support\Str;
+use PHPStan\PhpDocParser\Ast\PhpDoc\DeprecatedTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 
 use function DeepCopy\deep_copy;
@@ -166,6 +167,16 @@ class TypeTransformer
 
                 if ($format = array_values($docNode->getTagsByName('@format'))[0]->value->value ?? null) {
                     $openApiType->format($format);
+                }
+
+                $deprecated = array_values($docNode->getTagsByName('@deprecated'))[0]->value ?? null;
+                if ($deprecated instanceof DeprecatedTagValueNode) {
+                    $openApiType->deprecated(true);
+
+                    if ($deprecated->description) {
+                        $existingDesc = $openApiType->description ? $openApiType->description.' ' : '';
+                        $openApiType->setDescription($existingDesc.$deprecated->description);
+                    }
                 }
             }
         } elseif ($type instanceof Union) {

--- a/tests/TypeToSchemaTransformerTest.php
+++ b/tests/TypeToSchemaTransformerTest.php
@@ -355,6 +355,27 @@ it('supports @format tag in api resource', function () {
     ]);
 });
 
+it('supports @deprecated tag in api resource', function () {
+    $transformer = new TypeTransformer(app(Infer::class), $this->context, [JsonResourceTypeToSchema::class]);
+
+    $type = new ObjectType(ApiResourceTest_ResourceWithDeprecated::class);
+
+    expect($transformer->transform($type)->toArray())->toBe([
+        '$ref' => '#/components/schemas/ApiResourceTest_ResourceWithDeprecated',
+    ]);
+
+    expect($this->context->openApi->components->getSchema(ApiResourceTest_ResourceWithDeprecated::class)->toArray()['properties']['old_field'])->toBe([
+        'type' => 'integer',
+        'deprecated' => true,
+    ]);
+
+    expect($this->context->openApi->components->getSchema(ApiResourceTest_ResourceWithDeprecated::class)->toArray()['properties']['old_field_with_description'])->toBe([
+        'type' => 'string',
+        'description' => 'Use new_field instead.',
+        'deprecated' => true,
+    ]);
+});
+
 it('supports simple comments descriptions in api resource', function () {
     $transformer = new TypeTransformer($infer = app(Infer::class), $this->context, [JsonResourceTypeToSchema::class]);
 
@@ -623,6 +644,26 @@ class ApiResourceTest_ResourceWithFormat extends JsonResource
              * @format date-time
              */
             'now' => now(),
+        ];
+    }
+}
+
+/**
+ * @property SamplePostModel $resource
+ */
+class ApiResourceTest_ResourceWithDeprecated extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            /**
+             * @deprecated
+             */
+            'old_field' => $this->id,
+            /**
+             * @deprecated Use new_field instead.
+             */
+            'old_field_with_description' => $this->title,
         ];
     }
 }


### PR DESCRIPTION
This PR adds support for `@deprecated` in API resources.