### PR TITLE
Fix enum placed on array instead of items in OpenAPI spec

### DIFF
--- a/src/RuleTransformers/InRule.php
+++ b/src/RuleTransformers/InRule.php
@@ -3,6 +3,7 @@
 namespace Dedoc\Scramble\RuleTransformers;
 
 use Dedoc\Scramble\Contracts\RuleTransformer;
+use Dedoc\Scramble\Support\Generator\Types\ArrayType;
 use Dedoc\Scramble\Support\Generator\Types\Type;
 use Dedoc\Scramble\Support\RuleTransforming\NormalizedRule;
 use Dedoc\Scramble\Support\RuleTransforming\RuleTransformerContext;
@@ -17,12 +18,18 @@ class InRule implements RuleTransformer
 
     public function toSchema(Type $previous, NormalizedRule $rule, RuleTransformerContext $context): Type
     {
-        return $previous->enum(
-            collect($rule->parameters)
-                ->mapInto(Stringable::class)
-                ->map(fn (Stringable $v) => (string) $v->trim('"')->replace('""', '"'))
-                ->values()
-                ->all()
-        );
+        $enum = collect($rule->parameters)
+            ->mapInto(Stringable::class)
+            ->map(fn (Stringable $v) => (string) $v->trim('"')->replace('""', '"'))
+            ->values()
+            ->all();
+
+        if ($previous instanceof ArrayType) {
+            $previous->items->enum($enum);
+
+            return $previous;
+        }
+
+        return $previous->enum($enum);
     }
 }

--- a/tests/Support/OperationExtensions/RulesExtractor/RuleSetToSchemaTransformersTest.php
+++ b/tests/Support/OperationExtensions/RulesExtractor/RuleSetToSchemaTransformersTest.php
@@ -82,6 +82,21 @@ describe(InRule::class, function () {
                 'enum' => ['a', 'b'],
             ]);
     });
+
+    test('in rule with array type places enum on items', function () {
+        $rules = ['array', Rule::in(['a', 'b', 'c'])];
+
+        $schema = $this->transformer->transform($rules);
+
+        expect($schema->toArray())
+            ->toBe([
+                'type' => 'array',
+                'items' => [
+                    'type' => 'string',
+                    'enum' => ['a', 'b', 'c'],
+                ],
+            ]);
+    });
 });
 
 enum Enum_RuleSetToSchemaTransformerTest: string


### PR DESCRIPTION
When validation rules combine `array` with `Rule::in(...)`, the `InRule` transformer placed the `enum` constraint on the array type itself rather than on its `items`. This produced invalid OpenAPI:

  { "type": "array", "enum": [...], "items": { "type": "string" } }

Now when the previous type is an ArrayType, the enum values are applied to `items` instead, producing the correct schema:

  { "type": "array", "items": { "type": "string", "enum": [...] } }

Fixes #852