### PR TITLE
fix: silence PHP 8.5 deprecations (null array offset, preg_replace null)

### DIFF
--- a/src/Infer/Services/FileNameResolver.php
+++ b/src/Infer/Services/FileNameResolver.php
@@ -35,8 +35,8 @@ class FileNameResolver
 
         $code = Str::before($content, $firstMatchedClassLikeString);
 
-        // Removes all comments.
-        $code = preg_replace('/\/\*(?:[^*]|\*+[^*\/])*\*+\/|(?<![:\'"])\/\/.*|(?<![:\'"])#.*/', '', $code);
+        // Removes all comments. Fall back to the original code if PCRE returns null.
+        $code = preg_replace('/\/\*(?:[^*]|\*+[^*\/])*\*+\/|(?<![:\'"])\/\/.*|(?<![:\'"])#.*/', '', $code) ?? $code;
 
         $re = '/^(namespace|use) ([.\s\S]*?);/m';
         preg_match_all($re, $code, $matches);

--- a/src/Support/Generator/UniqueNamesOptionsCollection.php
+++ b/src/Support/Generator/UniqueNamesOptionsCollection.php
@@ -29,8 +29,9 @@ class UniqueNamesOptionsCollection
     {
         $this->names->push($name);
 
-        $this->eloquentNames[$name->eloquent] ??= [];
-        $this->eloquentNames[$name->eloquent][] = $name;
+        $eloquentKey = $name->eloquent ?? '';
+        $this->eloquentNames[$eloquentKey] ??= [];
+        $this->eloquentNames[$eloquentKey][] = $name;
 
         $this->fallbackEloquentNames[$name->getFallbackEloquent()] ??= [];
         $this->fallbackEloquentNames[$name->getFallbackEloquent()][] = $name;


### PR DESCRIPTION
Fixes #1154.

PHP 8.5 emits two deprecations when running Scramble's code paths:

1. **`UniqueNamesOptionsCollection.php:32-33`** — `UniqueNameOptions::$eloquent` is `?string`, and `null` array keys are deprecated. Coalesce to `''` before using it as a key. `getUniqueName()` already guards on `$name->eloquent` being truthy, so an empty-string bucket cannot collide with a real eloquent name.

2. **`FileNameResolver.php:39`** — `preg_replace()` can return `null` on PCRE error, and that `null` is then passed to `preg_match_all()` which now warns. Fall back to the original `$code` so the subject stays a string.

Two-line minimal change, no behaviour change on the happy path.