### PR TITLE
Add IgnoreParam attribute support

### DIFF
--- a/src/Attributes/IgnoreParam.php
+++ b/src/Attributes/IgnoreParam.php
@@ -8,7 +8,7 @@ use Attribute;
 class IgnoreParam
 {
     /**
-     * @param  'query'|'body'|null  $in
+     * @param  'query'|'path'|'header'|'cookie'|'body'|null  $in
      */
     public function __construct(
         public readonly string $name,

--- a/src/Attributes/IgnoreParam.php
+++ b/src/Attributes/IgnoreParam.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Dedoc\Scramble\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_FUNCTION)]
+class IgnoreParam
+{
+    /**
+     * @param  'query'|'body'|null  $in
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly ?string $in = null,
+    ) {}
+}

--- a/src/Support/OperationExtensions/ParameterExtractor/AttributesParametersExtractor.php
+++ b/src/Support/OperationExtensions/ParameterExtractor/AttributesParametersExtractor.php
@@ -3,6 +3,7 @@
 namespace Dedoc\Scramble\Support\OperationExtensions\ParameterExtractor;
 
 use Dedoc\Scramble\Attributes\Example;
+use Dedoc\Scramble\Attributes\IgnoreParam;
 use Dedoc\Scramble\Attributes\MissingValue;
 use Dedoc\Scramble\Attributes\Parameter as ParameterAttribute;
 use Dedoc\Scramble\PhpDoc\PhpDocTypeHelper;
@@ -32,9 +33,15 @@ class AttributesParametersExtractor implements ParameterExtractor
             return $parameterExtractionResults;
         }
 
+        $ignoredParameters = collect($reflectionAction->getAttributes(IgnoreParam::class, ReflectionAttribute::IS_INSTANCEOF))
+            ->values()
+            ->map(fn (ReflectionAttribute $ra) => $ra->newInstance())
+            ->all();
+
         $parameters = collect($reflectionAction->getAttributes(ParameterAttribute::class, ReflectionAttribute::IS_INSTANCEOF))
             ->values()
             ->map(fn (ReflectionAttribute $ra) => $this->createParameter($parameterExtractionResults, $ra->newInstance(), $ra->getArguments()))
+            ->reject(fn (Parameter $p) => $this->shouldIgnoreParameter($p, $ignoredParameters))
             ->all();
 
         $extractedAttributes = collect($parameters)->map(fn ($p) => "$p->name.$p->in")->all();
@@ -50,6 +57,7 @@ class AttributesParametersExtractor implements ParameterExtractor
             }
 
             $automaticallyExtractedParameters->parameters = collect($automaticallyExtractedParameters->parameters)
+                ->reject(fn (Parameter $p) => $this->shouldIgnoreParameter($p, $ignoredParameters))
                 ->filter(fn (Parameter $p) => ! in_array("$p->name.$p->in", $extractedAttributes))
                 ->values()
                 ->all();
@@ -66,9 +74,22 @@ class AttributesParametersExtractor implements ParameterExtractor
 
         $reflection = new ReflectionClass($parameterExtractionResult->sourceClass);
 
+        $ignoredParameters = collect($reflection->getAttributes(IgnoreParam::class, ReflectionAttribute::IS_INSTANCEOF))
+            ->values()
+            ->map(fn (ReflectionAttribute $ra) => $ra->newInstance())
+            ->all();
+
+        if ($ignoredParameters) {
+            $parameterExtractionResult->parameters = collect($parameterExtractionResult->parameters)
+                ->reject(fn (Parameter $p) => $this->shouldIgnoreParameter($p, $ignoredParameters))
+                ->values()
+                ->all();
+        }
+
         $attrs = collect($reflection->getAttributes(ParameterAttribute::class, ReflectionAttribute::IS_INSTANCEOF))
             ->values()
             ->map(fn (ReflectionAttribute $ra) => $this->createParameter([$parameterExtractionResult], $ra->newInstance(), $ra->getArguments()))
+            ->reject(fn (Parameter $p) => $this->shouldIgnoreParameter($p, $ignoredParameters))
             ->keyBy(fn (Parameter $p) => "$p->name.$p->in")
             ->all();
 
@@ -218,5 +239,27 @@ class AttributesParametersExtractor implements ParameterExtractor
                 return [$name => $value];
             })
             ->all();
+    }
+
+    /**
+     * @param  IgnoreParam[]  $ignoredParameters
+     */
+    private function shouldIgnoreParameter(Parameter $parameter, array $ignoredParameters): bool
+    {
+        foreach ($ignoredParameters as $ignoredParameter) {
+            if ($ignoredParameter->name !== $parameter->name) {
+                continue;
+            }
+
+            if ($ignoredParameter->in) {
+                return $ignoredParameter->in === $parameter->in;
+            }
+
+            if (in_array($parameter->in, ['body', 'query'], true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Attributes/ParameterAnnotationsTest.php
+++ b/tests/Attributes/ParameterAnnotationsTest.php
@@ -5,6 +5,7 @@ namespace Dedoc\Scramble\Tests\Attributes;
 use Dedoc\Scramble\Attributes\BodyParameter;
 use Dedoc\Scramble\Attributes\Example;
 use Dedoc\Scramble\Attributes\HeaderParameter;
+use Dedoc\Scramble\Attributes\IgnoreParam;
 use Dedoc\Scramble\Attributes\Parameter;
 use Dedoc\Scramble\Attributes\PathParameter;
 use Dedoc\Scramble\Attributes\QueryParameter;
@@ -304,4 +305,159 @@ class OverrideFormRequestParamController_ParameterAnnotationsTest
 {
     #[BodyParameter('name', 'From Controller')]
     public function __invoke(OverrideFormRequestParamFormRequest_ParameterAnnotationsTest $request) {}
+}
+
+it('ignores action-level validated body parameters using IgnoreParam attribute', function () {
+    $openApi = generateForRoute(fn (Router $r) => $r->post('api/test', IgnoreValidatedBodyParameterController_ParameterAnnotationsTest::class));
+
+    expect($openApi['paths']['/test']['post']['requestBody']['content']['application/json']['schema']['properties'] ?? [])
+        ->toBeEmpty();
+});
+class IgnoreValidatedBodyParameterController_ParameterAnnotationsTest
+{
+    #[IgnoreParam('foo')]
+    public function __invoke(Request $request)
+    {
+        $request->validate(['foo' => 'integer']);
+    }
+}
+
+it('ignores action-level request retrieval body parameters using IgnoreParam attribute', function () {
+    $openApi = generateForRoute(fn (Router $r) => $r->post('api/test', IgnoreRequestRetrievalBodyParameterController_ParameterAnnotationsTest::class));
+
+    expect($openApi['paths']['/test']['post']['requestBody']['content']['application/json']['schema']['properties'] ?? [])
+        ->toBeEmpty();
+});
+class IgnoreRequestRetrievalBodyParameterController_ParameterAnnotationsTest
+{
+    #[IgnoreParam('foo')]
+    public function __invoke(Request $request)
+    {
+        $request->integer('foo');
+    }
+}
+
+it('does not ignore unrelated action-level inferred parameters', function () {
+    $openApi = generateForRoute(fn (Router $r) => $r->post('api/test', IgnoreMissingBodyParameterController_ParameterAnnotationsTest::class));
+
+    expect($openApi['paths']['/test']['post']['requestBody']['content']['application/json']['schema']['properties'])
+        ->toHaveKey('foo');
+});
+class IgnoreMissingBodyParameterController_ParameterAnnotationsTest
+{
+    #[IgnoreParam('missing')]
+    public function __invoke(Request $request)
+    {
+        $request->validate(['foo' => 'integer']);
+    }
+}
+
+it('keeps path parameters when ignoring same-name action-level query parameters', function () {
+    $openApi = generateForRoute(fn (Router $r) => $r->get('api/test/{foo}', IgnoreSameNameQueryParameterController_ParameterAnnotationsTest::class));
+
+    expect($openApi['paths']['/test/{foo}']['get']['parameters'])
+        ->toHaveCount(1)
+        ->and($openApi['paths']['/test/{foo}']['get']['parameters'][0]['name'])->toBe('foo')
+        ->and($openApi['paths']['/test/{foo}']['get']['parameters'][0]['in'])->toBe('path');
+});
+class IgnoreSameNameQueryParameterController_ParameterAnnotationsTest
+{
+    #[IgnoreParam('foo')]
+    public function __invoke(Request $request, string $foo)
+    {
+        $request->validate(['foo' => 'integer']);
+    }
+}
+
+it('ignores FormRequest body parameters using class-level IgnoreParam attribute', function () {
+    $openApi = generateForRoute(fn (Router $r) => $r->post('api/test', IgnoreFormRequestBodyParameterController_ParameterAnnotationsTest::class));
+
+    expect($openApi['components']['schemas']['IgnoreFormRequestBodyParameterFormRequest_ParameterAnnotationsTest']['properties'])
+        ->toHaveKey('visible')
+        ->not->toHaveKey('secret');
+});
+#[IgnoreParam('secret')]
+class IgnoreFormRequestBodyParameterFormRequest_ParameterAnnotationsTest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['secret' => ['required', 'string'], 'visible' => ['required', 'string']];
+    }
+}
+class IgnoreFormRequestBodyParameterController_ParameterAnnotationsTest
+{
+    public function __invoke(IgnoreFormRequestBodyParameterFormRequest_ParameterAnnotationsTest $request) {}
+}
+
+it('ignores FormRequest query parameters using class-level IgnoreParam attribute', function () {
+    $openApi = generateForRoute(fn (Router $r) => $r->get('api/test', IgnoreFormRequestQueryParameterController_ParameterAnnotationsTest::class));
+
+    $parameterNames = collect($openApi['paths']['/test']['get']['parameters'])->pluck('name')->all();
+
+    expect($parameterNames)
+        ->toContain('visible')
+        ->not->toContain('search');
+});
+#[IgnoreParam('search')]
+class IgnoreFormRequestQueryParameterFormRequest_ParameterAnnotationsTest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['search' => ['nullable', 'string'], 'visible' => ['nullable', 'string']];
+    }
+}
+class IgnoreFormRequestQueryParameterController_ParameterAnnotationsTest
+{
+    public function __invoke(IgnoreFormRequestQueryParameterFormRequest_ParameterAnnotationsTest $request) {}
+}
+
+it('does not apply FormRequest IgnoreParam attributes to other request classes', function () {
+    $openApi = generateForRoute(function (Router $r) {
+        $r->post('api/ignored', IgnoreScopedFormRequestController_ParameterAnnotationsTest::class);
+        $r->post('api/visible', VisibleScopedFormRequestController_ParameterAnnotationsTest::class);
+    });
+
+    expect($openApi['components']['schemas']['IgnoreScopedFormRequest_ParameterAnnotationsTest']['properties'])
+        ->not->toHaveKey('secret')
+        ->and($openApi['components']['schemas']['VisibleScopedFormRequest_ParameterAnnotationsTest']['properties'])
+        ->toHaveKey('secret');
+});
+#[IgnoreParam('secret')]
+class IgnoreScopedFormRequest_ParameterAnnotationsTest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['secret' => ['required', 'string']];
+    }
+}
+class VisibleScopedFormRequest_ParameterAnnotationsTest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['secret' => ['required', 'string']];
+    }
+}
+class IgnoreScopedFormRequestController_ParameterAnnotationsTest
+{
+    public function __invoke(IgnoreScopedFormRequest_ParameterAnnotationsTest $request) {}
+}
+class VisibleScopedFormRequestController_ParameterAnnotationsTest
+{
+    public function __invoke(VisibleScopedFormRequest_ParameterAnnotationsTest $request) {}
+}
+
+it('lets IgnoreParam win over matching parameter metadata attributes', function () {
+    $openApi = generateForRoute(fn (Router $r) => $r->post('api/test', IgnoreParamWinsOverMetadataController_ParameterAnnotationsTest::class));
+
+    expect($openApi['paths']['/test']['post']['requestBody']['content']['application/json']['schema']['properties'] ?? [])
+        ->toBeEmpty();
+});
+class IgnoreParamWinsOverMetadataController_ParameterAnnotationsTest
+{
+    #[IgnoreParam('foo')]
+    #[BodyParameter('foo', 'Hidden field')]
+    public function __invoke(Request $request)
+    {
+        $request->validate(['foo' => 'integer']);
+    }
 }


### PR DESCRIPTION
## Overview

Adds an `IgnoreParam` PHP attribute that can hide inferred request parameters from generated OpenAPI docs. It works on controller actions, invokable controllers, route closures, and FormRequest classes.

## Why

Scramble already supports `@ignoreParam` in PHPDoc, but attributes are a better fit for projects that prefer native PHP metadata. This keeps the existing annotation behavior while providing the same practical control through an attribute.

## Examples

```php
#[IgnoreParam('secret')]
public function store(Request $request) {}
```

```php
#[IgnoreParam('secret')]
class StoreUserRequest extends FormRequest {}
```