### PR TITLE
Fix relationship resource guessing when not explicitly provided and recognize JSON:API parameters when resource is transformed to response

### DIFF
--- a/src/Configuration/ParametersExtractors.php
+++ b/src/Configuration/ParametersExtractors.php
@@ -70,12 +70,12 @@ class ParametersExtractors
             PathParametersExtractor::class,
             FormRequestParametersExtractor::class,
             ValidateCallParametersExtractor::class,
+            JsonApiResourceParametersExtractor::class,
         ];
 
         $defaultAppends = [
             MethodCallsParametersExtractor::class,
             AttributesParametersExtractor::class,
-            JsonApiResourceParametersExtractor::class,
         ];
 
         return array_values(array_unique([

--- a/src/Infer/Flow/AbstractNode.php
+++ b/src/Infer/Flow/AbstractNode.php
@@ -54,8 +54,8 @@ abstract class AbstractNode implements Node
             default => $empty,
         };
 
-        if ($label !== $empty) {
-            $dot .= '[label="'.Str::replace('"', '\"', $label).'"]'; // @phpstan-ignore argument.type
+        if ($label !== $empty && is_string($label)) {
+            $dot .= '[label="'.Str::replace('"', '\"', $label).'"]';
         }
 
         return $dot;

--- a/src/Reflection/ReflectionJsonApiResource.php
+++ b/src/Reflection/ReflectionJsonApiResource.php
@@ -7,6 +7,7 @@ use Dedoc\Scramble\Infer\Definition\ClassDefinition;
 use Dedoc\Scramble\Infer\Scope\GlobalScope;
 use Dedoc\Scramble\Infer\Services\ReferenceTypeResolver;
 use Dedoc\Scramble\Support\Helpers\JsonResourceHelper;
+use Dedoc\Scramble\Support\InferExtensions\ModelExtension;
 use Dedoc\Scramble\Support\Type as InferType;
 use Dedoc\Scramble\Support\Type\KeyedArrayType;
 use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
@@ -17,6 +18,7 @@ use Dedoc\Scramble\Support\TypeManagers\ResourceCollectionTypeManager;
 use Dedoc\Scramble\Support\TypeToSchemaExtensions\FlattensMergeValues;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\JsonApi\AnonymousResourceCollection as JsonApiAnonymousResourceCollection;
 use Illuminate\Http\Resources\JsonApi\Concerns\ResolvesJsonApiElements;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
@@ -229,19 +231,14 @@ class ReflectionJsonApiResource
                     : $newType->value;
 
                 if ($newType->isNumericKey() && $this->isLiteralString($newType->value)) {
-                    $className = $this->getLiteralStringValue($newType->value);
+                    $relationshipName = $this->getLiteralStringValue($newType->value);
 
-                    if (! $guessedClass = $this->guessResourceClass($className)) {
-                        /**
-                         * @see ResolvesJsonApiElements::compileResourceRelationshipUsingResolver() Line 256
-                         */
-                        $guessedClass = JsonApiResource::class;
-                    }
-
-                    $relationshipType = $modelType?->getPropertyType($className) ?? new InferType\UnknownType;
+                    $relationshipType = $modelType?->getPropertyType($relationshipName) ?? new InferType\UnknownType;
                     $relationshipIsMany = $relationshipType->isInstanceOf(Collection::class);
 
-                    $newType->key = $className;
+                    $guessedClass = $this->guessResourceClassFromRelationship($relationshipType);
+
+                    $newType->key = $relationshipName;
                     $newType->value = $relationshipIsMany
                         ? new InferType\Generic(JsonApiAnonymousResourceCollection::class, [new InferType\UnknownType, new InferType\UnknownType, new ObjectType($guessedClass)])
                         : new ObjectType($guessedClass);
@@ -268,6 +265,36 @@ class ReflectionJsonApiResource
         $arrayType->isList = KeyedArrayType::checkIsList($arrayType->items);
 
         return $arrayType;
+    }
+
+    /**
+     * Attempts to find the related model's resource class name from a relationship type.
+     * In case resource name cannot be found, falls back to {@see JsonApiResource::class} {@see ResolvesJsonApiElements::compileResourceRelationshipUsingResolver() Line 256}
+     * @param Type $relationshipType
+     * @return string
+     */
+    private function guessResourceClassFromRelationship(Type $relationshipType): string
+    {
+        $relatedModel = (new InferType\TypeWalker)->first($relationshipType, fn (Type $t) => $t->isInstanceOf(Model::class));
+        if ($relatedModel instanceof InferType\TemplateType) {
+            $relatedModel = $relatedModel->is;
+        }
+        if (! $relatedModel instanceof ObjectType) {
+            return JsonApiResource::class;
+        }
+
+        $guessedRelatedResource = $this->guessResourceClass($relatedModel->name);
+        /**
+         * If $guessedRelatedResource is JsonResource::class, it means that the type of `toResponse` was
+         * inferred from Model's `toResponse` definition (not via {@see ModelExtension}). In runtime this
+         * is causing the failure, but `JsonApiResource` wraps this call in `rescue`, and in case
+         * of exception, returns `JsonApiResource` {@see ResolvesJsonApiElements::compileResourceRelationshipUsingResolver() Line 256}
+         */
+        if (! $guessedRelatedResource || $guessedRelatedResource === JsonResource::class) {
+            return JsonApiResource::class;
+        }
+
+        return $guessedRelatedResource;
     }
 
     private function guessResourceClass(string $modelClass): ?string

--- a/src/Reflection/ReflectionJsonApiResource.php
+++ b/src/Reflection/ReflectionJsonApiResource.php
@@ -270,24 +270,17 @@ class ReflectionJsonApiResource
         return $arrayType;
     }
 
-    /**
-     * @todo
-     * This is temporary implementation, under the hood model's toResource is called.
-     */
-    private function guessResourceClass(string $relationship): ?string
+    private function guessResourceClass(string $modelClass): ?string
     {
-        $relationship = Str::of($relationship);
+        $modelType = new ObjectType($modelClass);
 
-        foreach ([
-            "App\\Http\\Resources\\{$relationship->singular()->studly()}Resource",
-            "App\\Http\\Resources\\{$relationship->studly()}Resource",
-        ] as $class) {
-            if (class_exists($class)) {
-                return $class;
-            }
-        }
+        $resourceType = ReferenceTypeResolver::getInstance()
+            ->resolve(
+                new GlobalScope,
+                new MethodCallReferenceType($modelType, 'toResource', []),
+            );
 
-        return null;
+        return $resourceType instanceof ObjectType ? $resourceType->name : null;
     }
 
     private function normalizeAttributesType(?Type $type): ?KeyedArrayType

--- a/src/Reflection/ReflectionJsonApiResource.php
+++ b/src/Reflection/ReflectionJsonApiResource.php
@@ -270,8 +270,6 @@ class ReflectionJsonApiResource
     /**
      * Attempts to find the related model's resource class name from a relationship type.
      * In case resource name cannot be found, falls back to {@see JsonApiResource::class} {@see ResolvesJsonApiElements::compileResourceRelationshipUsingResolver() Line 256}
-     * @param Type $relationshipType
-     * @return string
      */
     private function guessResourceClassFromRelationship(Type $relationshipType): string
     {

--- a/src/Support/OperationExtensions/ParameterExtractor/JsonApiResourceParametersExtractor.php
+++ b/src/Support/OperationExtensions/ParameterExtractor/JsonApiResourceParametersExtractor.php
@@ -120,7 +120,11 @@ class JsonApiResourceParametersExtractor implements ParameterExtractor
         if ($type instanceof TemplateType) {
             $type = $type->is;
         }
+        if (! $type) {
+            return null;
+        }
 
+        /** @var ObjectType|null $resourceType */
         $resourceType = (new TypeWalker())->first(
             $type,
             fn ($t) => $t instanceof ObjectType && $t->isInstanceOf(JsonApiResource::class),

--- a/src/Support/OperationExtensions/ParameterExtractor/JsonApiResourceParametersExtractor.php
+++ b/src/Support/OperationExtensions/ParameterExtractor/JsonApiResourceParametersExtractor.php
@@ -16,7 +16,6 @@ use Dedoc\Scramble\Support\Type\TemplateType;
 use Dedoc\Scramble\Support\Type\Type;
 use Dedoc\Scramble\Support\Type\TypeWalker;
 use Dedoc\Scramble\Support\TypeManagers\JsonApiResourceTypeManager;
-use Illuminate\Http\Resources\JsonApi\AnonymousResourceCollection;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
 
 class JsonApiResourceParametersExtractor implements ParameterExtractor
@@ -125,7 +124,7 @@ class JsonApiResourceParametersExtractor implements ParameterExtractor
         }
 
         /** @var ObjectType|null $resourceType */
-        $resourceType = (new TypeWalker())->first(
+        $resourceType = (new TypeWalker)->first(
             $type,
             fn ($t) => $t instanceof ObjectType && $t->isInstanceOf(JsonApiResource::class),
         );

--- a/src/Support/OperationExtensions/ParameterExtractor/JsonApiResourceParametersExtractor.php
+++ b/src/Support/OperationExtensions/ParameterExtractor/JsonApiResourceParametersExtractor.php
@@ -14,6 +14,7 @@ use Dedoc\Scramble\Support\Type\Literal\LiteralBooleanType;
 use Dedoc\Scramble\Support\Type\ObjectType;
 use Dedoc\Scramble\Support\Type\TemplateType;
 use Dedoc\Scramble\Support\Type\Type;
+use Dedoc\Scramble\Support\Type\TypeWalker;
 use Dedoc\Scramble\Support\TypeManagers\JsonApiResourceTypeManager;
 use Illuminate\Http\Resources\JsonApi\AnonymousResourceCollection;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
@@ -120,26 +121,16 @@ class JsonApiResourceParametersExtractor implements ParameterExtractor
             $type = $type->is;
         }
 
-        if (! $type instanceof ObjectType) {
+        $resourceType = (new TypeWalker())->first(
+            $type,
+            fn ($t) => $t instanceof ObjectType && $t->isInstanceOf(JsonApiResource::class),
+        );
+
+        if (! $resourceType) {
             return null;
         }
 
-        if ($type instanceof Generic && $type->isInstanceOf(AnonymousResourceCollection::class)) {
-            if (count($type->templateTypes) < 3) {
-                return null;
-            }
-
-            $type = $type->templateTypes[2 /* TCollects */];
-            if ($type instanceof TemplateType) {
-                $type = $type->is;
-            }
-        }
-
-        if ($type instanceof ObjectType && $type->isInstanceOf(JsonApiResource::class)) {
-            return $this->jsonApiResourceTypeManager->normalizeType($type);
-        }
-
-        return null;
+        return $this->jsonApiResourceTypeManager->normalizeType($resourceType);
     }
 
     /**

--- a/src/Support/OperationExtensions/ParameterExtractor/JsonApiResourceParametersExtractor.php
+++ b/src/Support/OperationExtensions/ParameterExtractor/JsonApiResourceParametersExtractor.php
@@ -49,7 +49,10 @@ class JsonApiResourceParametersExtractor implements ParameterExtractor
 
         return [
             ...$parameterExtractionResults,
-            new ParametersExtractionResult($parameters),
+            new ParametersExtractionResult(
+                $parameters,
+                sourceClass: $resourceType->name,
+            ),
         ];
     }
 

--- a/src/Support/OperationExtensions/RulesExtractor/DeepParametersMerger.php
+++ b/src/Support/OperationExtensions/RulesExtractor/DeepParametersMerger.php
@@ -142,7 +142,7 @@ class DeepParametersMerger
                 ->addRequired($parameter->required ? [$settingKey] : []);
         }
 
-        if ($isSettingArrayItems && $containingType instanceof ObjectType) { // @phpstan-ignore instanceof.alwaysTrue
+        if ($isSettingArrayItems && $containingType instanceof ObjectType) {
             $containingType->properties = collect($containingType->properties)
                 ->map(fn ($prop) => $prop instanceof UnknownType ? $typeToSet : $prop)
                 ->all();

--- a/tests/Support/OperationExtensions/ParameterExtractor/JsonApiResourceParametersExtractorTest.php
+++ b/tests/Support/OperationExtensions/ParameterExtractor/JsonApiResourceParametersExtractorTest.php
@@ -32,6 +32,30 @@ test('extracts includes parameter', function () {
     ]);
 });
 
+test('extracts includes parameter when resource transformed to response', function () {
+    $openApiDocument = generateForRoute(RouteFacade::get('/api/test', function () {
+        return SamplePostResource_JsonApiResourceParametersExtractorTest::make()->response()->setStatusCode(202);
+    }));
+
+    $parameters = collect($openApiDocument['paths']['/test']['get']['parameters']);
+
+    expect($parameters->firstWhere('name', 'include'))->toBe([
+        'name' => 'include',
+        'in' => 'query',
+        'schema' => [
+            'type' => 'array',
+            'items' => [
+                'type' => 'string',
+                'enum' => [
+                    'user',
+                    'parent',
+                ],
+            ],
+        ],
+        'explode' => false,
+    ]);
+});
+
 test('extracts fields parameter', function () {
     $openApiDocument = generateForRoute(RouteFacade::get('/api/test', function () {
         return SamplePostResource_JsonApiResourceParametersExtractorTest::make();


### PR DESCRIPTION
- Fixed relationship's resources guessing when not provided explicitly
- Fixed JSON:API parameters aren't recognized if resource is transformed to response