### PR TITLE
Improve performance for projects with many inline types

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -51,6 +51,8 @@ class Generator
 
     public function __invoke(?GeneratorConfig $config = null)
     {
+        $start = microtime(true);
+
         $config ??= Scramble::getGeneratorConfig(Scramble::DEFAULT_API);
 
         $openApi = $this->makeOpenApi($config);
@@ -128,6 +130,10 @@ class Generator
             throw new InvalidArgumentException('(callable(OpenApi, OpenApiContext): void)|DocumentTransformer type for document transformer expected, received '.$openApiTransformer::class);
         }
 
+        info('stats', [
+            'peak' => round(memory_get_peak_usage()/1024/1024, 2).'mb',
+            'time' => round((microtime(true) - $start) * 1000).'ms'
+        ]);
         return $openApi->toArray();
     }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -51,8 +51,6 @@ class Generator
 
     public function __invoke(?GeneratorConfig $config = null)
     {
-        $start = microtime(true);
-
         $config ??= Scramble::getGeneratorConfig(Scramble::DEFAULT_API);
 
         $openApi = $this->makeOpenApi($config);
@@ -129,11 +127,6 @@ class Generator
             // @phpstan-ignore deadCode.unreachable
             throw new InvalidArgumentException('(callable(OpenApi, OpenApiContext): void)|DocumentTransformer type for document transformer expected, received '.$openApiTransformer::class);
         }
-
-        info('stats', [
-            'peak' => round(memory_get_peak_usage() / 1024 / 1024, 2).'mb',
-            'time' => round((microtime(true) - $start) * 1000).'ms',
-        ]);
 
         return $openApi->toArray();
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -131,9 +131,10 @@ class Generator
         }
 
         info('stats', [
-            'peak' => round(memory_get_peak_usage()/1024/1024, 2).'mb',
-            'time' => round((microtime(true) - $start) * 1000).'ms'
+            'peak' => round(memory_get_peak_usage() / 1024 / 1024, 2).'mb',
+            'time' => round((microtime(true) - $start) * 1000).'ms',
         ]);
+
         return $openApi->toArray();
     }
 

--- a/src/Infer/Definition/ClassDefinition.php
+++ b/src/Infer/Definition/ClassDefinition.php
@@ -295,6 +295,8 @@ class ClassDefinition implements ClassDefinitionContract
                 ),
             );
 
+            FunctionLikeAstDefinitionBuilder::resolveFunctionParameterDefaults($methodScope, $this->methods[$name]);
+
             FunctionLikeAstDefinitionBuilder::resolveFunctionReturnReferences($methodScope, $this->methods[$name]);
 
             FunctionLikeAstDefinitionBuilder::resolveFunctionExceptions($methodScope, $this->methods[$name]);

--- a/src/Infer/DefinitionBuilders/FunctionLikeAstDefinitionBuilder.php
+++ b/src/Infer/DefinitionBuilders/FunctionLikeAstDefinitionBuilder.php
@@ -364,4 +364,13 @@ class FunctionLikeAstDefinitionBuilder implements FunctionLikeDefinitionBuilder
         $resolvedReference = ReferenceTypeResolver::getInstance()->resolve($scope, $returnType);
         $functionType->setReturnType($resolvedReference);
     }
+
+    public static function resolveFunctionParameterDefaults(Scope $scope, FunctionLikeDefinition $functionLikeDefinition): void
+    {
+        $referenceTypeResolver = ReferenceTypeResolver::getInstance();
+
+        foreach ($functionLikeDefinition->argumentsDefaults as $name => $argumentDefault) {
+            $functionLikeDefinition->argumentsDefaults[$name] = $referenceTypeResolver->resolve($scope, $argumentDefault);
+        }
+    }
 }

--- a/src/Infer/Reflector/ClosureReflector.php
+++ b/src/Infer/Reflector/ClosureReflector.php
@@ -158,6 +158,7 @@ class ClosureReflector
             throw new \LogicException('Cannot get scope of closure');
         }
 
+        Infer\DefinitionBuilders\FunctionLikeAstDefinitionBuilder::resolveFunctionParameterDefaults($scope, $closureDefinition);
         Infer\DefinitionBuilders\FunctionLikeAstDefinitionBuilder::resolveFunctionReturnReferences($scope, $closureDefinition);
         Infer\DefinitionBuilders\FunctionLikeAstDefinitionBuilder::resolveFunctionExceptions($scope, $closureDefinition);
 

--- a/src/Infer/Services/ReferenceTypeResolver.php
+++ b/src/Infer/Services/ReferenceTypeResolver.php
@@ -43,6 +43,8 @@ use Dedoc\Scramble\Support\Type\VoidType;
 
 class ReferenceTypeResolver
 {
+    private static array $cache = [];
+
     public function __construct(
         private Index $index,
     ) {}
@@ -54,6 +56,12 @@ class ReferenceTypeResolver
 
     public function resolve(Scope $scope, Type $type): Type
     {
+//        $key = $type->toString();
+
+//        if (isset(static::$cache[$key])) {
+//            return static::$cache[$key];
+//        }
+
         $originalType = $type;
 
         $resolvedType = RecursionGuard::run(
@@ -63,7 +71,7 @@ class ReferenceTypeResolver
         );
 
         // Type finalization: removing duplicates from union, unpacking array items (inside `replace`), calling resolving extensions.
-        return $this->finalizeType($resolvedType, $originalType);
+        return /*static::$cache[$key] = */$this->finalizeType($resolvedType, $originalType);
     }
 
     private function doResolve(Type $t, Type $type, Scope $scope): Type

--- a/src/Infer/Services/ReferenceTypeResolver.php
+++ b/src/Infer/Services/ReferenceTypeResolver.php
@@ -620,10 +620,10 @@ class ReferenceTypeResolver
             ->getFunctionContextTemplates($callee, $arguments)
             ->prepend($classContextTemplates);
 
-        $returnType = (new TypeWalker)->map(
-            $returnType,
-            fn (Type $t) => $t instanceof TemplateType ? $templatesMap->get($t->name, $t) : $t,
-        );
+        $localCache = [];
+        $returnType = (new TypeWalker)->map($returnType, function (Type $t) use ($templatesMap, &$localCache) {
+            return $t instanceof TemplateType ? $templatesMap->get($t->name, $t) : $t;
+        });
 
         if ($returnType instanceof Generic && ($selfOutType = $callee->getSelfOutType())) {
             $returnType->templateTypes = $this->applySelfOutType(

--- a/src/Infer/Services/ReferenceTypeResolver.php
+++ b/src/Infer/Services/ReferenceTypeResolver.php
@@ -87,7 +87,7 @@ class ReferenceTypeResolver
             return new UnknownType('self reference');
         }
 
-        return $resolved->clone();
+        return $resolved;
     }
 
     private function finalizeStatic(Type $type, Type $staticType): Type

--- a/src/Infer/Services/ReferenceTypeResolver.php
+++ b/src/Infer/Services/ReferenceTypeResolver.php
@@ -87,7 +87,7 @@ class ReferenceTypeResolver
             return new UnknownType('self reference');
         }
 
-        return $resolved;
+        return $resolved->clone();
     }
 
     private function finalizeStatic(Type $type, Type $staticType): Type

--- a/src/Infer/Services/ReferenceTypeResolver.php
+++ b/src/Infer/Services/ReferenceTypeResolver.php
@@ -43,8 +43,6 @@ use Dedoc\Scramble\Support\Type\VoidType;
 
 class ReferenceTypeResolver
 {
-    private static array $cache = [];
-
     public function __construct(
         private Index $index,
     ) {}
@@ -56,12 +54,6 @@ class ReferenceTypeResolver
 
     public function resolve(Scope $scope, Type $type): Type
     {
-//        $key = $type->toString();
-
-//        if (isset(static::$cache[$key])) {
-//            return static::$cache[$key];
-//        }
-
         $originalType = $type;
 
         $resolvedType = RecursionGuard::run(
@@ -71,7 +63,7 @@ class ReferenceTypeResolver
         );
 
         // Type finalization: removing duplicates from union, unpacking array items (inside `replace`), calling resolving extensions.
-        return /*static::$cache[$key] = */$this->finalizeType($resolvedType, $originalType);
+        return $this->finalizeType($resolvedType, $originalType);
     }
 
     private function doResolve(Type $t, Type $type, Scope $scope): Type
@@ -95,7 +87,7 @@ class ReferenceTypeResolver
             return new UnknownType('self reference');
         }
 
-        return $this->resolve($scope, $resolved);
+        return $resolved;
     }
 
     private function finalizeStatic(Type $type, Type $staticType): Type

--- a/src/Infer/Services/ReferenceTypeResolver.php
+++ b/src/Infer/Services/ReferenceTypeResolver.php
@@ -622,7 +622,7 @@ class ReferenceTypeResolver
 
         $localCache = [];
         $returnType = (new TypeWalker)->map($returnType, function (Type $t) use ($templatesMap, &$localCache) {
-            return $t instanceof TemplateType ? $templatesMap->get($t->name, $t) : $t;
+            return $t instanceof TemplateType ? ($localCache[$t->name] ??= $templatesMap->get($t->name, $t)) : $t;
         });
 
         if ($returnType instanceof Generic && ($selfOutType = $callee->getSelfOutType())) {

--- a/src/Infer/Services/ReferenceTypeResolver.php
+++ b/src/Infer/Services/ReferenceTypeResolver.php
@@ -614,7 +614,7 @@ class ReferenceTypeResolver
 
         $returnType = (new TypeWalker)->map(
             $returnType,
-            fn (Type $t) => $t instanceof TemplateType ? $templatesMap->get($t->name, $t) : $t
+            fn (Type $t) => $t instanceof TemplateType ? $templatesMap->get($t->name, $t) : $t,
         );
 
         if ($returnType instanceof Generic && ($selfOutType = $callee->getSelfOutType())) {

--- a/src/Infer/Services/ReferenceTypeResolver.php
+++ b/src/Infer/Services/ReferenceTypeResolver.php
@@ -620,10 +620,10 @@ class ReferenceTypeResolver
             ->getFunctionContextTemplates($callee, $arguments)
             ->prepend($classContextTemplates);
 
-        $localCache = [];
-        $returnType = (new TypeWalker)->map($returnType, function (Type $t) use ($templatesMap, &$localCache) {
-            return $t instanceof TemplateType ? ($localCache[$t->name] ??= $templatesMap->get($t->name, $t)) : $t;
-        });
+        $returnType = (new TypeWalker)->map(
+            $returnType,
+            fn (Type $t) => $t instanceof TemplateType ? $templatesMap->get($t->name, $t) : $t
+        );
 
         if ($returnType instanceof Generic && ($selfOutType = $callee->getSelfOutType())) {
             $returnType->templateTypes = $this->applySelfOutType(

--- a/src/Infer/Services/TemplatesMap.php
+++ b/src/Infer/Services/TemplatesMap.php
@@ -19,6 +19,9 @@ class TemplatesMap
     /** @var array<string, Type> */
     public array $additional = [];
 
+    /** @var array<string, Type> */
+    private array $cache = [];
+
     /**
      * @param  TemplateType[]  $templates
      * @param  array<string, Type>  $parameters
@@ -43,6 +46,11 @@ class TemplatesMap
     }
 
     public function get(string $name, Type $defaultType = new UnknownType): Type
+    {
+        return $this->cache[$name] ??= $this->doGet($name, $defaultType);
+    }
+
+    private function doGet(string $name, Type $defaultType = new UnknownType): Type
     {
         if ($name === self::ARGUMENTS) {
             return new KeyedArrayType(collect($this->arguments->all())->map(fn ($t, $k) => new ArrayItemType_($k, $t))->all());

--- a/src/ScrambleServiceProvider.php
+++ b/src/ScrambleServiceProvider.php
@@ -29,6 +29,7 @@ use Dedoc\Scramble\Support\IndexBuilders\IndexBuilder;
 use Dedoc\Scramble\Support\IndexBuilders\PaginatorsCandidatesBuilder;
 use Dedoc\Scramble\Support\InferExtensions\AbortHelpersExceptionInfer;
 use Dedoc\Scramble\Support\InferExtensions\AfterAnonymousResourceCollectionDefinitionCreatedExtension;
+use Dedoc\Scramble\Support\InferExtensions\AfterEloquentCollectionDefinitionCreatedExtension;
 use Dedoc\Scramble\Support\InferExtensions\AfterJsonApiResourceDefinitionCreatedExtension;
 use Dedoc\Scramble\Support\InferExtensions\AfterJsonResourceDefinitionCreatedExtension;
 use Dedoc\Scramble\Support\InferExtensions\AfterResourceCollectionDefinitionCreatedExtension;
@@ -153,6 +154,7 @@ class ScrambleServiceProvider extends PackageServiceProvider
                     JsonApiResourceMethodReturnTypeExtension::class,
                     JsonApiResourceCollectionMethodReturnTypeExtension::class,
                     AfterJsonApiResourceDefinitionCreatedExtension::class,
+                    AfterEloquentCollectionDefinitionCreatedExtension::class,
                     JsonResourceExtension::class,
                     ResourceResponseMethodReturnTypeExtension::class,
                     JsonResponseMethodReturnTypeExtension::class,

--- a/src/Support/Generator/Combined/AllOf.php
+++ b/src/Support/Generator/Combined/AllOf.php
@@ -17,6 +17,17 @@ class AllOf extends Type
         $this->items = [new StringType];
     }
 
+    public function clone(): static
+    {
+        $clone = parent::clone();
+        $clone->items = array_map(
+            fn (Type $item) => $item->clone(),
+            $clone->items,
+        );
+
+        return $clone;
+    }
+
     public function toArray()
     {
         $parentArray = parent::toArray();

--- a/src/Support/Generator/Combined/AnyOf.php
+++ b/src/Support/Generator/Combined/AnyOf.php
@@ -17,6 +17,17 @@ class AnyOf extends Type
         $this->items = [new StringType];
     }
 
+    public function clone(): static
+    {
+        $clone = parent::clone();
+        $clone->items = array_map(
+            fn (Type $item) => $item->clone(),
+            $clone->items,
+        );
+
+        return $clone;
+    }
+
     public function toArray()
     {
         $parentArray = parent::toArray();

--- a/src/Support/Generator/TypeTransformer.php
+++ b/src/Support/Generator/TypeTransformer.php
@@ -40,6 +40,8 @@ use function DeepCopy\deep_copy;
  */
 class TypeTransformer
 {
+    private static $cache = [];
+
     /** @var TypeToSchemaExtension[] */
     private array $typeToSchemaExtensions;
 
@@ -76,6 +78,12 @@ class TypeTransformer
 
     public function transform(Type $type): OpenApiType
     {
+        $key = $type->toString();
+
+        if (isset(static::$cache[$key])) {
+            return static::$cache[$key];
+        }
+
         $openApiType = new UnknownType;
 
         if ($type instanceof TemplateType && $type->is) {
@@ -293,7 +301,7 @@ class TypeTransformer
             $openApiType->setAttribute('line', $type->getAttribute('line'));
         }
 
-        return $openApiType;
+        return static::$cache[$key] = $openApiType;
     }
 
     private function handleUsingExtensions(Type $type): OpenApiType|Reference|null

--- a/src/Support/Generator/TypeTransformer.php
+++ b/src/Support/Generator/TypeTransformer.php
@@ -250,7 +250,7 @@ class TypeTransformer
 
             // @todo use PhpDocSchemaTransformer
 
-            /** @var PhpDocNode|null $valueDocNode */
+            /** @var PhpDocNode|null $docNode */
             $docNode = $typeValue->getAttribute('docNode');
 
             if ($docNode) {

--- a/src/Support/Generator/TypeTransformer.php
+++ b/src/Support/Generator/TypeTransformer.php
@@ -120,13 +120,55 @@ class TypeTransformer
         $key = $this->getCacheKey($type);
 
         if (isset($this->cache[$key])) {
-            return $this->cache[$key]->clone();
+            $openApiType = $this->cache[$key]->clone();
+            $this->registerReferences($openApiType);
+
+            return $openApiType;
         }
 
         $openApiType = $this->transformUncached($type);
         $this->cache[$key] = $openApiType->clone();
 
         return $openApiType;
+    }
+
+    private function registerReferences(OpenApiType $type): void
+    {
+        if ($type instanceof Reference) {
+            $this->context->references->schemas->add($type->fullName, $type);
+
+            return;
+        }
+
+        if ($type instanceof ArrayType) {
+            $this->registerReferences($type->items);
+
+            foreach ($type->prefixItems as $item) {
+                $this->registerReferences($item);
+            }
+
+            return;
+        }
+
+        if ($type instanceof ObjectType) {
+            foreach ($type->properties as $property) {
+                if ($property) {
+                    $this->registerReferences($property);
+                }
+            }
+
+            if ($type->additionalProperties) {
+                $this->registerReferences($type->additionalProperties);
+            }
+
+            return;
+        }
+
+        if ($type instanceof AnyOf || $type instanceof AllOf) {
+            foreach ($type->items as $item) {
+                $this->registerReferences($item);
+            }
+        }
     }
 
     private function transformUncached(Type $type): OpenApiType

--- a/src/Support/Generator/TypeTransformer.php
+++ b/src/Support/Generator/TypeTransformer.php
@@ -40,7 +40,8 @@ use function DeepCopy\deep_copy;
  */
 class TypeTransformer
 {
-    private static $cache = [];
+    /** @var array<string, OpenApiType> */
+    private array $cache = [];
 
     /** @var TypeToSchemaExtension[] */
     private array $typeToSchemaExtensions;
@@ -78,17 +79,63 @@ class TypeTransformer
 
     public function transform(Type $type): OpenApiType
     {
-        $key = $type->toString();
-
-        if (isset(static::$cache[$key])) {
-            return static::$cache[$key];
-        }
-
-        $openApiType = new UnknownType;
-
         if ($type instanceof TemplateType && $type->is) {
             $type = $type->is;
         }
+
+        $openApiType = $this->shouldCache($type)
+            ? $this->transformCached($type)
+            : $this->transformUncached($type);
+
+        return $this->applyTypeAttributes($openApiType, $type);
+    }
+
+    private function getCacheKey(Type $type): string
+    {
+        if ($type instanceof TemplateType && $type->is) {
+            $type = $type->is;
+        }
+
+        return $type::class.'|'.$type->toString();
+    }
+
+    private function shouldCache(Type $type): bool
+    {
+        $attributesHandledAfterCache = array_flip(['docNode', 'format', 'file', 'line']);
+
+        return ! array_diff_key($type->attributes(), $attributesHandledAfterCache)
+            && ! $type instanceof ArrayItemType_
+            && ! $type instanceof \Dedoc\Scramble\Support\Type\KeyedArrayType
+            && ! $type instanceof \Dedoc\Scramble\Support\Type\ArrayType
+            && ! $type instanceof Union
+            && ! $type instanceof \Dedoc\Scramble\Support\Type\IntersectionType;
+    }
+
+    private function transformCached(Type $type): OpenApiType
+    {
+        if ($type instanceof TemplateType && $type->is) {
+            $type = $type->is;
+        }
+
+        $key = $this->getCacheKey($type);
+
+        if (isset($this->cache[$key])) {
+            return $this->cache[$key]->clone();
+        }
+
+        $openApiType = $this->transformUncached($type);
+        $this->cache[$key] = $openApiType->clone();
+
+        return $openApiType;
+    }
+
+    private function transformUncached(Type $type): OpenApiType
+    {
+        if ($type instanceof TemplateType && $type->is) {
+            $type = $type->is;
+        }
+
+        $openApiType = new UnknownType;
 
         if (
             $type instanceof \Dedoc\Scramble\Support\Type\KeyedArrayType
@@ -140,9 +187,7 @@ class TypeTransformer
                     ->additionalProperties($this->transform($type->value));
             }
         } elseif ($type instanceof ArrayItemType_) {
-            $openApiType = $this->transform($type->value);
-
-            // @todo use PhpDocSchemaTransformer
+            $typeValue = clone $type->value;
 
             /** @var PhpDocNode|null $valueDocNode */
             $valueDocNode = $type->value->getAttribute('docNode');
@@ -156,7 +201,17 @@ class TypeTransformer
                 ]);
                 PhpDoc::addSummaryAttributes($docNode);
 
-                /** @var PhpDocNode $docNode */
+                $typeValue->setAttribute('docNode', $docNode);
+            }
+
+            $openApiType = $this->transform($typeValue);
+
+            // @todo use PhpDocSchemaTransformer
+
+            /** @var PhpDocNode|null $valueDocNode */
+            $docNode = $typeValue->getAttribute('docNode');
+
+            if ($docNode) {
                 $varNode = array_values($docNode->getVarTagValues())[0] ?? null;
 
                 $openApiType = $varNode
@@ -289,6 +344,11 @@ class TypeTransformer
             $openApiType = $typeHandledByExtension;
         }
 
+        return $openApiType;
+    }
+
+    private function applyTypeAttributes(OpenApiType $openApiType, Type $type): OpenApiType
+    {
         if ($type->hasAttribute('format')) {
             $openApiType->format($type->getAttribute('format'));
         }
@@ -301,7 +361,7 @@ class TypeTransformer
             $openApiType->setAttribute('line', $type->getAttribute('line'));
         }
 
-        return static::$cache[$key] = $openApiType;
+        return $openApiType;
     }
 
     private function handleUsingExtensions(Type $type): OpenApiType|Reference|null

--- a/src/Support/Generator/Types/ArrayType.php
+++ b/src/Support/Generator/Types/ArrayType.php
@@ -26,6 +26,18 @@ class ArrayType extends Type
         $this->items = $defaultMissingType;
     }
 
+    public function clone(): static
+    {
+        $clone = parent::clone();
+        $clone->items = $clone->items->clone();
+        $clone->prefixItems = array_map(
+            fn (Type $item) => $item->clone(),
+            $clone->prefixItems,
+        );
+
+        return $clone;
+    }
+
     public function setMin($min)
     {
         $this->minItems = $min;

--- a/src/Support/Generator/Types/ObjectType.php
+++ b/src/Support/Generator/Types/ObjectType.php
@@ -17,6 +17,21 @@ class ObjectType extends Type
         parent::__construct('object');
     }
 
+    public function clone(): static
+    {
+        $clone = parent::clone();
+
+        foreach ($clone->properties as $name => $property) {
+            $clone->properties[$name] = $property?->clone();
+        }
+
+        if ($clone->additionalProperties) {
+            $clone->additionalProperties = $clone->additionalProperties->clone();
+        }
+
+        return $clone;
+    }
+
     public function addProperty(string $name, $propertyType)
     {
         $this->properties[$name] = $propertyType;

--- a/src/Support/Generator/Types/Type.php
+++ b/src/Support/Generator/Types/Type.php
@@ -48,6 +48,11 @@ abstract class Type
         $this->default = new MissingValue;
     }
 
+    public function clone(): static
+    {
+        return clone $this;
+    }
+
     /**
      * @return $this
      */

--- a/src/Support/InferExtensions/AfterEloquentCollectionDefinitionCreatedExtension.php
+++ b/src/Support/InferExtensions/AfterEloquentCollectionDefinitionCreatedExtension.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Dedoc\Scramble\Support\InferExtensions;
+
+use Dedoc\Scramble\Infer\Extensions\AfterClassDefinitionCreatedExtension;
+use Dedoc\Scramble\Infer\Extensions\Event\ClassDefinitionCreatedEvent;
+use Dedoc\Scramble\Support\Type\FunctionType;
+use Dedoc\Scramble\Support\Type\Generic;
+use Dedoc\Scramble\Support\Type\IntegerType;
+use Dedoc\Scramble\Support\Type\Reference\StaticReference;
+use Dedoc\Scramble\Support\Type\StringType;
+use Dedoc\Scramble\Support\Type\TemplateType;
+use Dedoc\Scramble\Support\Type\Union;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+
+/**
+ * Purely for performance improvements for cases, when mapping over eloquent collection
+ * creates unneeded unions which in cases of nested map calls degrade performance.
+ */
+class AfterEloquentCollectionDefinitionCreatedExtension implements AfterClassDefinitionCreatedExtension
+{
+    public function shouldHandle(string $name): bool
+    {
+        return $name === EloquentCollection::class;
+    }
+
+    public function afterClassDefinitionCreated(ClassDefinitionCreatedEvent $event): void
+    {
+        $definition = $event->classDefinition;
+
+        $tKey = collect($definition->templateTypes)->firstOrFail('name', 'TKey');
+        $tModel = collect($definition->templateTypes)->firstOrFail('name', 'TModel');
+
+        $definition->methods['map'] = $this->buildMapMethodDefinition($tKey, $tModel);
+        $definition->methods['mapWithKeys'] = $this->buildMapWithKeysMethodDefinition($tKey, $tModel);
+    }
+
+    private function buildMapMethodDefinition(TemplateType $tKey, TemplateType $tModel): ShallowFunctionDefinition
+    {
+        $templates = [
+            $tMapValue = new TemplateType('TMapValue'),
+        ];
+
+        return new ShallowFunctionDefinition(
+            type: tap(new FunctionType(
+                name: 'map',
+                arguments: [
+                    'callback' => new FunctionType('{}', [$tModel, $tKey], $tMapValue),
+                ],
+                returnType: new Generic(StaticReference::STATIC, [$tKey, $tMapValue]),
+            ), function (FunctionType $ft) use ($templates) {
+                $ft->templates = $templates;
+            }),
+            definingClassName: EloquentCollection::class,
+        );
+    }
+
+    private function buildMapWithKeysMethodDefinition(TemplateType $tKey, TemplateType $tModel): ShallowFunctionDefinition
+    {
+        $templates = [
+            $tMapWithKeysKey = new TemplateType('TMapWithKeysKey', is: new Union([new IntegerType, new StringType])),
+            $tMapWithKeysValue = new TemplateType('TMapWithKeysValue'),
+        ];
+
+        return new ShallowFunctionDefinition(
+            type: tap(new FunctionType(
+                name: 'mapWithKeys',
+                arguments: [
+                    'callback' => new FunctionType('{}', [$tModel, $tKey], new Generic('iterable', [
+                        $tMapWithKeysKey,
+                        $tMapWithKeysValue,
+                    ])),
+                ],
+                returnType: new Generic(StaticReference::STATIC, [$tMapWithKeysKey, $tMapWithKeysValue]),
+            ), function (FunctionType $ft) use ($templates) {
+                $ft->templates = $templates;
+            }),
+            definingClassName: EloquentCollection::class,
+        );
+    }
+}

--- a/src/Support/Type/BooleanType.php
+++ b/src/Support/Type/BooleanType.php
@@ -6,7 +6,7 @@ class BooleanType extends AbstractType
 {
     public function isSame(Type $type)
     {
-        return $type instanceof static;
+        return $type::class === static::class;
     }
 
     public function toString(): string

--- a/src/Support/Type/FloatType.php
+++ b/src/Support/Type/FloatType.php
@@ -6,7 +6,7 @@ class FloatType extends AbstractType
 {
     public function isSame(Type $type)
     {
-        return $type instanceof static;
+        return $type::class === static::class;
     }
 
     public function toString(): string

--- a/src/Support/Type/Generic.php
+++ b/src/Support/Type/Generic.php
@@ -68,6 +68,29 @@ class Generic extends ObjectType
         });
     }
 
+    public function isSame(Type $type)
+    {
+        if (! $type instanceof static) {
+            return false;
+        }
+
+        if ($type->name !== $this->name) {
+            return false;
+        }
+
+        if (count($type->templateTypes) !== count($this->templateTypes)) {
+            return false;
+        }
+
+        foreach ($type->templateTypes as $i => $templateType) {
+            if (! $templateType->isSame($this->templateTypes[$i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public function toString(): string
     {
         return sprintf(

--- a/src/Support/Type/IntegerType.php
+++ b/src/Support/Type/IntegerType.php
@@ -6,7 +6,7 @@ class IntegerType extends AbstractType
 {
     public function isSame(Type $type)
     {
-        return $type instanceof static;
+        return $type::class === static::class;
     }
 
     public function toString(): string

--- a/src/Support/Type/Literal/LiteralBooleanType.php
+++ b/src/Support/Type/Literal/LiteralBooleanType.php
@@ -4,6 +4,7 @@ namespace Dedoc\Scramble\Support\Type\Literal;
 
 use Dedoc\Scramble\Support\Type\BooleanType;
 use Dedoc\Scramble\Support\Type\Contracts\LiteralType;
+use Dedoc\Scramble\Support\Type\Type;
 
 class LiteralBooleanType extends BooleanType implements LiteralType
 {
@@ -17,6 +18,11 @@ class LiteralBooleanType extends BooleanType implements LiteralType
     public function getValue(): bool
     {
         return $this->value;
+    }
+
+    public function isSame(Type $type)
+    {
+        return $type instanceof static && $type->value === $this->value;
     }
 
     public function toString(): string

--- a/src/Support/Type/Literal/LiteralFloatType.php
+++ b/src/Support/Type/Literal/LiteralFloatType.php
@@ -4,6 +4,7 @@ namespace Dedoc\Scramble\Support\Type\Literal;
 
 use Dedoc\Scramble\Support\Type\Contracts\LiteralType;
 use Dedoc\Scramble\Support\Type\FloatType;
+use Dedoc\Scramble\Support\Type\Type;
 
 class LiteralFloatType extends FloatType implements LiteralType
 {
@@ -17,6 +18,11 @@ class LiteralFloatType extends FloatType implements LiteralType
     public function getValue(): float
     {
         return $this->value;
+    }
+
+    public function isSame(Type $type)
+    {
+        return $type instanceof static && $type->value === $this->value;
     }
 
     public function toString(): string

--- a/src/Support/Type/Literal/LiteralIntegerType.php
+++ b/src/Support/Type/Literal/LiteralIntegerType.php
@@ -4,6 +4,7 @@ namespace Dedoc\Scramble\Support\Type\Literal;
 
 use Dedoc\Scramble\Support\Type\Contracts\LiteralType;
 use Dedoc\Scramble\Support\Type\IntegerType;
+use Dedoc\Scramble\Support\Type\Type;
 
 class LiteralIntegerType extends IntegerType implements LiteralType
 {
@@ -17,6 +18,11 @@ class LiteralIntegerType extends IntegerType implements LiteralType
     public function getValue(): int
     {
         return $this->value;
+    }
+
+    public function isSame(Type $type)
+    {
+        return $type instanceof static && $type->value === $this->value;
     }
 
     public function toString(): string

--- a/src/Support/Type/Literal/LiteralStringType.php
+++ b/src/Support/Type/Literal/LiteralStringType.php
@@ -4,6 +4,7 @@ namespace Dedoc\Scramble\Support\Type\Literal;
 
 use Dedoc\Scramble\Support\Type\Contracts\LiteralString;
 use Dedoc\Scramble\Support\Type\StringType;
+use Dedoc\Scramble\Support\Type\Type;
 
 class LiteralStringType extends StringType implements LiteralString
 {
@@ -17,6 +18,11 @@ class LiteralStringType extends StringType implements LiteralString
     public function getValue(): string
     {
         return $this->value;
+    }
+
+    public function isSame(Type $type)
+    {
+        return $type instanceof static && $type->value === $this->value;
     }
 
     public function toString(): string

--- a/src/Support/Type/ObjectType.php
+++ b/src/Support/Type/ObjectType.php
@@ -28,7 +28,7 @@ class ObjectType extends AbstractType
 
     public function isSame(Type $type)
     {
-        return false;
+        return $type instanceof static && $type->name === $this->name;
     }
 
     public function getPropertyType(string $propertyName, Scope $scope = new GlobalScope): Type

--- a/src/Support/Type/RecursiveTemplateSolver.php
+++ b/src/Support/Type/RecursiveTemplateSolver.php
@@ -9,7 +9,7 @@ class RecursiveTemplateSolver
     public function solve(Type $parameter, Type $argument, TemplateType $template): ?Type
     {
         if ($template === $parameter) {
-            return $argument;
+            return $argument->clone();
         }
 
         if ($parameter instanceof Union) {

--- a/src/Support/Type/StringType.php
+++ b/src/Support/Type/StringType.php
@@ -6,7 +6,7 @@ class StringType extends AbstractType
 {
     public function isSame(Type $type)
     {
-        return $type instanceof static;
+        return $type::class === static::class;
     }
 
     public function toString(): string

--- a/src/Support/Type/TemplateType.php
+++ b/src/Support/Type/TemplateType.php
@@ -16,7 +16,8 @@ class TemplateType extends AbstractType
 
     public function isSame(Type $type)
     {
-        return false;
+        return $type instanceof self
+            && $this->name === $type->name;
     }
 
     public function isInstanceOf(string $className): bool

--- a/src/Support/Type/TypeHelper.php
+++ b/src/Support/Type/TypeHelper.php
@@ -67,20 +67,6 @@ class TypeHelper
         }
 
         return Union::wrap($flattenedTypes);
-
-        $types = collect($types)
-            ->flatMap(fn ($type) => $type instanceof Union ? $type->types : [$type])
-            ->unique(fn (Type $type) => $type->toString())
-            ->pipe(function (Collection $c) {
-                if ($c->count() > 1 && $c->contains(fn ($t) => $t instanceof VoidType || $t instanceof NeverType)) {
-                    return $c->reject(fn ($t) => $t instanceof VoidType || $t instanceof NeverType);
-                }
-
-                return $c;
-            })
-            ->all();
-
-        return Union::wrap($types);
     }
 
     public static function withoutNull(Type $type): Type

--- a/src/Support/Type/TypeHelper.php
+++ b/src/Support/Type/TypeHelper.php
@@ -18,6 +18,56 @@ class TypeHelper
 {
     public static function mergeTypes(...$types)
     {
+        $flattenedTypes = [];
+
+        foreach ($types as $type) {
+            $nestedTypes = $type instanceof Union
+                ? $type->types
+                : [$type];
+
+            foreach ($nestedTypes as $nestedType) {
+                $alreadyAdded = false;
+
+                foreach ($flattenedTypes as $existingType) {
+                    if ($nestedType->isSame($existingType)) {
+                        $alreadyAdded = true;
+
+                        break;
+                    }
+                }
+
+                if (! $alreadyAdded) {
+                    $flattenedTypes[] = $nestedType;
+                }
+            }
+        }
+
+        $hasVoidOrNever = false;
+
+        foreach ($flattenedTypes as $type) {
+            if ($type instanceof VoidType || $type instanceof NeverType) {
+                $hasVoidOrNever = true;
+
+                break;
+            }
+        }
+
+        if ($hasVoidOrNever && count($flattenedTypes) > 1) {
+            $filtered = [];
+
+            foreach ($flattenedTypes as $type) {
+                if ($type instanceof VoidType || $type instanceof NeverType) {
+                    continue;
+                }
+
+                $filtered[] = $type;
+            }
+
+            $flattenedTypes = $filtered;
+        }
+
+        return Union::wrap($flattenedTypes);
+
         $types = collect($types)
             ->flatMap(fn ($type) => $type instanceof Union ? $type->types : [$type])
             ->unique(fn (Type $type) => $type->toString())

--- a/src/Support/Type/TypeHelper.php
+++ b/src/Support/Type/TypeHelper.php
@@ -7,7 +7,6 @@ use Dedoc\Scramble\Support\Type\Contracts\LateResolvingType;
 use Dedoc\Scramble\Support\Type\Literal\LiteralBooleanType;
 use Dedoc\Scramble\Support\Type\Literal\LiteralIntegerType;
 use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
-use Illuminate\Support\Collection;
 use PhpParser\Node;
 use PhpParser\PrettyPrinter\Standard;
 use ReflectionNamedType;

--- a/src/Support/Type/TypeTraverser.php
+++ b/src/Support/Type/TypeTraverser.php
@@ -12,7 +12,7 @@ class TypeTraverser
     public function __construct(
         private array $visitors = [],
     ) {
-        $this->traversedTypes = new \WeakMap();
+        $this->traversedTypes = new \WeakMap;
     }
 
     public function traverse(Type $type): Type

--- a/src/Support/Type/TypeTraverser.php
+++ b/src/Support/Type/TypeTraverser.php
@@ -2,9 +2,12 @@
 
 namespace Dedoc\Scramble\Support\Type;
 
+use WeakMap;
+
 class TypeTraverser
 {
-    private \WeakMap $traversedTypes;
+    /** @var WeakMap<Type, true> */
+    private WeakMap $traversedTypes;
 
     /**
      * @param  TypeVisitor[]  $visitors
@@ -12,7 +15,7 @@ class TypeTraverser
     public function __construct(
         private array $visitors = [],
     ) {
-        $this->traversedTypes = new \WeakMap;
+        $this->traversedTypes = new WeakMap;
     }
 
     public function traverse(Type $type): Type

--- a/src/Support/Type/TypeTraverser.php
+++ b/src/Support/Type/TypeTraverser.php
@@ -4,15 +4,25 @@ namespace Dedoc\Scramble\Support\Type;
 
 class TypeTraverser
 {
+    private \WeakMap $traversedTypes;
+
     /**
      * @param  TypeVisitor[]  $visitors
      */
     public function __construct(
         private array $visitors = [],
-    ) {}
+    ) {
+        $this->traversedTypes = new \WeakMap();
+    }
 
     public function traverse(Type $type): Type
     {
+        if (isset($this->traversedTypes[$type])) {
+            return $type;
+        }
+
+        $this->traversedTypes[$type] = true;
+
         $enterResult = $this->enterType($type);
 
         if ($enterResult === TypeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN) {

--- a/src/Support/Type/TypeWalker.php
+++ b/src/Support/Type/TypeWalker.php
@@ -81,15 +81,15 @@ class TypeWalker
                 continue;
             }
             if (! is_array($node)) {
-                $subject->$propertyWithNode = TypeHelper::unpackIfArray($this->replace($node, $replacer));
+                $subject->$propertyWithNode = $this->replace($node, $replacer);
             } else {
                 foreach ($node as $index => $item) {
-                    $subject->$propertyWithNode[$index] = TypeHelper::unpackIfArray($this->replace($item, $replacer));
+                    $subject->$propertyWithNode[$index] = $this->replace($item, $replacer);
                 }
             }
         }
 
-        return TypeHelper::unpackIfArray($subject);
+        return $subject;
     }
 
     /**

--- a/src/Support/Type/Union.php
+++ b/src/Support/Type/Union.php
@@ -2,7 +2,6 @@
 
 namespace Dedoc\Scramble\Support\Type;
 
-
 use Illuminate\Support\Arr;
 
 class Union extends AbstractType

--- a/src/Support/Type/Union.php
+++ b/src/Support/Type/Union.php
@@ -92,8 +92,6 @@ class Union extends AbstractType
             }
         }
 
-        $types = array_values($uniqueTypes);
-
         if (! count($types)) {
             return new VoidType;
         }

--- a/src/Support/Type/Union.php
+++ b/src/Support/Type/Union.php
@@ -2,6 +2,7 @@
 
 namespace Dedoc\Scramble\Support\Type;
 
+
 use Illuminate\Support\Arr;
 
 class Union extends AbstractType
@@ -92,15 +93,15 @@ class Union extends AbstractType
             }
         }
 
-        if (! count($types)) {
+        if (! count($uniqueTypes)) {
             return new VoidType;
         }
 
-        if (count($types) === 1) {
-            return $types[0];
+        if (count($uniqueTypes) === 1) {
+            return $uniqueTypes[0];
         }
 
-        return new self($types);
+        return new self($uniqueTypes);
     }
 
     public function toString(): string

--- a/src/Support/Type/Union.php
+++ b/src/Support/Type/Union.php
@@ -18,8 +18,15 @@ class Union extends AbstractType
 
     public function isSame(Type $type)
     {
-        return $type instanceof static
-            && collect($this->types)->every(fn (Type $t, $i) => $t->isSame($type->types[$i]));
+        if (! $type instanceof static) {
+            return false;
+        }
+
+        if (count($this->types) !== count($type->types)) {
+            return false;
+        }
+
+        return collect($this->types)->every(fn (Type $t, $i) => $t->isSame($type->types[$i]));
     }
 
     public function widen(): Type
@@ -66,10 +73,32 @@ class Union extends AbstractType
     public static function wrap(...$types): Type
     {
         $types = Arr::wrap(...$types);
-        $types = collect(array_values($types))
-            ->unique(fn (Type $t) => $t->toString())
-            ->values()
-            ->all();
+
+
+        $uniqueTypes = [];
+
+        foreach (array_values($types) as $type) {
+            $alreadyAdded = false;
+
+            foreach ($uniqueTypes as $existingType) {
+                if ($type->isSame($existingType)) {
+                    $alreadyAdded = true;
+
+                    break;
+                }
+            }
+
+            if (! $alreadyAdded) {
+                $uniqueTypes[] = $type;
+            }
+        }
+
+        $types = array_values($uniqueTypes);
+
+//        $types = collect(array_values($types))
+//            ->unique(fn (Type $t) => $t->toString())
+//            ->values()
+//            ->all();
 
         if (! count($types)) {
             return new VoidType;

--- a/src/Support/Type/Union.php
+++ b/src/Support/Type/Union.php
@@ -74,7 +74,6 @@ class Union extends AbstractType
     {
         $types = Arr::wrap(...$types);
 
-
         $uniqueTypes = [];
 
         foreach (array_values($types) as $type) {
@@ -95,10 +94,10 @@ class Union extends AbstractType
 
         $types = array_values($uniqueTypes);
 
-//        $types = collect(array_values($types))
-//            ->unique(fn (Type $t) => $t->toString())
-//            ->values()
-//            ->all();
+        //        $types = collect(array_values($types))
+        //            ->unique(fn (Type $t) => $t->toString())
+        //            ->values()
+        //            ->all();
 
         if (! count($types)) {
             return new VoidType;

--- a/src/Support/Type/Union.php
+++ b/src/Support/Type/Union.php
@@ -94,11 +94,6 @@ class Union extends AbstractType
 
         $types = array_values($uniqueTypes);
 
-        //        $types = collect(array_values($types))
-        //            ->unique(fn (Type $t) => $t->toString())
-        //            ->values()
-        //            ->all();
-
         if (! count($types)) {
             return new VoidType;
         }

--- a/src/Support/Type/UnknownType.php
+++ b/src/Support/Type/UnknownType.php
@@ -10,7 +10,7 @@ class UnknownType extends AbstractType
 
     public function isSame(Type $type)
     {
-        return false;
+        return $type instanceof self;
     }
 
     public function intersect(Type $otherType): Type

--- a/src/Support/TypeToSchemaExtensions/FlattensMergeValues.php
+++ b/src/Support/TypeToSchemaExtensions/FlattensMergeValues.php
@@ -50,19 +50,8 @@ trait FlattensMergeValues
                     }
                 }
 
-                if (
-                    $item->value instanceof Union
-                    && (new TypeWalker)->first($item->value, $this->isUnionWithMissingValue(...))
-                ) {
-                    $newType = (new TypeWalker)->replace($item->value, function (Type $t) {
-                        if (! $this->isUnionWithMissingValue($t)) {
-                            return null;
-                        }
-
-                        return Union::wrap(array_values(
-                            array_filter($t->types, fn (Type $t) => ! $t->isInstanceOf(MissingValue::class))
-                        ));
-                    });
+                if ($this->isUnionWithMissingValue($item->value)) {
+                    $newType = $this->removeMissingValueFromUnion($item->value);
 
                     if ($newType instanceof VoidType) {
                         return [];
@@ -74,6 +63,8 @@ trait FlattensMergeValues
 
                     return $this->flattenMergeValues([$item]);
                 }
+
+                $item->value = $this->flattenNestedKeyedArrayValues($item->value);
 
                 if (
                     $item->value instanceof Generic
@@ -105,6 +96,27 @@ trait FlattensMergeValues
             })
             ->values()
             ->all();
+    }
+
+    private function flattenNestedKeyedArrayValues(Type $type): Type
+    {
+        return (new TypeWalker)->replace($type, function (Type $t) {
+            if (! $t instanceof KeyedArrayType) {
+                return null;
+            }
+
+            $t->items = $this->flattenMergeValues($t->items);
+            $t->isList = KeyedArrayType::checkIsList($t->items);
+
+            return $t;
+        });
+    }
+
+    private function removeMissingValueFromUnion(Union $type): Type
+    {
+        return Union::wrap(array_values(
+            array_filter($type->types, fn (Type $t) => ! $t->isInstanceOf(MissingValue::class))
+        ));
     }
 
     /**

--- a/tests/Infer/Scope/IndexTest.php
+++ b/tests/Infer/Scope/IndexTest.php
@@ -293,6 +293,12 @@ it('handles eloquent collection map call without union proliferation', function 
     expect($type->toString())->toBe('Illuminate\Database\Eloquent\Collection<int|string, int(1)>');
 });
 
+it('handles eloquent collection mapWithKeys call without union proliferation', function () {
+    $type = getStatementType('(new '.EloquentCollection::class.'())->mapWithKeys(fn () => ["foo" => 1])');
+
+    expect($type->toString())->toBe('Illuminate\Database\Eloquent\Collection<string(foo), int(1)>');
+});
+
 it('handles collection empty construct call', function () {
     $type = getStatementType('(new '.Collection::class.'([]))');
 

--- a/tests/Infer/Scope/IndexTest.php
+++ b/tests/Infer/Scope/IndexTest.php
@@ -13,6 +13,7 @@ use Dedoc\Scramble\Support\Type\Generic;
 use Dedoc\Scramble\Support\Type\IntegerType;
 use Dedoc\Scramble\Support\Type\Reference\MethodCallReferenceType;
 use Dedoc\Scramble\Support\Type\StringType;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
 
 beforeEach(function () {
@@ -284,6 +285,12 @@ it('handles collection map call', function () {
     $type = getStatementType('(new '.Collection::class.'())->map(fn () => 1)');
 
     expect($type->toString())->toBe('Illuminate\Support\Collection<int|string, int(1)>');
+});
+
+it('handles eloquent collection map call without union proliferation', function () {
+    $type = getStatementType('(new '.EloquentCollection::class.'())->map(fn () => 1)');
+
+    expect($type->toString())->toBe('Illuminate\Database\Eloquent\Collection<int|string, int(1)>');
 });
 
 it('handles collection empty construct call', function () {

--- a/tests/Infer/Services/ReferenceTypeResolverTest.php
+++ b/tests/Infer/Services/ReferenceTypeResolverTest.php
@@ -254,6 +254,11 @@ it('allows overriding types accepted by another type', function () {
 
     $def = new FunctionLikeDefinition($functionType);
 
+    FunctionLikeAstDefinitionBuilder::resolveFunctionParameterDefaults(
+        new GlobalScope,
+        $def,
+    );
+
     FunctionLikeAstDefinitionBuilder::resolveFunctionReturnReferences(
         new GlobalScope,
         $def,

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -197,6 +197,7 @@ function resolveReferences(Index $index, ReferenceTypeResolver $referenceResolve
             new ScopeContext(functionDefinition: $functionDefinition),
             new FileNameResolver(new NameContext(new Throwing)),
         );
+        FunctionLikeAstDefinitionBuilder::resolveFunctionParameterDefaults($fnScope, $functionDefinition);
         FunctionLikeAstDefinitionBuilder::resolveFunctionReturnReferences($fnScope, $functionDefinition);
     }
 
@@ -208,6 +209,7 @@ function resolveReferences(Index $index, ReferenceTypeResolver $referenceResolve
                 new ScopeContext($classDefinition, $methodDefinition),
                 new FileNameResolver(new NameContext(new Throwing)),
             );
+            FunctionLikeAstDefinitionBuilder::resolveFunctionParameterDefaults($methodScope, $methodDefinition);
             FunctionLikeAstDefinitionBuilder::resolveFunctionReturnReferences($methodScope, $methodDefinition);
         }
     }

--- a/tests/Support/Type/TypeWidenerTest.php
+++ b/tests/Support/Type/TypeWidenerTest.php
@@ -33,18 +33,6 @@ test('widens allowed key value generic collections', function (string $collectio
     Enumerable::class,
 ]);
 
-test('widens Enumerable subtype|supertype into the more specific type', function () {
-    $type = TestUtils::parseType(EloquentCollection::class.'<int, string>|'.Collection::class.'<int, string>');
-
-    expect($type->widen()->toString())->toBe(EloquentCollection::class.'<int, string>');
-});
-
-test('widens Enumerable subtype|supertype with differing templates', function () {
-    $type = TestUtils::parseType(EloquentCollection::class.'<int, string>|'.Collection::class.'<string, int>');
-
-    expect($type->widen()->toString())->toBe(EloquentCollection::class.'<int|string, string|int>');
-});
-
 test('does not widen anonymous resource collection templates as key value pairs', function () {
     $type = TestUtils::parseType(AnonymousResourceCollection::class.'<unknown, array<mixed>, App\Http\Brands\Events\Resources\EventResource>'
         .'|'.AnonymousResourceCollection::class.'<'.LengthAwarePaginator::class.', array<mixed>, App\Http\Brands\Events\Resources\EventResource>');

--- a/tests/Support/Type/TypeWidenerTest.php
+++ b/tests/Support/Type/TypeWidenerTest.php
@@ -33,6 +33,18 @@ test('widens allowed key value generic collections', function (string $collectio
     Enumerable::class,
 ]);
 
+test('widens Enumerable subtype|supertype into the more specific type', function () {
+    $type = TestUtils::parseType(EloquentCollection::class.'<int, string>|'.Collection::class.'<int, string>');
+
+    expect($type->widen()->toString())->toBe(EloquentCollection::class.'<int, string>');
+});
+
+test('widens Enumerable subtype|supertype with differing templates', function () {
+    $type = TestUtils::parseType(EloquentCollection::class.'<int, string>|'.Collection::class.'<string, int>');
+
+    expect($type->widen()->toString())->toBe(EloquentCollection::class.'<int|string, string|int>');
+});
+
 test('does not widen anonymous resource collection templates as key value pairs', function () {
     $type = TestUtils::parseType(AnonymousResourceCollection::class.'<unknown, array<mixed>, App\Http\Brands\Events\Resources\EventResource>'
         .'|'.AnonymousResourceCollection::class.'<'.LengthAwarePaginator::class.', array<mixed>, App\Http\Brands\Events\Resources\EventResource>');

--- a/tests/Support/TypeToSchemaExtensions/JsonResourceTypeToSchemaTest.php
+++ b/tests/Support/TypeToSchemaExtensions/JsonResourceTypeToSchemaTest.php
@@ -276,6 +276,71 @@ class JsonResourceTypeToSchemaTest_WithDefault extends JsonResource
     }
 }
 
+it('keeps collection union properties required while flattening nested missing values', function () {
+    $type = new Generic(JsonResourceTypeToSchemaTest_WithCollectionUnionMissingValue::class, [new UnknownType]);
+
+    $extension = new JsonResourceTypeToSchema($this->infer, $this->transformer, $this->context->openApi->components, $this->context);
+
+    expect($extension->toSchema($type)->toArray())->toEqual([
+        'type' => 'object',
+        'properties' => [
+            'planned_matches' => [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'event' => [
+                            'type' => 'array',
+                            'items' => (object) [],
+                        ],
+                    ],
+                ],
+            ],
+            'eloquent_planned_matches' => [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'event' => [
+                            'type' => 'array',
+                            'items' => (object) [],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        'required' => ['planned_matches', 'eloquent_planned_matches'],
+    ]);
+});
+class JsonResourceTypeToSchemaTest_WithCollectionUnionMissingValue extends JsonResource
+{
+    public function toArray(Request $request)
+    {
+        return [
+            'planned_matches' => unknown()
+                ? $this->supportPlannedMatches()
+                : $this->eloquentPlannedMatches(),
+            'eloquent_planned_matches' => $this->eloquentPlannedMatches(),
+        ];
+    }
+
+    /**
+     * @scramble-return \Illuminate\Support\Collection<int, array{event: array<mixed>|\Illuminate\Http\Resources\MissingValue}>
+     */
+    private function supportPlannedMatches()
+    {
+        return new \Illuminate\Support\Collection;
+    }
+
+    /**
+     * @scramble-return \Illuminate\Database\Eloquent\Collection<int, array{event: array<mixed>|\Illuminate\Http\Resources\MissingValue}>
+     */
+    private function eloquentPlannedMatches()
+    {
+        return new \Illuminate\Database\Eloquent\Collection;
+    }
+}
+
 it('handles additional data with custom status code', function () {
     $openApiDocument = generateForRoute(function () {
         return Route::get('api/test', [JsonResourceTypeToSchemaTest_AdditionalController::class, 'index']);


### PR DESCRIPTION
- Updated union uniqueness check to work without casting them to strings
- Added caching for type -> JSON schema transformer
- Do not traverse type multiple times (type traverser)
- Template lookup caching
- Reference resolver avoids recursive re-resolution
- Avoiding Eloquent collection union explosion