### PR TITLE
Fix `required` rule on arrays not setting minItems: 1

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
@@ -107,6 +107,10 @@ class RulesMapper
     {
         $type->setAttribute('required', true);
 
+        if ($type instanceof ArrayType && $type->minItems === null) {
+            $type->setMin(1);
+        }
+
         return $type;
     }
 

--- a/tests/ValidationRulesDocumentingTest.php
+++ b/tests/ValidationRulesDocumentingTest.php
@@ -75,6 +75,52 @@ it('supports present rule on array', function () {
         ]);
 });
 
+it('sets minItems 1 when required rule is used on array', function () {
+    $rules = [
+        'items' => 'required|array',
+        'items.*' => ['string'],
+    ];
+
+    $params = validationRulesToDocumentationWithDeep(($this->buildRulesToParameters)($rules));
+
+    expect($params = collect($params)->map->toArray()->all())
+        ->toHaveCount(1)
+        ->and($params[0])
+        ->toMatchArray([
+            'name' => 'items',
+            'in' => 'query',
+            'schema' => [
+                'type' => 'array',
+                'items' => ['type' => 'string'],
+                'minItems' => 1,
+            ],
+            'required' => true,
+        ]);
+});
+
+it('does not override explicit minItems when required rule is used on array', function () {
+    $rules = [
+        'items' => 'required|array|min:3',
+        'items.*' => ['string'],
+    ];
+
+    $params = validationRulesToDocumentationWithDeep(($this->buildRulesToParameters)($rules));
+
+    expect($params = collect($params)->map->toArray()->all())
+        ->toHaveCount(1)
+        ->and($params[0])
+        ->toMatchArray([
+            'name' => 'items',
+            'in' => 'query',
+            'schema' => [
+                'type' => 'array',
+                'items' => ['type' => 'string'],
+                'minItems' => 3,
+            ],
+            'required' => true,
+        ]);
+});
+
 it('supports present rule in array', function () {
     $rules = [
         'user.password' => ['present'],

--- a/tests/__snapshots__/ValidationRulesDocumentingTest__it_extract_rules_from_array_like_rules__1.yml
+++ b/tests/__snapshots__/ValidationRulesDocumentingTest__it_extract_rules_from_array_like_rules__1.yml
@@ -6,4 +6,4 @@
     name: some
     in: query
     required: true
-    schema: { type: array, items: { type: object, properties: { id: { type: integer }, name: { type: string } }, required: [id] } }
+    schema: { type: array, items: { type: object, properties: { id: { type: integer }, name: { type: string } }, required: [id] }, minItems: 1 }

--- a/tests/__snapshots__/ValidationRulesDocumentingTest__it_extract_rules_from_array_like_rules__2.yml
+++ b/tests/__snapshots__/ValidationRulesDocumentingTest__it_extract_rules_from_array_like_rules__2.yml
@@ -6,4 +6,4 @@
     name: some
     in: query
     required: true
-    schema: { type: array, items: { type: object, properties: { id: { type: integer }, name: { type: string } }, required: [id] } }
+    schema: { type: array, items: { type: object, properties: { id: { type: integer }, name: { type: string } }, required: [id] }, minItems: 1 }


### PR DESCRIPTION
Laravel's `required` validation rejects empty arrays (count < 1), but Scramble only marked the parameter as required without reflecting this constraint in the OpenAPI schema.

Now when `required` is applied to an ArrayType, `minItems: 1` is set unless an explicit `min` rule already provides a higher value.

Fixes #927