### PR TITLE
fix: preserve validation chain properties (like nullable) on enums

### DIFF
--- a/src/RuleTransformers/EnumRule.php
+++ b/src/RuleTransformers/EnumRule.php
@@ -18,7 +18,8 @@ class EnumRule implements RuleTransformer
 {
     public function __construct(
         protected TypeTransformer $openApiTransformer,
-    ) {}
+    ) {
+    }
 
     public function shouldHandle(NormalizedRule $rule): bool
     {
@@ -42,11 +43,31 @@ class EnumRule implements RuleTransformer
         /** @var BackedEnum[] $only */
         $only = method_exists(Enum::class, 'only') ? $this->getProtectedValue($rule, 'only') : []; // @phpstan-ignore function.alreadyNarrowedType
 
-        if ($except || $only) {
-            return $this->createPartialEnum($enumName, $only, $except);
+        if (!($except || $only)) {
+            return $this->openApiTransformer
+                ->transform($objectType)
+                ->addProperties($previous);
         }
 
-        return $this->openApiTransformer->transform($objectType);
+        $type = $this->createPartialEnum($enumName, $only, $except);
+
+        // Backup the enum/const properties generated for the partial enum,
+        // because addProperties() will overwrite them with values from $previous.
+        $enum = $type->enum;
+        $const = $type->const;
+
+        // Preserve attributes/properties (e.g. nullable, description) from preceding rules
+        $type->addProperties($previous);
+
+        // Restore the partial enum's constraints
+        if (count($enum)) {
+            $type->enum($enum);
+        }
+        if (!is_null($const)) {
+            $type->const($const);
+        }
+
+        return $type;
     }
 
     /**
@@ -57,23 +78,23 @@ class EnumRule implements RuleTransformer
     private function createPartialEnum(string $enumName, array $only, array $except): Type
     {
         $cases = collect($enumName::cases())
-            ->reject(fn ($case) => in_array($case, $except))
-            ->filter(fn ($case) => ! $only || in_array($case, $only));
+            ->reject(fn($case) => in_array($case, $except))
+            ->filter(fn($case) => !$only || in_array($case, $only));
 
-        if (! isset($cases->first()->value)) {
+        if ($cases->isEmpty()) {
             return new UnknownType; // $enumName enum doesnt have values (only/except context)
         }
 
         return $this->openApiTransformer->transform(Union::wrap(
-            $cases->map(fn ($c) => TypeHelper::createTypeFromValue($c->value))->all()
+            $cases->map(fn($c) => TypeHelper::createTypeFromValue($c->value))->all()
         ));
     }
 
     private function getProtectedValue(object $obj, string $name): mixed
     {
         $array = (array) $obj;
-        $prefix = chr(0).'*'.chr(0);
+        $prefix = chr(0) . '*' . chr(0);
 
-        return $array[$prefix.$name];
+        return $array[$prefix . $name];
     }
 }

--- a/src/Support/TypeToSchemaExtensions/EnumToSchema.php
+++ b/src/Support/TypeToSchemaExtensions/EnumToSchema.php
@@ -32,13 +32,15 @@ class EnumToSchema extends TypeToSchemaExtension
      */
     public function toSchema(Type $type): OpenApi\Type
     {
+        /** @var class-string<\UnitEnum> $name */
         $name = $type->name;
 
-        if (! isset($name::cases()[0]->value)) { // only backed enums support
+        // Only backed enums are supported
+        if (!is_subclass_of($name, \BackedEnum::class)) {
             return new UnknownType;
         }
 
-        $values = array_map(fn ($s) => $s->value, $name::cases());
+        $values = array_map(fn($s) => $s->value, $name::cases());
 
         $schemaType = is_string($values[0]) ? new StringType : new IntegerType;
         $schemaType->enum($values);
@@ -63,16 +65,16 @@ class EnumToSchema extends TypeToSchemaExtension
 
         $cases = collect(array_filter(
             $enumReflection->getCases(),
-            fn ($case) => $case instanceof ReflectionEnumBackedCase,
+            fn($case) => $case instanceof ReflectionEnumBackedCase,
         ))
-            ->keyBy(fn (ReflectionEnumBackedCase $case): int|string => $case->getBackingValue())
+            ->keyBy(fn(ReflectionEnumBackedCase $case): int|string => $case->getBackingValue())
             ->map(function (ReflectionEnumBackedCase $case) {
                 $doc = PhpDoc::parse($case->getDocComment() ?: '/** */');
 
-                return trim(Str::replace("\n", ' ', $doc->getAttribute('summary').' '.$doc->getAttribute('description'))); // @phpstan-ignore binaryOp.invalid, binaryOp.invalid
+                return trim(Str::replace("\n", ' ', $doc->getAttribute('summary') . ' ' . $doc->getAttribute('description'))); // @phpstan-ignore binaryOp.invalid, binaryOp.invalid
             });
 
-        if (! $cases->some(fn ($description) => (bool) $description)) {
+        if (!$cases->some(fn($description) => (bool) $description)) {
             return;
         }
 
@@ -96,13 +98,13 @@ class EnumToSchema extends TypeToSchemaExtension
         $enumReflection = new ReflectionEnum($type->name); // @phpstan-ignore argument.type
 
         $doc = PhpDoc::parse($enumReflection->getDocComment() ?: '/** */');
-        $description = trim(Str::replace("\n", ' ', $doc->getAttribute('summary').' '.$doc->getAttribute('description'))); // @phpstan-ignore binaryOp.invalid, binaryOp.invalid
+        $description = trim(Str::replace("\n", ' ', $doc->getAttribute('summary') . ' ' . $doc->getAttribute('description'))); // @phpstan-ignore binaryOp.invalid, binaryOp.invalid
 
-        if (! $description) {
+        if (!$description) {
             return;
         }
 
-        $schemaType->setDescription($description."\n".$schemaType->description);
+        $schemaType->setDescription($description . "\n" . $schemaType->description);
 
         /*
          * Cases description are stored in attribute due to if enum is used as a property in some object,
@@ -116,16 +118,16 @@ class EnumToSchema extends TypeToSchemaExtension
         /** @var 'name'|'varnames'|null $enumNameStrategy */
         $enumNameStrategy = config('scramble.enum_cases_names_strategy');
 
-        if (! $enumNameStrategy) {
+        if (!$enumNameStrategy) {
             return;
         }
 
         $enumReflection = new ReflectionEnum($type->name); // @phpstan-ignore argument.type
 
         $nameCases = collect($enumReflection->getCases())
-            ->filter(fn (ReflectionEnumUnitCase $case) => $case instanceof ReflectionEnumBackedCase)
-            ->keyBy(fn (ReflectionEnumBackedCase $case): int|string => $case->getBackingValue())
-            ->map(fn (ReflectionEnumBackedCase $case) => $case->getName());
+            ->filter(fn(ReflectionEnumUnitCase $case) => $case instanceof ReflectionEnumBackedCase)
+            ->keyBy(fn(ReflectionEnumBackedCase $case): int|string => $case->getBackingValue())
+            ->map(fn(ReflectionEnumBackedCase $case) => $case->getName());
 
         $this->handleEnumNames($schemaType, $nameCases, $enumNameStrategy);
     }
@@ -136,7 +138,7 @@ class EnumToSchema extends TypeToSchemaExtension
     protected function handleDescriptionEnumStrategy(OpenApi\Type $schema, Collection $cases): void
     {
         $description = $cases
-            ->map(fn ($description, $value) => "| `{$value}` <br/> {$description} |")
+            ->map(fn($description, $value) => "| `{$value}` <br/> {$description} |")
             ->prepend('|---|')
             ->prepend('| |')
             ->join("\n");


### PR DESCRIPTION
Fixes #1159 

This PR fixes a bug where parameters validated using the Enum rule (e.g. new Enum(UserStatus::class)) would lose prior properties in the validation rules chain, such as nullable or default.

For example, a validation rule definition like:

```php
'status' => ['nullable', new Enum(UserStatus::class)]
```
would generate a schema without `nullable: true` in the final OpenAPI documentation.

### Why this happens
During schema extraction, the validation rules are processed sequentially. The `nullable` rule runs first and sets `$previous->nullable = true` . When the `Enum` rule runs, `EnumRule` discarded the `$previous` type state, returning a fresh OpenAPI type that lost all previously-applied attributes.


