### PR TITLE
Support more string types

### DIFF
--- a/src/PhpDoc/PhpDocTypeHelper.php
+++ b/src/PhpDoc/PhpDocTypeHelper.php
@@ -159,7 +159,20 @@ class PhpDocTypeHelper
 
     private static function handleIdentifierNode(IdentifierTypeNode $type)
     {
-        if ($type->name === 'string') {
+        if (in_array($type->name, [
+            'string',
+            'non-empty-string',
+            'callable-string',
+            'numeric-string',
+            'non-falsy-string',
+            'truthy-string',
+            'literal-string',
+            'lowercase-string',
+            'uppercase-string',
+            'non-empty-lowercase-string',
+            'non-empty-uppercase-string',
+            'non-empty-literal-string',
+        ])) {
             return new StringType;
         }
         if (in_array($type->name, ['float', 'double'])) {

--- a/tests/PhpDoc/PhpDocTypeHelperTest.php
+++ b/tests/PhpDoc/PhpDocTypeHelperTest.php
@@ -63,6 +63,25 @@ it('parses integers', function (string $phpDocType, string $expectedTypeString) 
     ['/** @var int<10, min> */', 'int'],
 ]);
 
+it('parses strings', function (string $phpDocType, string $expectedTypeString) {
+    expect(
+        getPhpTypeFromDoc_Copy($phpDocType)->toString()
+    )->toBe($expectedTypeString);
+})->with([
+    ['/** @var string */', 'string'],
+    ['/** @var non-empty-string */', 'string'],
+    ['/** @var callable-string */', 'string'],
+    ['/** @var numeric-string */', 'string'],
+    ['/** @var non-falsy-string */', 'string'],
+    ['/** @var truthy-string */', 'string'],
+    ['/** @var literal-string */', 'string'],
+    ['/** @var lowercase-string */', 'string'],
+    ['/** @var uppercase-string */', 'string'],
+    ['/** @var non-empty-lowercase-string */', 'string'],
+    ['/** @var non-empty-uppercase-string */', 'string'],
+    ['/** @var non-empty-literal-string */', 'string'],
+]);
+
 it('parses unions', function (string $phpDocType, string $expectedTypeString) {
     expect(
         getPhpTypeFromDoc_Copy($phpDocType)->toString()


### PR DESCRIPTION
In continuation of my previous PR (https://github.com/dedoc/scramble/pull/996) I usually use more specific types accepted by [PHPStan](https://phpstan.org/writing-php-code/phpdoc-types). I've added support for these types to avoid having to put `/** @var string */` in all my resources where I use these.

I mostly needed this for `non-empty-string`, but I thought it would be nice to add support for the others as well