### PR TITLE
Smarter inference for `paginate` calls on models and query builders

### DIFF
--- a/src/Support/InferExtensions/PaginateMethodsReturnTypeExtension.php
+++ b/src/Support/InferExtensions/PaginateMethodsReturnTypeExtension.php
@@ -10,6 +10,7 @@ use Dedoc\Scramble\Support\Type\Generic;
 use Dedoc\Scramble\Support\Type\IntegerType;
 use Dedoc\Scramble\Support\Type\ObjectType;
 use Dedoc\Scramble\Support\Type\Type;
+use Dedoc\Scramble\Support\Type\TypeWalker;
 use Dedoc\Scramble\Support\Type\UnknownType;
 use Illuminate\Contracts\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Contracts\Database\Query\Builder as BaseBuilder;
@@ -42,7 +43,17 @@ class PaginateMethodsReturnTypeExtension implements AnyMethodReturnTypeExtension
             return null;
         }
 
-        return $this->getPaginatorType($event->name);
+        return $this->getPaginatorType(
+            $this->normalizeCalleeQueryBuilder($event->callee),
+            $event->name,
+        );
+    }
+
+    private function normalizeCalleeQueryBuilder(string $model): Generic
+    {
+        return new Generic(\Illuminate\Database\Eloquent\Builder::class, [
+            new ObjectType($model),
+        ]);
     }
 
     public function getMethodReturnType(AnyMethodCallEvent $event): ?Type
@@ -59,12 +70,15 @@ class PaginateMethodsReturnTypeExtension implements AnyMethodReturnTypeExtension
             return null;
         }
 
-        return $this->getPaginatorType($event->name);
+        return $this->getPaginatorType($event->getInstance(), $event->name);
     }
 
-    private function getPaginatorType(string $name): Generic
+    private function getPaginatorType(Type $callee, string $name): Generic
     {
-        $valueType = new UnknownType;
+        $valueType = (new TypeWalker)->first(
+            $callee,
+            fn (Type $type) => $type->isInstanceOf(Model::class),
+        ) ?: new UnknownType;
 
         return match ($name) {
             'paginate', 'fastPaginate' => new Generic(LengthAwarePaginator::class, [new IntegerType, $valueType]),

--- a/tests/Support/InferExtensions/PaginatorReturnTypeExtensionTest.php
+++ b/tests/Support/InferExtensions/PaginatorReturnTypeExtensionTest.php
@@ -13,14 +13,14 @@ it('guesses paginate type', function (string $expression, string $expectedTypeSt
 
     expect($type->toString())->toBe($expectedTypeString);
 })->with([
-    [SampleUserModel::class.'::paginate()', LengthAwarePaginator::class.'<int, unknown>'],
-    [SampleUserModel::class.'::query()->paginate()', LengthAwarePaginator::class.'<int, unknown>'],
-    [SampleUserModel::class.'::query()->fastPaginate()', LengthAwarePaginator::class.'<int, unknown>'],
-    [SampleUserModel::class.'::query()->where("foo", "bar")->paginate()', LengthAwarePaginator::class.'<int, unknown>'],
+    [SampleUserModel::class.'::paginate()', LengthAwarePaginator::class.'<int, '.SampleUserModel::class.'>'],
+    [SampleUserModel::class.'::query()->paginate()', LengthAwarePaginator::class.'<int, '.SampleUserModel::class.'>'],
+    [SampleUserModel::class.'::query()->fastPaginate()', LengthAwarePaginator::class.'<int, '.SampleUserModel::class.'>'],
+    [SampleUserModel::class.'::query()->where("foo", "bar")->paginate()', LengthAwarePaginator::class.'<int, '.SampleUserModel::class.'>'],
 
-    [SampleUserModel::class.'::cursorPaginate()', CursorPaginator::class.'<int, unknown>'],
-    [SampleUserModel::class.'::query()->cursorPaginate()', CursorPaginator::class.'<int, unknown>'],
+    [SampleUserModel::class.'::cursorPaginate()', CursorPaginator::class.'<int, '.SampleUserModel::class.'>'],
+    [SampleUserModel::class.'::query()->cursorPaginate()', CursorPaginator::class.'<int, '.SampleUserModel::class.'>'],
 
-    [SampleUserModel::class.'::simplePaginate()', Paginator::class.'<int, unknown>'],
-    [SampleUserModel::class.'::query()->simplePaginate()', Paginator::class.'<int, unknown>'],
+    [SampleUserModel::class.'::simplePaginate()', Paginator::class.'<int, '.SampleUserModel::class.'>'],
+    [SampleUserModel::class.'::query()->simplePaginate()', Paginator::class.'<int, '.SampleUserModel::class.'>'],
 ]);


### PR DESCRIPTION
Now the information about the model being paginated is preserved.

