### PR TITLE
Fix: Handle `null` value for `ui.title` in docs view.

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="color-scheme" content="{{ $config->get('ui.theme', 'light') }}">
-    <title>{{ $config->get('ui.title', config('app.name') . ' - API Docs') }}</title>
+    <title>{{ $config->get('ui.title') ?? config('app.name') . ' - API Docs' }}</title>
 
     <script src="https://unpkg.com/@stoplight/elements@8.4.2/web-components.min.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements@8.4.2/styles.min.css">


### PR DESCRIPTION
This PR fixes an issue where the documentation page title would render empty when `ui.title` was explicitly set to `null` in the configuration.

The problem occurred because the configuration key existed but had a `null` value, preventing the fallback title from being applied.

The fix ensures that when `ui.title` is `null`, the default application name with the "API Docs" suffix is used instead.