### PR TITLE
Add ability to cache OpenAPI document

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -31,6 +31,16 @@ return [
      */
     'export_path' => 'api.json',
 
+    /*
+     * Cache configuration for the generated OpenAPI document.
+     *
+     * Use `scramble:cache` to warm the cache and `scramble:clear` to invalidate it.
+     */
+    'cache' => [
+        'key' => 'scramble.openapi',
+        'store' => 'file',
+    ],
+
     'info' => [
         /*
          * API version.

--- a/src/CacheableGenerator.php
+++ b/src/CacheableGenerator.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Dedoc\Scramble;
+
+class CacheableGenerator
+{
+    public function __construct(
+        private Generator $generator,
+    ) {}
+
+    public function __invoke(?GeneratorConfig $config = null): array
+    {
+        $config ??= Scramble::getGeneratorConfig(Scramble::DEFAULT_API);
+
+        $store = config('scramble.cache.store', 'file');
+        $key = config('scramble.cache.key').':'.$this->resolveApi($config);
+
+        if ($cached = cache()->store($store)->get($key)) {
+            return $cached;
+        }
+
+        return ($this->generator)($config);
+    }
+
+    private function resolveApi(GeneratorConfig $config): string
+    {
+        foreach (Scramble::getConfigurationsInstance()->all() as $api => $generatorConfig) {
+            if ($generatorConfig === $config) {
+                return $api;
+            }
+        }
+
+        return Scramble::DEFAULT_API;
+    }
+}

--- a/src/CacheableGenerator.php
+++ b/src/CacheableGenerator.php
@@ -12,8 +12,14 @@ class CacheableGenerator
     {
         $config ??= Scramble::getGeneratorConfig(Scramble::DEFAULT_API);
 
-        $store = config('scramble.cache.store', 'file');
-        $key = config('scramble.cache.key').':'.$this->resolveApi($config);
+        $store = config('scramble.cache.store');
+        $keyBase = config('scramble.cache.key');
+
+        if (! $store || ! $keyBase) {
+            return ($this->generator)($config);
+        }
+
+        $key = $keyBase.':'.$this->resolveApi($config);
 
         if ($cached = cache()->store($store)->get($key)) {
             return $cached;

--- a/src/Console/Commands/CacheDocumentation.php
+++ b/src/Console/Commands/CacheDocumentation.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Dedoc\Scramble\Console\Commands;
+
+use Dedoc\Scramble\Console\Commands\Concerns\ManagesDocumentationCache;
+use Dedoc\Scramble\Generator;
+use Dedoc\Scramble\Scramble;
+use Illuminate\Console\Command;
+
+class CacheDocumentation extends Command
+{
+    use ManagesDocumentationCache;
+
+    protected $signature = 'scramble:cache
+        {--api=* : The API to cache a documentation for (by default, caches all APIs)}
+    ';
+
+    protected $description = 'Cache the generated OpenAPI document.';
+
+    public function handle(Generator $generator): int
+    {
+        if (! $this->ensureDocumentationCacheConfigured()) {
+            return self::SUCCESS;
+        }
+
+        $store = config('scramble.cache.store');
+
+        foreach ($this->resolveApis() as $api) {
+            $config = Scramble::getGeneratorConfig($api);
+
+            cache()->store($store)->forever(
+                $this->cacheKey($api),
+                $generator($config),
+            );
+
+            $this->info("OpenAPI document cached for [{$api}] API.");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/ClearDocumentationCache.php
+++ b/src/Console/Commands/ClearDocumentationCache.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Dedoc\Scramble\Console\Commands;
+
+use Dedoc\Scramble\Console\Commands\Concerns\ManagesDocumentationCache;
+use Illuminate\Console\Command;
+
+class ClearDocumentationCache extends Command
+{
+    use ManagesDocumentationCache;
+
+    protected $signature = 'scramble:clear
+        {--api=* : The API to clear a documentation cache for (by default, clears all APIs)}
+    ';
+
+    protected $description = 'Clear the cached OpenAPI document.';
+
+    public function handle(): int
+    {
+        if (! $this->ensureDocumentationCacheConfigured()) {
+            return self::SUCCESS;
+        }
+
+        $store = config('scramble.cache.store');
+
+        foreach ($this->resolveApis() as $api) {
+            cache()->store($store)->forget($this->cacheKey($api));
+
+            $this->info("OpenAPI document cache cleared for [{$api}] API.");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/Concerns/ManagesDocumentationCache.php
+++ b/src/Console/Commands/Concerns/ManagesDocumentationCache.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Dedoc\Scramble\Console\Commands\Concerns;
+
+use Dedoc\Scramble\Scramble;
+
+trait ManagesDocumentationCache
+{
+    protected function ensureDocumentationCacheConfigured(): bool
+    {
+        if (config('scramble.cache.store') === null) {
+            $this->info('Documentation cache store is not configured. Set `scramble.cache.store` in your config.');
+
+            return false;
+        }
+
+        if (config('scramble.cache.key') === null) {
+            $this->info('Documentation cache key is not configured. Set `scramble.cache.key` in your config.');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /** @return string[] */
+    protected function resolveApis(): array
+    {
+        $apis = array_filter($this->option('api') ?: []);
+
+        if ($apis === [] || $apis === ['*']) {
+            return array_keys(Scramble::getConfigurationsInstance()->all());
+        }
+
+        return $apis;
+    }
+
+    protected function cacheKey(string $api): string
+    {
+        return config('scramble.cache.key').':'.$api;
+    }
+}

--- a/src/Scramble.php
+++ b/src/Scramble.php
@@ -149,7 +149,7 @@ class Scramble
     {
         $config = static::getGeneratorConfig($api);
 
-        return RouteFacade::get($path, function (Generator $generator) use ($api) {
+        return RouteFacade::get($path, function (CacheableGenerator $generator) use ($api) {
             $config = static::getGeneratorConfig($api);
 
             return view('scramble::docs', [
@@ -164,7 +164,7 @@ class Scramble
     {
         $config = static::getGeneratorConfig($api);
 
-        return RouteFacade::get($path, function (Generator $generator) use ($api) {
+        return RouteFacade::get($path, function (CacheableGenerator $generator) use ($api) {
             $config = static::getGeneratorConfig($api);
 
             return response()->json($generator($config), options: JSON_PRETTY_PRINT);

--- a/src/ScrambleServiceProvider.php
+++ b/src/ScrambleServiceProvider.php
@@ -5,6 +5,8 @@ namespace Dedoc\Scramble;
 use Dedoc\Scramble\Configuration\GeneratorConfigCollection;
 use Dedoc\Scramble\Configuration\OperationTransformers;
 use Dedoc\Scramble\Console\Commands\AnalyzeDocumentation;
+use Dedoc\Scramble\Console\Commands\CacheDocumentation;
+use Dedoc\Scramble\Console\Commands\ClearDocumentationCache;
 use Dedoc\Scramble\Console\Commands\ExportDocumentation;
 use Dedoc\Scramble\DocumentTransformers\AddDocumentTags;
 use Dedoc\Scramble\DocumentTransformers\CleanupUnusedResponseReferencesTransformer;
@@ -88,6 +90,7 @@ class ScrambleServiceProvider extends PackageServiceProvider
     public $singletons = [
         PrettyPrinter::class => PrettyPrinter\Standard::class,
         GeneratorConfigCollection::class => GeneratorConfigCollection::class,
+        CacheableGenerator::class => CacheableGenerator::class,
     ];
 
     public function configurePackage(Package $package): void
@@ -97,6 +100,8 @@ class ScrambleServiceProvider extends PackageServiceProvider
             ->hasConfigFile()
             ->hasCommand(ExportDocumentation::class)
             ->hasCommand(AnalyzeDocumentation::class)
+            ->hasCommand(CacheDocumentation::class)
+            ->hasCommand(ClearDocumentationCache::class)
             ->hasViews('scramble');
 
         $this->app->singleton(FileParser::class, function () {
@@ -298,7 +303,7 @@ class ScrambleServiceProvider extends PackageServiceProvider
                     ? $generatorConfig->uiRoute
                     : fn ($router, $action) => $router->get($generatorConfig->uiRoute, $action);
 
-                $cb($router, function (Generator $generator) use ($api) {
+                $cb($router, function (CacheableGenerator $generator) use ($api) {
                     $config = Scramble::getGeneratorConfig($api);
 
                     return view($config->renderer()->view, [
@@ -313,7 +318,7 @@ class ScrambleServiceProvider extends PackageServiceProvider
                     ? $generatorConfig->documentRoute
                     : fn ($router, $action) => $router->get($generatorConfig->documentRoute, $action);
 
-                $cb($router, function (Generator $generator) use ($api) {
+                $cb($router, function (CacheableGenerator $generator) use ($api) {
                     $config = Scramble::getGeneratorConfig($api);
 
                     return response()->json($generator($config), options: JSON_PRETTY_PRINT);

--- a/tests/Console/Commands/CacheDocumentationTest.php
+++ b/tests/Console/Commands/CacheDocumentationTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use Dedoc\Scramble\CacheableGenerator;
+use Dedoc\Scramble\Console\Commands\CacheDocumentation;
+use Dedoc\Scramble\Console\Commands\ClearDocumentationCache;
+use Dedoc\Scramble\Generator;
+use Dedoc\Scramble\Scramble;
+use Illuminate\Support\Facades\Cache;
+
+use function Pest\Laravel\artisan;
+
+beforeEach(function () {
+    config()->set('scramble.cache', [
+        'key' => 'scramble.openapi.test',
+        'store' => 'array',
+    ]);
+
+    Scramble::configure()->useConfig(config('scramble'));
+});
+
+it('returns cached documentation when cache is configured', function () {
+    $generator = app(Generator::class);
+    $cacheableGenerator = app(CacheableGenerator::class);
+    $config = Scramble::getGeneratorConfig(Scramble::DEFAULT_API);
+
+    $expected = $generator($config);
+
+    Cache::store('array')->forever(
+        'scramble.openapi.test:'.Scramble::DEFAULT_API,
+        $expected,
+    );
+
+    expect($cacheableGenerator($config))->toBe($expected);
+});
+
+it('generates documentation on cache miss without storing', function () {
+    $generator = app(Generator::class);
+    $cacheableGenerator = app(CacheableGenerator::class);
+    $config = Scramble::getGeneratorConfig(Scramble::DEFAULT_API);
+
+    expect($cacheableGenerator($config))->toBe($generator($config));
+    expect(Cache::store('array')->has('scramble.openapi.test:'.Scramble::DEFAULT_API))->toBeFalse();
+});
+
+it('uses api-specific cache keys for registered apis', function () {
+    $api = 'v2';
+
+    Scramble::registerApi($api, [
+        'api_path' => 'api/v2',
+    ]);
+
+    artisan(CacheDocumentation::class, ['--api' => [$api]])->assertOk();
+
+    expect(Cache::store('array')->has("scramble.openapi.test:{$api}"))->toBeTrue();
+});
+
+it('caches documentation for all apis by default', function () {
+    $api = 'v2';
+
+    Scramble::registerApi($api, [
+        'api_path' => 'api/v2',
+    ]);
+
+    artisan(CacheDocumentation::class)->assertOk();
+
+    expect(Cache::store('array')->has('scramble.openapi.test:'.Scramble::DEFAULT_API))->toBeTrue()
+        ->and(Cache::store('array')->has("scramble.openapi.test:{$api}"))->toBeTrue();
+});
+
+it('caches documentation using scramble:cache command', function () {
+    $generator = app(Generator::class);
+    $config = Scramble::getGeneratorConfig(Scramble::DEFAULT_API);
+    $expected = $generator($config);
+
+    artisan(CacheDocumentation::class, ['--api' => [Scramble::DEFAULT_API]])->assertOk();
+
+    expect(Cache::store('array')->get('scramble.openapi.test:'.Scramble::DEFAULT_API))->toBe($expected);
+});
+
+it('clears documentation cache using scramble:clear command', function () {
+    Cache::store('array')->forever('scramble.openapi.test:'.Scramble::DEFAULT_API, ['openapi' => '3.1.0']);
+
+    expect(Cache::store('array')->has('scramble.openapi.test:'.Scramble::DEFAULT_API))->toBeTrue();
+
+    artisan(ClearDocumentationCache::class, ['--api' => [Scramble::DEFAULT_API]])->assertOk();
+
+    expect(Cache::store('array')->has('scramble.openapi.test:'.Scramble::DEFAULT_API))->toBeFalse();
+});
+
+it('clears documentation cache for all apis by default', function () {
+    $api = 'v2';
+
+    Scramble::registerApi($api, [
+        'api_path' => 'api/v2',
+    ]);
+
+    Cache::store('array')->forever('scramble.openapi.test:'.Scramble::DEFAULT_API, ['openapi' => '3.1.0']);
+    Cache::store('array')->forever("scramble.openapi.test:{$api}", ['openapi' => '3.1.0']);
+
+    artisan(ClearDocumentationCache::class)->assertOk();
+
+    expect(Cache::store('array')->has('scramble.openapi.test:'.Scramble::DEFAULT_API))->toBeFalse()
+        ->and(Cache::store('array')->has("scramble.openapi.test:{$api}"))->toBeFalse();
+});
+
+it('returns early when cache store is not configured', function () {
+    config()->set('scramble.cache.store', null);
+
+    artisan(CacheDocumentation::class)
+        ->assertOk()
+        ->expectsOutput('Documentation cache store is not configured. Set `scramble.cache.store` in your config.');
+});
+
+it('returns early when cache key is not configured', function () {
+    config()->set('scramble.cache.key', null);
+
+    artisan(ClearDocumentationCache::class)
+        ->assertOk()
+        ->expectsOutput('Documentation cache key is not configured. Set `scramble.cache.key` in your config.');
+});


### PR DESCRIPTION
This PR adds 2 commands for caching resulting OpenAPI document:

```sh
php artisan scramble:cache --api=*
php artisan scramble:clear --api=*
```

This is extremely useful (and needed!) if documentation is exposed in production environment.