### PR TITLE
Infer 201 status code for JsonResource wrapping a newly created model

### DIFF
--- a/src/Support/InferExtensions/EloquentBuilderExtension.php
+++ b/src/Support/InferExtensions/EloquentBuilderExtension.php
@@ -20,6 +20,10 @@ class EloquentBuilderExtension implements MethodReturnTypeExtension
 
     public function getMethodReturnType(MethodCallEvent $event): ?Type
     {
+        if ($this->isModelCreationMethod($event->getName())) {
+            return $this->handleModelCreation($event);
+        }
+
         if ($event->getDefinition()->hasMethodDefinition($event->getName())) {
             return null;
         }
@@ -102,6 +106,23 @@ class EloquentBuilderExtension implements MethodReturnTypeExtension
         }
 
         return new Generic($type->name, []);
+    }
+
+    private function isModelCreationMethod(string $name): bool
+    {
+        return in_array($name, ['create', 'forceCreate', 'forceCreateQuietly'], true);
+    }
+
+    private function handleModelCreation(MethodCallEvent $event): ?Type
+    {
+        if (! $modelType = $this->getModelType($event->getInstance())) {
+            return null;
+        }
+
+        $modelType = clone $modelType;
+        $modelType->setAttribute('wasRecentlyCreated', true);
+
+        return $modelType;
     }
 
     private function getScopeMethodName(string $scope): string

--- a/src/Support/TypeToSchemaExtensions/ResourceResponseTypeToSchema.php
+++ b/src/Support/TypeToSchemaExtensions/ResourceResponseTypeToSchema.php
@@ -155,7 +155,9 @@ class ResourceResponseTypeToSchema extends TypeToSchemaExtension
     {
         $definition = $this->infer->analyzeClass($resourceType->name);
 
-        $responseType = new Generic(JsonResponse::class, [new UnknownType, new LiteralIntegerType(200), new KeyedArrayType]);
+        $statusCode = $this->inferStatusCode($resourceType);
+
+        $responseType = new Generic(JsonResponse::class, [new UnknownType, new LiteralIntegerType($statusCode), new KeyedArrayType]);
 
         $methodQuery = MethodQuery::make($this->infer)
             ->withArgumentType([null, 1], $responseType)
@@ -170,6 +172,17 @@ class ResourceResponseTypeToSchema extends TypeToSchemaExtension
             });
 
         return $responseType;
+    }
+
+    private function inferStatusCode(ObjectType $resourceType): int
+    {
+        if ($resourceType instanceof Generic && ($resourceType->templateTypes[0] ?? null) instanceof ObjectType) {
+            if ($resourceType->templateTypes[0]->getAttribute('wasRecentlyCreated')) {
+                return 201;
+            }
+        }
+
+        return 200;
     }
 
     protected function wrap(?string $wrapKey, OpenApiType $data, ?OpenApiType $additional): OpenApiType

--- a/tests/Support/TypeToSchemaExtensions/JsonResourceTypeToSchemaTest.php
+++ b/tests/Support/TypeToSchemaExtensions/JsonResourceTypeToSchemaTest.php
@@ -334,3 +334,66 @@ class JsonResourceTypeToSchemaTest_WithCustomName extends JsonResource
         return ['foo' => 'bar'];
     }
 }
+
+it('infers 201 status code when returning resource wrapping a newly created model', function () {
+    $openApiDocument = generateForRoute(function () {
+        return Route::post('api/test', [JsonResourceTypeToSchemaTest_CreatedModelController::class, 'store']);
+    });
+
+    $responses = $openApiDocument['paths']['/test']['post']['responses'];
+
+    expect($responses)
+        ->toHaveKey('201')
+        ->not->toHaveKey('200');
+});
+class JsonResourceTypeToSchemaTest_CreatedModelController
+{
+    public function store()
+    {
+        $user = JsonResourceTypeToSchemaTest_User::create([]);
+
+        return new JsonResourceTypeToSchemaTest_Sample($user);
+    }
+}
+
+it('infers 200 status code when returning resource wrapping an existing model', function () {
+    $openApiDocument = generateForRoute(function () {
+        return Route::get('api/test', [JsonResourceTypeToSchemaTest_ExistingModelController::class, 'show']);
+    });
+
+    $responses = $openApiDocument['paths']['/test']['get']['responses'];
+
+    expect($responses)
+        ->toHaveKey('200')
+        ->not->toHaveKey('201');
+});
+class JsonResourceTypeToSchemaTest_ExistingModelController
+{
+    public function show()
+    {
+        $user = JsonResourceTypeToSchemaTest_User::first();
+
+        return new JsonResourceTypeToSchemaTest_Sample($user);
+    }
+}
+
+it('infers 201 status code when using static make with created model', function () {
+    $openApiDocument = generateForRoute(function () {
+        return Route::post('api/test', [JsonResourceTypeToSchemaTest_CreatedModelMakeController::class, 'store']);
+    });
+
+    $responses = $openApiDocument['paths']['/test']['post']['responses'];
+
+    expect($responses)
+        ->toHaveKey('201')
+        ->not->toHaveKey('200');
+});
+class JsonResourceTypeToSchemaTest_CreatedModelMakeController
+{
+    public function store()
+    {
+        return JsonResourceTypeToSchemaTest_Sample::make(
+            JsonResourceTypeToSchemaTest_User::create([]),
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1071 

When a controller creates a model via Builder::create() / forceCreate() / forceCreateQuietly() and returns it wrapped in a JsonResource, Laravel automatically responds with 201 (because Model::$wasRecentlyCreated is true). Scramble previously always documented this as 200.

This PR adds detection for this pattern to document the correct 201 status code.

```php
// Now correctly documented as 201
public function store(Request $request)
{
    $user = User::create($request->validated());
    return new UserResource($user);
}
```

### How it works
1. EloquentBuilderExtension marks model types returned from create(), forceCreate(), and forceCreateQuietly() with a wasRecentlyCreated type attribute
2. ResourceResponseTypeToSchema checks for this attribute when determining the base response status code, using 201 instead of the hardcoded 200
3. Explicit withResponse() or ->response()->setStatusCode() overrides still take precedence

### Scope
This covers the most common and unambiguous creation patterns — methods that always create a new model. Ambiguous methods like firstOrCreate() and updateOrCreate() (which may or may not create) are intentionally left at 200.