### PR TITLE
Improve inference by dropping type of calls to non-existing methods in unions, added `newCollection` support

### DIFF
--- a/src/Infer/Definition/ClassDefinition.php
+++ b/src/Infer/Definition/ClassDefinition.php
@@ -374,7 +374,10 @@ class ClassDefinition implements ClassDefinitionContract
             if ($definition = $this->getIndex()->getClass($type->name)) {
                 foreach ($definition->templateTypes as $i => $templateType) {
                     $concreteType = (new TypeWalker)->map(
-                        $type->templateTypes[$i] ?? $templateType->default ?? new UnknownType,
+                        $type->templateTypes[$i]
+                            ?? $this->templateTypes[$i]
+                            ?? $templateType->default
+                            ?? new UnknownType,
                         fn ($t) => $t instanceof ObjectType ? $classTemplatesByName->get($t->name, $t) : $t,
                     );
 

--- a/src/Infer/Services/ReferenceTypeResolver.php
+++ b/src/Infer/Services/ReferenceTypeResolver.php
@@ -218,7 +218,7 @@ class ReferenceTypeResolver
             }
 
             if (! $methodDefinition = $calleeType->getMethodDefinition($type->methodName, $scope)) {
-                return new UnknownType("Cannot get a method type [$type->methodName] on type [$calleeType->name]");
+                return $this->unreachable("Cannot get a method type [$type->methodName] on type [$calleeType->name]");
             }
 
             $resultingType = $this->getFunctionCallResult($methodDefinition, new AutoResolvingArgumentTypeBag($scope, $type->arguments), $calleeType);
@@ -284,7 +284,7 @@ class ReferenceTypeResolver
         }
 
         if (! $methodDefinition = $calleeDefinition->getMethodDefinition($type->methodName, $scope)) {
-            return new UnknownType("Cannot get a method type [$type->methodName] on type [$contextualClassName]");
+            return $this->unreachable("Cannot get a method type [$type->methodName] on type [$contextualClassName]");
         }
 
         return $this->finalizeStatic(
@@ -642,5 +642,10 @@ class ReferenceTypeResolver
             StaticReference::STATIC => $scope->context->classDefinition?->name,
             StaticReference::PARENT => $scope->context->classDefinition?->parentFqn,
         };
+    }
+
+    private function unreachable(string $error): NeverType
+    {
+        return tap(new NeverType, fn (NeverType $t) => $t->setAttribute('error', $error));
     }
 }

--- a/src/Infer/Services/ReferenceTypeResolver.php
+++ b/src/Infer/Services/ReferenceTypeResolver.php
@@ -237,7 +237,7 @@ class ReferenceTypeResolver
             }
 
             if (! $methodDefinition = $calleeType->getMethodDefinition($type->methodName, $scope)) {
-                return $this->unreachable("Cannot get a method type [$type->methodName] on type [$calleeType->name]");
+                return new NeverType;
             }
 
             $resultingType = $this->getFunctionCallResult($methodDefinition, new AutoResolvingArgumentTypeBag($scope, $type->arguments), $calleeType);
@@ -303,7 +303,7 @@ class ReferenceTypeResolver
         }
 
         if (! $methodDefinition = $calleeDefinition->getMethodDefinition($type->methodName, $scope)) {
-            return $this->unreachable("Cannot get a method type [$type->methodName] on type [$contextualClassName]");
+            return new NeverType;
         }
 
         return $this->finalizeStatic(
@@ -665,10 +665,5 @@ class ReferenceTypeResolver
             StaticReference::STATIC => $scope->context->classDefinition?->name,
             StaticReference::PARENT => $scope->context->classDefinition?->parentFqn,
         };
-    }
-
-    private function unreachable(string $error): NeverType
-    {
-        return tap(new NeverType, fn (NeverType $t) => $t->setAttribute('error', $error));
     }
 }

--- a/src/Infer/Services/ReferenceTypeResolver.php
+++ b/src/Infer/Services/ReferenceTypeResolver.php
@@ -90,6 +90,23 @@ class ReferenceTypeResolver
         return $resolved;
     }
 
+    /**
+     * When a parent method returns `static`, chained calls on that value must still resolve
+     * methods on the current class (late static binding), without widening the return type.
+     */
+    private function resolveStaticCalleeForMethodLookup(Scope $scope, Type $calleeType): Type
+    {
+        if (
+            $calleeType instanceof ObjectType
+            && $calleeType->name === StaticReference::STATIC
+            && $scope->context->classDefinition
+        ) {
+            return new SelfType($scope->context->classDefinition->name);
+        }
+
+        return $calleeType;
+    }
+
     private function finalizeStatic(Type $type, Type $staticType): Type
     {
         return (new TypeWalker)->map($type, function (Type $t) use ($staticType) {
@@ -173,6 +190,8 @@ class ReferenceTypeResolver
             : [$calleeType];
 
         return Union::wrap(array_map(function (Type $calleeType) use ($scope, $type, $arguments) {
+            $calleeType = $this->resolveStaticCalleeForMethodLookup($scope, $calleeType);
+
             $classDefinition = $calleeType instanceof ObjectType
                 ? $this->index->getClass($calleeType->name)
                 : null;
@@ -426,6 +445,8 @@ class ReferenceTypeResolver
             : [$callee];
 
         return Union::wrap(array_map(function (Type $callee) use ($scope, $type, $arguments) {
+            $callee = $this->resolveStaticCalleeForMethodLookup($scope, $callee);
+
             if (! $callee instanceof Generic) {
                 return $callee;
             }
@@ -476,6 +497,8 @@ class ReferenceTypeResolver
             : [$objectType];
 
         return Union::wrap(array_map(function (Type $objectType) use ($scope, $type) {
+            $objectType = $this->resolveStaticCalleeForMethodLookup($scope, $objectType);
+
             if ($objectType instanceof MixedType) {
                 return new UnknownType;
             }

--- a/src/Support/InferExtensions/EloquentBuilderExtension.php
+++ b/src/Support/InferExtensions/EloquentBuilderExtension.php
@@ -21,7 +21,7 @@ class EloquentBuilderExtension implements MethodReturnTypeExtension
     public function getMethodReturnType(MethodCallEvent $event): ?Type
     {
         if ($event->getDefinition()->hasMethodDefinition($event->getName())) {
-            return null;
+            return $this->handleExistingMethodReturnType($event);
         }
 
         if ($this->shouldForwardCallToModel($event)) {
@@ -39,6 +39,16 @@ class EloquentBuilderExtension implements MethodReturnTypeExtension
         }
 
         return null;
+    }
+
+    private function handleExistingMethodReturnType(MethodCallEvent $event): ?Type
+    {
+        return match ($event->getName()) {
+            'get' => ($modelType = $this->getModelType($event->getInstance()))
+                ? ModelCollectionTypeResolver::resolve($modelType)
+                : null,
+            default => null,
+        };
     }
 
     private function shouldForwardCallToModel(MethodCallEvent $event): bool

--- a/src/Support/InferExtensions/ModelCollectionTypeResolver.php
+++ b/src/Support/InferExtensions/ModelCollectionTypeResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Dedoc\Scramble\Support\InferExtensions;
+
+use Dedoc\Scramble\Infer\Scope\GlobalScope;
+use Dedoc\Scramble\Infer\Services\ReferenceTypeResolver;
+use Dedoc\Scramble\Support\Type\ArrayType;
+use Dedoc\Scramble\Support\Type\ObjectType;
+use Dedoc\Scramble\Support\Type\Reference\NewCallReferenceType;
+use Dedoc\Scramble\Support\Type\Type;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Throwable;
+
+class ModelCollectionTypeResolver
+{
+    public static function resolve(ObjectType $modelType): Type
+    {
+        return ReferenceTypeResolver::getInstance()->resolve(
+            new GlobalScope,
+            new NewCallReferenceType(
+                static::resolveClass($modelType->name),
+                [new ArrayType($modelType)],
+            ),
+        );
+    }
+
+    public static function resolveClass(string $modelClass): string
+    {
+        try {
+            $reflectionMethod = new \ReflectionMethod($modelClass, 'newCollection');
+
+            if ($reflectionMethod->getDeclaringClass()->getName() === Model::class) {
+                return EloquentCollection::class;
+            }
+
+            /** @var Model $model */
+            $model = app($modelClass);
+
+            return get_class($model->newCollection([]));
+        } catch (Throwable) {
+            return EloquentCollection::class;
+        }
+    }
+}

--- a/src/Support/InferExtensions/ModelExtension.php
+++ b/src/Support/InferExtensions/ModelExtension.php
@@ -27,7 +27,6 @@ use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
 use Dedoc\Scramble\Support\Type\NullType;
 use Dedoc\Scramble\Support\Type\ObjectType;
 use Dedoc\Scramble\Support\Type\Reference\MethodCallReferenceType;
-use Dedoc\Scramble\Support\Type\Reference\NewCallReferenceType;
 use Dedoc\Scramble\Support\Type\Reference\StaticMethodCallReferenceType;
 use Dedoc\Scramble\Support\Type\StringType;
 use Dedoc\Scramble\Support\Type\TemplateType;

--- a/src/Support/InferExtensions/ModelExtension.php
+++ b/src/Support/InferExtensions/ModelExtension.php
@@ -27,6 +27,7 @@ use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
 use Dedoc\Scramble\Support\Type\NullType;
 use Dedoc\Scramble\Support\Type\ObjectType;
 use Dedoc\Scramble\Support\Type\Reference\MethodCallReferenceType;
+use Dedoc\Scramble\Support\Type\Reference\NewCallReferenceType;
 use Dedoc\Scramble\Support\Type\Reference\StaticMethodCallReferenceType;
 use Dedoc\Scramble\Support\Type\StringType;
 use Dedoc\Scramble\Support\Type\TemplateType;
@@ -170,34 +171,13 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
         return $type;
     }
 
-    private function getRelationType(array $relation)
+    private function getRelationType(array $relation): Type
     {
         if ($isManyRelation = Str::contains($relation['type'], 'Many')) {
-            return new Generic(
-                $this->getCollectionClassForModel($relation['related']),
-                [new IntegerType, new ObjectType($relation['related'])]
-            );
+            return ModelCollectionTypeResolver::resolve(new ObjectType($relation['related']));
         }
 
         return new ObjectType($relation['related']);
-    }
-
-    private function getCollectionClassForModel(string $modelClass): string
-    {
-        try {
-            $reflectionMethod = new \ReflectionMethod($modelClass, 'newCollection');
-
-            if ($reflectionMethod->getDeclaringClass()->getName() === Model::class) {
-                return \Illuminate\Database\Eloquent\Collection::class;
-            }
-
-            /** @var Model $model */
-            $model = app($modelClass);
-
-            return get_class($model->newCollection([]));
-        } catch (Throwable) {
-            return \Illuminate\Database\Eloquent\Collection::class;
-        }
     }
 
     protected function getToArrayMethodReturnType(MethodCallEvent $event): ?Type
@@ -343,7 +323,10 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
 
     public function getStaticMethodReturnType(StaticMethodCallEvent $event): ?Type
     {
-        return $this->maybeProxyMethodCallToBuilder($event);
+        return match ($event->name) {
+            'all' => ModelCollectionTypeResolver::resolve(new ObjectType($event->callee)),
+            default => $this->maybeProxyMethodCallToBuilder($event),
+        };
     }
 
     private function maybeProxyMethodCallToBuilder(MethodCallEvent|StaticMethodCallEvent $event): ?Type

--- a/src/Support/InferExtensions/ModelExtension.php
+++ b/src/Support/InferExtensions/ModelExtension.php
@@ -174,12 +174,30 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
     {
         if ($isManyRelation = Str::contains($relation['type'], 'Many')) {
             return new Generic(
-                \Illuminate\Database\Eloquent\Collection::class,
+                $this->getCollectionClassForModel($relation['related']),
                 [new IntegerType, new ObjectType($relation['related'])]
             );
         }
 
         return new ObjectType($relation['related']);
+    }
+
+    private function getCollectionClassForModel(string $modelClass): string
+    {
+        try {
+            $reflectionMethod = new \ReflectionMethod($modelClass, 'newCollection');
+
+            if ($reflectionMethod->getDeclaringClass()->getName() === Model::class) {
+                return \Illuminate\Database\Eloquent\Collection::class;
+            }
+
+            /** @var Model $model */
+            $model = app($modelClass);
+
+            return get_class($model->newCollection([]));
+        } catch (Throwable) {
+            return \Illuminate\Database\Eloquent\Collection::class;
+        }
     }
 
     protected function getToArrayMethodReturnType(MethodCallEvent $event): ?Type

--- a/tests/Infer/ClassDefinitionTest.php
+++ b/tests/Infer/ClassDefinitionTest.php
@@ -194,6 +194,40 @@ it('understands method calls type', function () {
     expect($type->methods['bar']->type->toString())->toBe('(): int(1)');
 });
 
+it('infers return type for custom eloquent collection methods that chain other methods', function () {
+    $def = analyzeFile(__DIR__.'/files/custom_collection_chain.php')
+        ->getClassDefinition('CustomCollectionChainTest_Collection');
+
+    expect($def->methods['published']->getReturnType()->toString())
+        ->toBe('static')
+        ->and($def->methods['publishedFeatured']->getReturnType()->toString())
+        ->toBe('static');
+});
+
+it('binds parent collection template at same index when child uses a different template name', function () {
+    Scramble::infer()
+        ->configure()
+        ->buildDefinitionsUsingReflectionFor([
+            ParentWithTvalue_ClassDefinitionTest::class,
+        ]);
+
+    $def = app(Index::class)->getClass(ChildWithTmodel_ClassDefinitionTest::class);
+
+    expect($def->getMethod('first')->getReturnType()->toString())
+        ->toBe('TValue');
+});
+/**
+ * @template TKey
+ * @template TValue
+ */
+class ParentWithTvalue_ClassDefinitionTest
+{
+    /** @return TValue */
+    public function first() {}
+}
+
+class ChildWithTmodel_ClassDefinitionTest extends ParentWithTvalue_ClassDefinitionTest {}
+
 it('infers templated property fetch type', function () {
     $type = analyzeFile(__DIR__.'/files/class_with_property_fetch_in_method.php')
         ->getClassDefinition('Foo');

--- a/tests/Infer/ReferenceResolutionTest.php
+++ b/tests/Infer/ReferenceResolutionTest.php
@@ -234,7 +234,7 @@ class Bar {
 }
 EOD)->getClassDefinition('Foo');
 
-    expect($type->methods['foo']->type->toString())->toBe('(): unknown');
+    expect($type->methods['foo']->type->toString())->toBe('(): never');
 });
 
 it('detects indirect calls cyclic reference', function () {

--- a/tests/Infer/ReferenceTypesTest.php
+++ b/tests/Infer/ReferenceTypesTest.php
@@ -139,7 +139,7 @@ class Foo {
 }
 EOD)->getClassDefinition('Foo');
 
-    expect($type->methods['foo']->type->toString())->toBe('(): list{int(2), unknown}');
+    expect($type->methods['foo']->type->toString())->toBe('(): list{int(2), never}');
 });
 
 it('resolves a deep reference when encountered in self class', function () {

--- a/tests/Infer/Services/ReferenceTypeResolverTest.php
+++ b/tests/Infer/Services/ReferenceTypeResolverTest.php
@@ -18,6 +18,9 @@ use Dedoc\Scramble\Support\Type\StringType;
 use Dedoc\Scramble\Support\Type\TemplateType;
 use Dedoc\Scramble\Support\Type\Type;
 use Dedoc\Scramble\Support\Type\Union;
+use Dedoc\Scramble\Tests\Files\SampleUserModel;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 beforeEach(function () {
     $this->index = app(Index::class);
@@ -87,6 +90,39 @@ it('support method calls on unions with null', function () {
 
     expect($result->toString())->toBe('string(bar)');
 });
+
+it('prunes union members when method does not exist on known class', function () {
+    $type = getStatementType(
+        '(new '.ReferenceTypeResolverUnionServiceTest::class.'())->get(true)->orderBy("name")'
+    );
+
+    expect($type->toString())->toBe(
+        'Illuminate\Database\Eloquent\Builder<'.SampleUserModel::class.'>'
+    );
+});
+
+it('infers paginator type through union service builder chain', function () {
+    $type = getStatementType(
+        '(new '.ReferenceTypeResolverUnionServiceTest::class.'())->get(true)->orderBy("name")->paginate(4)'
+    );
+
+    expect($type->toString())->toBe(
+        'Illuminate\Pagination\LengthAwarePaginator<int, '.SampleUserModel::class.'>'
+    );
+});
+
+class ReferenceTypeResolverUnionServiceTest
+{
+    /**
+     * @return (Builder<SampleUserModel>|EloquentCollection<int, SampleUserModel>)
+     */
+    public function get(bool $toBuilder): Builder|EloquentCollection
+    {
+        $query = SampleUserModel::query();
+
+        return $toBuilder ? $query : $query->get();
+    }
+}
 
 /*
  * Callable calls

--- a/tests/Infer/files/custom_collection_chain.php
+++ b/tests/Infer/files/custom_collection_chain.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Eloquent\Collection;
+
+class CustomCollectionChainTest_Collection extends Collection
+{
+    public function published()
+    {
+        return $this->whereNotNull('published_at');
+    }
+
+    public function featured()
+    {
+        return $this->where('is_featured', 1);
+    }
+
+    public function publishedFeatured()
+    {
+        return $this->where('is_featured', 1)->where('is_featured', 1)->where('is_featured', 1);
+    }
+}

--- a/tests/Infer/files/custom_collection_chain.php
+++ b/tests/Infer/files/custom_collection_chain.php
@@ -16,6 +16,6 @@ class CustomCollectionChainTest_Collection extends Collection
 
     public function publishedFeatured()
     {
-        return $this->where('is_featured', 1)->where('is_featured', 1)->where('is_featured', 1);
+        return $this->featured()->published()->where('is_featured', 1)->where('is_featured', 1)->where('is_featured', 1);
     }
 }

--- a/tests/InferExtensions/ModelExtensionTest.php
+++ b/tests/InferExtensions/ModelExtensionTest.php
@@ -193,3 +193,31 @@ it('toResource returns instance of explicitly passed resource class', function (
 
     expect($type->toString())->toBe(ModelExtensionTest_AttributeResource::class.'<'.SampleUserModel::class.'>');
 })->skip(fn () => ! method_exists(Model::class, 'toResource'));
+
+class Foo_ModelExtensionTest extends Model
+{
+    public function newCollection(array $models = [])
+    {
+        return new FooCollection_ModelExtensionTest($models);
+    }
+}
+
+class FooCollection_ModelExtensionTest extends \Illuminate\Database\Eloquent\Collection {}
+
+class Bar_ModelExtensionTest extends Model
+{
+    public function foos()
+    {
+        return $this->hasMany(Foo_ModelExtensionTest::class);
+    }
+}
+
+it('uses custom collection type from newCollection for hasMany relations', function () {
+    $this->infer->analyzeClass(Foo_ModelExtensionTest::class);
+    $this->infer->analyzeClass(Bar_ModelExtensionTest::class);
+
+    $object = new ObjectType(Bar_ModelExtensionTest::class);
+
+    expect($object->getPropertyType('foos')->toString())
+        ->toBe(FooCollection_ModelExtensionTest::class.'<int, '.Foo_ModelExtensionTest::class.'>');
+});

--- a/tests/InferExtensions/ModelExtensionTest.php
+++ b/tests/InferExtensions/ModelExtensionTest.php
@@ -221,3 +221,33 @@ it('uses custom collection type from newCollection for hasMany relations', funct
     expect($object->getPropertyType('foos')->toString())
         ->toBe(FooCollection_ModelExtensionTest::class.'<int, '.Foo_ModelExtensionTest::class.'>');
 });
+
+it('uses custom collection type from newCollection for query get', function () {
+    $this->infer->analyzeClass(Foo_ModelExtensionTest::class);
+
+    $type = ReferenceTypeResolver::getInstance()
+        ->resolve(
+            new Infer\Scope\GlobalScope,
+            new MethodCallReferenceType(
+                new MethodCallReferenceType(
+                    new ObjectType(Foo_ModelExtensionTest::class),
+                    'query',
+                    []
+                ),
+                'get',
+                []
+            )
+        );
+
+    expect($type->toString())
+        ->toBe(FooCollection_ModelExtensionTest::class.'<int, '.Foo_ModelExtensionTest::class.'>');
+});
+
+it('uses custom collection type from newCollection for all', function () {
+    $this->infer->analyzeClass(Foo_ModelExtensionTest::class);
+
+    $type = getStatementType(Foo_ModelExtensionTest::class.'::all()');
+
+    expect($type->toString())
+        ->toBe(FooCollection_ModelExtensionTest::class.'<int, '.Foo_ModelExtensionTest::class.'>');
+});

--- a/tests/Support/TypeToSchemaExtensions/AnonymousResourceCollectionTypeToSchemaTest.php
+++ b/tests/Support/TypeToSchemaExtensions/AnonymousResourceCollectionTypeToSchemaTest.php
@@ -48,6 +48,42 @@ it('documents inferred pagination response', function () {
         ->and($schema['properties'])
         ->toHaveKeys(['data', 'meta', 'links']);
 });
+
+it('documents paginated response from service builder union chain', function () {
+    $openApiDocument = generateForRoute(fn () => Route::get('test', ServiceBuilderPagination_AnonymousResourceCollectionTypeToSchemaTestController::class));
+
+    expect($responses = $openApiDocument['paths']['/test']['get']['responses'])
+        ->toHaveKey(200)
+        ->and($schema = $responses[200]['content']['application/json']['schema'])
+        ->toHaveKeys(['type', 'properties'])
+        ->and($schema['properties'])
+        ->toHaveKeys(['data', 'meta', 'links']);
+});
+class ServiceBuilderPagination_AnonymousResourceCollectionTypeToSchemaTestController
+{
+    public function __invoke()
+    {
+        return UserResource_AnonymousResourceCollectionTypeToSchemaTest::collection(
+            (new UserService_AnonymousResourceCollectionTypeToSchemaTest)
+                ->getByName('Test', true)
+                ->orderBy('name')
+                ->orderBy('id')
+                ->paginate(4)
+        );
+    }
+}
+class UserService_AnonymousResourceCollectionTypeToSchemaTest
+{
+    /**
+     * @return (\Illuminate\Database\Eloquent\Builder<User_AnonymousResourceCollectionTypeToSchemaTest>|Illuminate\Database\Eloquent\Collection<int, User_AnonymousResourceCollectionTypeToSchemaTest>)
+     */
+    public function getByName(string $name, bool $toBuilder = false): \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Collection
+    {
+        $query = User_AnonymousResourceCollectionTypeToSchemaTest::query()->where('name', '=', $name);
+
+        return $toBuilder ? $query : $query->get();
+    }
+}
 class InferredPagination_AnonymousResourceCollectionTypeToSchemaTestController
 {
     public function __invoke()


### PR DESCRIPTION
fixes #1169
