### PR TITLE
Add support for Laravel's fluent File validation rule

### DIFF
--- a/src/Configuration/RuleTransformers.php
+++ b/src/Configuration/RuleTransformers.php
@@ -7,6 +7,7 @@ use Dedoc\Scramble\Contracts\RuleTransformer;
 use Dedoc\Scramble\RuleTransformers\ConfirmedRule;
 use Dedoc\Scramble\RuleTransformers\EnumRule;
 use Dedoc\Scramble\RuleTransformers\ExistsRule;
+use Dedoc\Scramble\RuleTransformers\FileRule;
 use Dedoc\Scramble\RuleTransformers\InRule;
 use Dedoc\Scramble\RuleTransformers\RegexRule;
 use Dedoc\Scramble\Support\ContainerUtils;
@@ -83,6 +84,7 @@ class RuleTransformers
         $base = $this->transformers ?: [
             EnumRule::class,
             InRule::class,
+            FileRule::class,
             ConfirmedRule::class,
             ExistsRule::class,
             RegexRule::class,

--- a/src/RuleTransformers/FileRule.php
+++ b/src/RuleTransformers/FileRule.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Dedoc\Scramble\RuleTransformers;
+
+use Dedoc\Scramble\Contracts\RuleTransformer;
+use Dedoc\Scramble\Support\Generator\Types\Type;
+use Dedoc\Scramble\Support\OperationExtensions\RulesExtractor\RulesMapper;
+use Dedoc\Scramble\Support\RuleTransforming\NormalizedRule;
+use Dedoc\Scramble\Support\RuleTransforming\RuleTransformerContext;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Validation\Rules\File;
+
+class FileRule implements RuleTransformer
+{
+    public function __construct(
+        protected RulesMapper $rulesMapper,
+    ) {
+    }
+
+    public function shouldHandle(NormalizedRule $rule): bool
+    {
+        return $rule->is(File::class);
+    }
+
+    /**
+     * @param  NormalizedRule<File>  $rule
+     */
+    public function toSchema(Type $previous, NormalizedRule $rule, RuleTransformerContext $context): Type
+    {
+        $fileRule = $rule->getRule();
+
+        $rulesToSchemaTransformer = (fn () => $this->rulesToSchemaTransformer)->call($this->rulesMapper);
+
+        return $rulesToSchemaTransformer->transform(
+            $this->buildFileValidationRules($fileRule),
+            $previous,
+            $context,
+        );
+    }
+
+    /**
+     * @return list<string|ValidationRule>
+     */
+    private function buildFileValidationRules(File $rule): array
+    {
+        return array_values(array_map(
+            fn ($rule) => $rule instanceof ValidationRule ? $rule : (string) $rule,
+            (fn () => $this->buildValidationRules())->call($rule),
+        ));
+    }
+}

--- a/src/RuleTransformers/FileRule.php
+++ b/src/RuleTransformers/FileRule.php
@@ -4,8 +4,8 @@ namespace Dedoc\Scramble\RuleTransformers;
 
 use Dedoc\Scramble\Contracts\RuleTransformer;
 use Dedoc\Scramble\Support\Generator\Types\Type;
-use Dedoc\Scramble\Support\OperationExtensions\RulesExtractor\RulesMapper;
 use Dedoc\Scramble\Support\RuleTransforming\NormalizedRule;
+use Dedoc\Scramble\Support\RuleTransforming\RuleSetToSchemaTransformer;
 use Dedoc\Scramble\Support\RuleTransforming\RuleTransformerContext;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Validation\Rules\File;
@@ -13,7 +13,7 @@ use Illuminate\Validation\Rules\File;
 class FileRule implements RuleTransformer
 {
     public function __construct(
-        protected RulesMapper $rulesMapper,
+        private RuleSetToSchemaTransformer $rulesToSchemaTransformer,
     ) {
     }
 
@@ -29,9 +29,7 @@ class FileRule implements RuleTransformer
     {
         $fileRule = $rule->getRule();
 
-        $rulesToSchemaTransformer = (fn () => $this->rulesToSchemaTransformer)->call($this->rulesMapper);
-
-        return $rulesToSchemaTransformer->transform(
+        return $this->rulesToSchemaTransformer->transform(
             $this->buildFileValidationRules($fileRule),
             $previous,
             $context,
@@ -45,6 +43,10 @@ class FileRule implements RuleTransformer
     {
         return array_values(array_map(
             fn ($rule) => $rule instanceof ValidationRule ? $rule : (string) $rule,
+            /**
+             * `buildValidationRules` is protected {@see File::buildValidationRules},
+             * so to get the rules the transformer can transform, this "magic" is used.
+             */
             (fn () => $this->buildValidationRules())->call($rule),
         ));
     }

--- a/src/Support/RuleTransforming/RuleSetToSchemaTransformer.php
+++ b/src/Support/RuleTransforming/RuleSetToSchemaTransformer.php
@@ -99,6 +99,7 @@ class RuleSetToSchemaTransformer
 
         $extensions = $this->config
             ->instances(RuleTransformer::class, [
+                RuleSetToSchemaTransformer::class => $this,
                 TypeTransformer::class => $this->openApiTransformer,
                 RulesMapper::class => new RulesMapper($this->openApiTransformer, $this),
             ])

--- a/src/Support/RuleTransforming/RuleSetToSchemaTransformer.php
+++ b/src/Support/RuleTransforming/RuleSetToSchemaTransformer.php
@@ -8,13 +8,11 @@ use Dedoc\Scramble\Support\Generator\Types\Type as OpenApiType;
 use Dedoc\Scramble\Support\Generator\Types\UnknownType;
 use Dedoc\Scramble\Support\Generator\TypeTransformer;
 use Dedoc\Scramble\Support\OperationExtensions\RulesExtractor\RulesMapper;
-use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
-use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 
@@ -134,10 +132,6 @@ class RuleSetToSchemaTransformer
      */
     protected function transformRuleValueToSchema(OpenApiType $type, $rule, RuleTransformerContext $context): OpenApiType
     {
-        if ($rule instanceof File) {
-            return $this->transformToSchema(static::normalizeAndPrioritizeRules($this->buildFileValidationRules($rule)), $type, $context);
-        }
-
         $rulesHandler = new RulesMapper($this->openApiTransformer, $this);
 
         $methodName = Str::camel(class_basename(get_class($rule)));
@@ -145,17 +139,6 @@ class RuleSetToSchemaTransformer
         return method_exists($rulesHandler, $methodName)
             ? $rulesHandler->$methodName($type, $rule, $context)
             : $type;
-    }
-
-    /**
-     * @return list<string|ValidationRule>
-     */
-    private function buildFileValidationRules(File $rule): array
-    {
-        return array_values(array_map(
-            fn ($rule) => $rule instanceof ValidationRule ? $rule : (string) $rule,
-            (fn () => $this->buildValidationRules())->call($rule),
-        ));
     }
 
     /**

--- a/src/Support/RuleTransforming/RuleSetToSchemaTransformer.php
+++ b/src/Support/RuleTransforming/RuleSetToSchemaTransformer.php
@@ -8,11 +8,13 @@ use Dedoc\Scramble\Support\Generator\Types\Type as OpenApiType;
 use Dedoc\Scramble\Support\Generator\Types\UnknownType;
 use Dedoc\Scramble\Support\Generator\TypeTransformer;
 use Dedoc\Scramble\Support\OperationExtensions\RulesExtractor\RulesMapper;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
+use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 
@@ -132,6 +134,10 @@ class RuleSetToSchemaTransformer
      */
     protected function transformRuleValueToSchema(OpenApiType $type, $rule, RuleTransformerContext $context): OpenApiType
     {
+        if ($rule instanceof File) {
+            return $this->transformToSchema(static::normalizeAndPrioritizeRules($this->buildFileValidationRules($rule)), $type, $context);
+        }
+
         $rulesHandler = new RulesMapper($this->openApiTransformer, $this);
 
         $methodName = Str::camel(class_basename(get_class($rule)));
@@ -139,6 +145,17 @@ class RuleSetToSchemaTransformer
         return method_exists($rulesHandler, $methodName)
             ? $rulesHandler->$methodName($type, $rule, $context)
             : $type;
+    }
+
+    /**
+     * @return list<string|ValidationRule>
+     */
+    private function buildFileValidationRules(File $rule): array
+    {
+        return array_values(array_map(
+            fn ($rule) => $rule instanceof ValidationRule ? $rule : (string) $rule,
+            (fn () => $this->buildValidationRules())->call($rule),
+        ));
     }
 
     /**

--- a/tests/Support/OperationExtensions/RulesExtractor/RuleSetToSchemaTransformersTest.php
+++ b/tests/Support/OperationExtensions/RulesExtractor/RuleSetToSchemaTransformersTest.php
@@ -11,6 +11,7 @@ use Dedoc\Scramble\Support\Generator\TypeTransformer;
 use Dedoc\Scramble\Support\RuleTransforming\RuleSetToSchemaTransformer;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Enum;
+use Illuminate\Validation\Rules\File;
 
 beforeEach(function () {
     $this->openApiTransformer = app(TypeTransformer::class, [
@@ -95,6 +96,40 @@ describe(InRule::class, function () {
                     'type' => 'string',
                     'enum' => ['a', 'b', 'c'],
                 ],
+            ]);
+    });
+});
+
+describe(File::class, function () {
+    test('file rule', function () {
+        $rules = [File::types(['pdf'])->min(1024)->max(12 * 1024)];
+
+        $schema = $this->transformer->transform($rules);
+
+        expect($schema->toArray())
+            ->toBe([
+                'type' => 'string',
+                'format' => 'binary',
+                'contentMediaType' => 'application/octet-stream',
+                'minLength' => 1024.0,
+                'maxLength' => 12288.0,
+            ]);
+    });
+
+    test('image file rule', function () {
+        $rules = [
+            File::image()->dimensions(
+                Rule::dimensions()->maxWidth(1000)->maxHeight(500),
+            ),
+        ];
+
+        $schema = $this->transformer->transform($rules);
+
+        expect($schema->toArray())
+            ->toBe([
+                'type' => 'string',
+                'format' => 'binary',
+                'contentMediaType' => 'application/octet-stream',
             ]);
     });
 });


### PR DESCRIPTION
Adds support for the Illuminate\Validation\Rules\File validation rule.

With this change, it now correctly transforms the fluent File rule (and ImageFile) into OpenAPI schema definitions. (https://laravel.com/docs/13.x/validation#validating-files)

This ensures that constraints like file types, minimum/maximum sizes, and image dimensions are accurately reflected in the generated documentation.