### PR TITLE
Soft delete methods support

### DIFF
--- a/src/Support/InferExtensions/EloquentBuilderExtension.php
+++ b/src/Support/InferExtensions/EloquentBuilderExtension.php
@@ -9,6 +9,7 @@ use Dedoc\Scramble\Support\Type\ObjectType;
 use Dedoc\Scramble\Support\Type\Type;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class EloquentBuilderExtension implements MethodReturnTypeExtension
 {
@@ -25,6 +26,16 @@ class EloquentBuilderExtension implements MethodReturnTypeExtension
 
         if ($this->shouldForwardCallToModel($event)) {
             return $this->forwardCallToModel($event);
+        }
+
+        if (! $modelType = $this->getModelType($event->getInstance())) {
+            return null;
+        }
+        if (
+            $this->modelIsSoftDeletable($modelType)
+            && ($softDeleteCallResult = $this->handleSoftDeletes($event, $modelType))
+        ) {
+            return $softDeleteCallResult;
         }
 
         return null;
@@ -48,6 +59,23 @@ class EloquentBuilderExtension implements MethodReturnTypeExtension
         }
 
         return $event->getInstance();
+    }
+
+    /**
+     * @see SoftDeletes
+     */
+    private function modelIsSoftDeletable(ObjectType $modelType): bool
+    {
+        return method_exists($modelType->name, 'bootSoftDeletes');
+    }
+
+    private function handleSoftDeletes(MethodCallEvent $event, ObjectType $modelType): ?Type
+    {
+        return match ($event->name) {
+            'onlyTrashed', 'withTrashed', 'withoutTrashed' => $event->getInstance(),
+            'restoreOrCreate', 'createOrRestore' => $modelType,
+            default => null,
+        };
     }
 
     private function getModelType(ObjectType $instance): ?ObjectType

--- a/tests/Support/InferExtensions/EloquentBuilderExtensionTest.php
+++ b/tests/Support/InferExtensions/EloquentBuilderExtensionTest.php
@@ -10,7 +10,7 @@ use Dedoc\Scramble\Support\Type\Reference\MethodCallReferenceType;
 use Dedoc\Scramble\Tests\Files\SamplePostModel;
 use Illuminate\Database\Eloquent\Builder;
 
-test('forwards call to scope', function (string $method, string $expectedType) {
+test('supports extension methods', function (string $method, string $expectedType) {
     $type = ReferenceTypeResolver::getInstance()
         ->resolve(
             new GlobalScope,
@@ -23,6 +23,14 @@ test('forwards call to scope', function (string $method, string $expectedType) {
 
     expect($type->toString())->toBe($expectedType);
 })->with([
+    // forwards call to scope
     ['approved', Builder::class.'<'.SamplePostModel::class.'>'],
     ['approvedTypedParam', Builder::class.'<'.SamplePostModel::class.'>'],
+
+    // supports soft deletes macro methods
+    ['onlyTrashed', Builder::class.'<'.SamplePostModel::class.'>'],
+    ['withTrashed', Builder::class.'<'.SamplePostModel::class.'>'],
+    ['withoutTrashed', Builder::class.'<'.SamplePostModel::class.'>'],
+    ['restoreOrCreate', SamplePostModel::class],
+    ['createOrRestore', SamplePostModel::class],
 ]);


### PR DESCRIPTION
Now, Scramble will correctly infer the types of soft delete macro method calls when `SoftDeletes` trait is used on a model:

```php
Post::onlyTrashed() // or Post::query()->onlyTrashed() — type is Builder<Post>
Post::withTrashed() // type is Builder<Post>
Post::withoutTrashed() // type is Builder<Post>
Post::restoreOrCreate([...]) // type is Post
Post::createOrRestore([...]) // type is Post
```