### PR TITLE
Fixed JSON API resources when consts are used for attributes and relations properties

### DIFF
--- a/src/Reflection/ReflectionJsonApiResource.php
+++ b/src/Reflection/ReflectionJsonApiResource.php
@@ -12,6 +12,7 @@ use Dedoc\Scramble\Support\Type as InferType;
 use Dedoc\Scramble\Support\Type\KeyedArrayType;
 use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
 use Dedoc\Scramble\Support\Type\ObjectType;
+use Dedoc\Scramble\Support\Type\Reference\ConstFetchReferenceType;
 use Dedoc\Scramble\Support\Type\Reference\MethodCallReferenceType;
 use Dedoc\Scramble\Support\Type\Type;
 use Dedoc\Scramble\Support\TypeManagers\ResourceCollectionTypeManager;
@@ -355,7 +356,11 @@ class ReflectionJsonApiResource
 
     private function getPropertyDefaultType(string $name): ?Type
     {
-        return $this->definition->getPropertyDefinition($name)?->defaultType;
+        if (! $defaultType = $this->definition->getPropertyDefinition($name)?->defaultType) {
+            return null;
+        }
+
+        return ReferenceTypeResolver::getInstance()->resolve(new GlobalScope, $defaultType);
     }
 
     private function getMethodReturnType(string $method): ?Type

--- a/src/Reflection/ReflectionJsonApiResource.php
+++ b/src/Reflection/ReflectionJsonApiResource.php
@@ -12,7 +12,6 @@ use Dedoc\Scramble\Support\Type as InferType;
 use Dedoc\Scramble\Support\Type\KeyedArrayType;
 use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
 use Dedoc\Scramble\Support\Type\ObjectType;
-use Dedoc\Scramble\Support\Type\Reference\ConstFetchReferenceType;
 use Dedoc\Scramble\Support\Type\Reference\MethodCallReferenceType;
 use Dedoc\Scramble\Support\Type\Type;
 use Dedoc\Scramble\Support\TypeManagers\ResourceCollectionTypeManager;

--- a/tests/Reflection/ReflectionJsonApiResourceTest.php
+++ b/tests/Reflection/ReflectionJsonApiResourceTest.php
@@ -42,8 +42,11 @@ class ReflectionJsonApiResourceTestConst_JsonApi extends JsonApiResource
 class ReflectionJsonApiResourceTestConstUserModel extends SampleUserModel
 {
     public const ID = 'id';
+
     public const USER_ID = 'user_id';
+
     public const NAME = 'name';
+
     public const RELATION_SURVEYS = 'surveys';
 
     public function surveys()

--- a/tests/Reflection/ReflectionJsonApiResourceTest.php
+++ b/tests/Reflection/ReflectionJsonApiResourceTest.php
@@ -5,6 +5,7 @@ namespace Dedoc\Scramble\Tests\Reflection;
 use Dedoc\Scramble\Reflection\ReflectionJsonApiResource;
 use Dedoc\Scramble\Tests\Files\SamplePostModel;
 use Dedoc\Scramble\Tests\Files\SampleUserModel;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\JsonApi\AnonymousResourceCollection;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
@@ -13,6 +14,42 @@ if (! class_exists(JsonApiResource::class)) {
     test('JSON:API resources are available')->skip('JSON:API resources are not available in this Laravel version.');
 
     return;
+}
+
+test('returns attributes and relationships type from properties with model constants', function () {
+    $resource = ReflectionJsonApiResource::createForClass(ReflectionJsonApiResourceTestConst_JsonApi::class);
+
+    expect($resource->getAttributesType()->toString())->toBe('array{id: int, user_id: unknown, name: string, created_at: Carbon\Carbon|null}')
+        ->and($resource->getRelationshipsType()->toString())->toBe('array{surveys: Illuminate\Http\Resources\JsonApi\AnonymousResourceCollection<unknown, unknown, Illuminate\Http\Resources\JsonApi\JsonApiResource>}');
+});
+/**
+ * @property-read ReflectionJsonApiResourceTestConstUserModel $resource
+ */
+class ReflectionJsonApiResourceTestConst_JsonApi extends JsonApiResource
+{
+    public array $attributes = [
+        ReflectionJsonApiResourceTestConstUserModel::ID,
+        ReflectionJsonApiResourceTestConstUserModel::USER_ID,
+        ReflectionJsonApiResourceTestConstUserModel::NAME,
+        Model::CREATED_AT,
+    ];
+
+    public array $relationships = [
+        ReflectionJsonApiResourceTestConstUserModel::RELATION_SURVEYS,
+    ];
+}
+
+class ReflectionJsonApiResourceTestConstUserModel extends SampleUserModel
+{
+    public const ID = 'id';
+    public const USER_ID = 'user_id';
+    public const NAME = 'name';
+    public const RELATION_SURVEYS = 'surveys';
+
+    public function surveys()
+    {
+        return $this->hasMany(SamplePostModel::class);
+    }
 }
 
 test('returns attributes type from property', function () {


### PR DESCRIPTION
Previously this JSON API resource did not work:

```php
class TeamResource extends JsonApiResource
{
    public array $attributes = [
        Team::ID,
        Team::USER_ID,
        Team::NAME,
        Model::CREATED_AT,
    ];

    public array $relationships = [
        Team::RELATION_SURVEYS,
    ];
}
```

Now it works!