### PR TITLE
feat: add optional hierarchical endpoint grouping

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -57,6 +57,35 @@ return [
         'title' => null,
     ],
 
+    /*
+     * Hierarchical grouping of endpoints (the documentation "explorer" tree).
+     *
+     * Disabled by default to preserve Scramble's flat, tag-based behaviour. When
+     * enabled, each operation is assigned to a (possibly nested) group resolved
+     * from, in order: the #[Group] attribute, the `rules` below, the route
+     * prefix/name, and finally the controller name.
+     *
+     * The resolved hierarchy is emitted as parent/child `tag` relationships plus
+     * the `x-tree` and `x-tagGroups` document extensions, and is rendered as a
+     * collapsible sidebar by the bundled UI.
+     */
+    'groups' => [
+        'enabled' => false,
+
+        /*
+         * Config-driven group assignment rules, evaluated top to bottom. The
+         * first matching rule wins. `group` supports nesting via `/`, `>` or `.`
+         * (e.g. 'Admin/Security'). `match` may combine `middleware`, `prefix`
+         * and `namespace` patterns (matched with Str::is).
+         *
+         * [
+         *     'group' => 'Admin/Security',
+         *     'match' => ['middleware' => 'auth:admin', 'prefix' => 'admin/*'],
+         * ],
+         */
+        'rules' => [],
+    ],
+
     'renderer' => 'elements',
 
     'renderers' => [

--- a/src/Attributes/Group.php
+++ b/src/Attributes/Group.php
@@ -19,5 +19,6 @@ class Group
          * by the name (with `SORT_LOCALE_STRING` sorting flag).
          */
         public readonly int $weight = PHP_INT_MAX,
+        public readonly ?string $parent = null,
     ) {}
 }

--- a/src/DocumentTransformers/AddDocumentTags.php
+++ b/src/DocumentTransformers/AddDocumentTags.php
@@ -35,6 +35,7 @@ class AddDocumentTags implements DocumentTransformer
 
             $description = $arguments['description'] ?? $arguments[1] ?? null;
             $weight = $arguments['weight'] ?? $arguments[2] ?? null;
+            $parent = $arguments['parent'] ?? $arguments[3] ?? null;
 
             /** @var Tag $tag */
             $tag = $acc->get($name, new Tag($name));
@@ -45,6 +46,10 @@ class AddDocumentTags implements DocumentTransformer
 
             if ($weight !== null && $tag->getAttribute('weight') === null) {
                 $tag->setAttribute('weight', $weight);
+            }
+
+            if ($parent !== null && $tag->parent === null) {
+                $tag->parent = $parent;
             }
 
             $acc->offsetSet($name, $tag);

--- a/src/DocumentTransformers/AddTagGroups.php
+++ b/src/DocumentTransformers/AddTagGroups.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Dedoc\Scramble\DocumentTransformers;
+
+use Dedoc\Scramble\Contracts\DocumentTransformer;
+use Dedoc\Scramble\OpenApiContext;
+use Dedoc\Scramble\Support\Generator\OpenApi;
+use Dedoc\Scramble\Support\Generator\Operation;
+use Dedoc\Scramble\Support\Generator\Tag;
+use Dedoc\Scramble\Support\GroupTree\GroupResolverPipeline;
+use Dedoc\Scramble\Support\GroupTree\TreeBuilder;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Str;
+
+/**
+ * Builds the hierarchical documentation explorer.
+ *
+ * For every operation a group path is resolved through the
+ * {@see GroupResolverPipeline}. The resolved paths are used to:
+ *
+ *  - assign each operation its leaf group as a tag;
+ *  - synthesise parent/child tag relationships (`parent`);
+ *  - emit the `x-tree` and `x-tagGroups` document extensions consumed by the
+ *    documentation UI and Redoc-compatible renderers.
+ *
+ * The transformer is a no-op unless `scramble.groups.enabled` is `true`, which
+ * preserves Scramble's default (flat) tagging behaviour for existing users.
+ */
+class AddTagGroups implements DocumentTransformer
+{
+    /**
+     * Per-instance cache of resolved group paths, keyed by route signature.
+     *
+     * @var array<string, list<string>>
+     */
+    protected array $resolvedPaths = [];
+
+    public function __construct(
+        protected ?GroupResolverPipeline $pipeline = null,
+    ) {}
+
+    public function handle(OpenApi $document, OpenApiContext $context): void
+    {
+        if (! config('scramble.groups.enabled', false)) {
+            return;
+        }
+
+        $pipeline = $this->pipeline ?? new GroupResolverPipeline;
+        $tree = new TreeBuilder;
+
+        $tags = $this->indexTags($document);
+        $orders = $this->groupOrders($document);
+
+        /** @var array<string, array<string, true>> $tagGroups */
+        $tagGroups = [];
+        $hasNesting = false;
+
+        foreach ($document->paths as $pathItem) {
+            foreach ($pathItem->operations as $operation) {
+                $routeAttribute = $operation->getAttribute('route');
+                $route = $routeAttribute instanceof Route ? $routeAttribute : null;
+
+                $groupPath = $this->resolveGroupPath($pipeline, $operation, $route);
+                if ($groupPath === []) {
+                    continue;
+                }
+
+                $tree->addRoute($groupPath, $this->makeRouteNode($operation, $route), $orders);
+
+                $this->syncTags($document, $tags, $groupPath);
+
+                $leaf = $groupPath[array_key_last($groupPath)];
+                $operation->setTags([$leaf]);
+
+                $top = $groupPath[0];
+                $tagGroups[$top][$leaf] = true;
+
+                if (count($groupPath) > 1) {
+                    $hasNesting = true;
+                }
+            }
+        }
+
+        $document->setExtensionProperty('tree', $tree->toArray());
+
+        if ($hasNesting) {
+            $document->setExtensionProperty('tagGroups', $this->buildTagGroups($tagGroups));
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function resolveGroupPath(GroupResolverPipeline $pipeline, Operation $operation, ?Route $route): array
+    {
+        if ($route instanceof Route) {
+            $key = implode('|', $route->methods()).':'.$route->uri();
+
+            return $this->resolvedPaths[$key] ??= $this->ensureNonEmpty(
+                $pipeline->resolve($operation, $route),
+                $operation,
+            );
+        }
+
+        return $this->ensureNonEmpty([], $operation);
+    }
+
+    /**
+     * Guarantee a non-empty group path, falling back to the operation's existing
+     * tags (the default Scramble behaviour) and finally to "General".
+     *
+     * @param  list<string>  $path
+     * @return list<string>
+     */
+    protected function ensureNonEmpty(array $path, Operation $operation): array
+    {
+        if ($path !== []) {
+            return $path;
+        }
+
+        if ($operation->tags !== []) {
+            return [$operation->tags[0]];
+        }
+
+        return ['General'];
+    }
+
+    /**
+     * Index the document tags by name for O(1) lookups and mutation.
+     *
+     * @return array<string, Tag>
+     */
+    protected function indexTags(OpenApi $document): array
+    {
+        $tags = [];
+        foreach ($document->tags as $tag) {
+            $tags[$tag->name] = $tag;
+        }
+
+        return $tags;
+    }
+
+    /**
+     * Map of group name to sort order, derived from `#[Group(weight:)]`.
+     *
+     * @return array<string, int>
+     */
+    protected function groupOrders(OpenApi $document): array
+    {
+        $orders = [];
+        foreach ($document->tags as $tag) {
+            $weight = $tag->getAttribute('weight');
+            if (is_int($weight)) {
+                $orders[$tag->name] = $weight;
+            }
+        }
+
+        return $orders;
+    }
+
+    /**
+     * Ensure each segment of the path exists as a Tag and carries the correct
+     * parent relationship.
+     *
+     * @param  array<string, Tag>  $tags
+     * @param  list<string>  $groupPath
+     */
+    protected function syncTags(OpenApi $document, array &$tags, array $groupPath): void
+    {
+        $parent = null;
+
+        foreach ($groupPath as $segment) {
+            if (! isset($tags[$segment])) {
+                $tags[$segment] = new Tag($segment);
+                $document->tags[] = $tags[$segment];
+            }
+
+            if ($parent !== null) {
+                $tags[$segment]->parent = $parent;
+            }
+
+            $parent = $segment;
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function makeRouteNode(Operation $operation, ?Route $route): array
+    {
+        $controller = $route?->getAction('controller');
+        $controllerName = is_string($controller) ? class_basename(explode('@', $controller)[0]) : null;
+
+        $id = $operation->operationId
+            ?: $operation->method.'-'.Str::of($operation->path)->replace(['/', '{', '}'], ['-', '', ''])->trim('-');
+
+        return array_filter([
+            'id' => $id,
+            'name' => $operation->summary ?: $operation->method.' '.$operation->path,
+            'method' => $operation->method,
+            'path' => $operation->path,
+            'summary' => $operation->summary,
+            'operationId' => $operation->operationId,
+            'controller' => $controllerName,
+            'type' => 'route',
+            'icon' => 'endpoint',
+        ], fn ($value) => $value !== null && $value !== '');
+    }
+
+    /**
+     * @param  array<string, array<string, true>>  $tagGroups
+     * @return list<array{name: string, tags: list<string>}>
+     */
+    protected function buildTagGroups(array $tagGroups): array
+    {
+        $result = [];
+
+        foreach ($tagGroups as $name => $leaves) {
+            $result[] = [
+                'name' => $name,
+                'tags' => array_keys($leaves),
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/ScrambleServiceProvider.php
+++ b/src/ScrambleServiceProvider.php
@@ -9,6 +9,7 @@ use Dedoc\Scramble\Console\Commands\CacheDocumentation;
 use Dedoc\Scramble\Console\Commands\ClearDocumentationCache;
 use Dedoc\Scramble\Console\Commands\ExportDocumentation;
 use Dedoc\Scramble\DocumentTransformers\AddDocumentTags;
+use Dedoc\Scramble\DocumentTransformers\AddTagGroups;
 use Dedoc\Scramble\DocumentTransformers\CleanupUnusedResponseReferencesTransformer;
 use Dedoc\Scramble\Extensions\ExceptionToResponseExtension;
 use Dedoc\Scramble\Extensions\OperationExtension;
@@ -292,6 +293,7 @@ class ScrambleServiceProvider extends PackageServiceProvider
             })
             ->withDocumentTransformers([
                 AddDocumentTags::class,
+                AddTagGroups::class,
                 CleanupUnusedResponseReferencesTransformer::class,
             ]);
 

--- a/src/Support/Generator/OpenApi.php
+++ b/src/Support/Generator/OpenApi.php
@@ -4,6 +4,8 @@ namespace Dedoc\Scramble\Support\Generator;
 
 class OpenApi
 {
+    use WithExtensions;
+
     public string $version;
 
     public InfoObject $info;
@@ -126,6 +128,6 @@ class OpenApi
             $result['components'] = $serializedComponents;
         }
 
-        return $result;
+        return array_merge($result, $this->extensionPropertiesToArray());
     }
 }

--- a/src/Support/Generator/Tag.php
+++ b/src/Support/Generator/Tag.php
@@ -10,6 +10,7 @@ class Tag
     public function __construct(
         public string $name,
         public ?string $description = null,
+        public ?string $parent = null,
     ) {}
 
     public function toArray(): mixed
@@ -17,6 +18,7 @@ class Tag
         $result = array_filter([
             'name' => $this->name,
             'description' => $this->description,
+            'parent' => $this->parent,
         ]);
 
         return array_merge(

--- a/src/Support/GroupTree/AttributeGroupResolver.php
+++ b/src/Support/GroupTree/AttributeGroupResolver.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Dedoc\Scramble\Support\GroupTree;
+
+use Dedoc\Scramble\Attributes\Group;
+use Dedoc\Scramble\Support\Generator\Operation;
+use Illuminate\Routing\Route;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionMethod;
+use Throwable;
+
+class AttributeGroupResolver implements GroupResolverStrategy
+{
+    public function resolve(Operation $operation, Route $route): ?array
+    {
+        $controller = $route->getAction('controller');
+        if (! is_string($controller)) {
+            return null;
+        }
+
+        try {
+            $parts = explode('@', $controller, 2);
+            $className = $parts[0];
+            $methodName = $parts[1] ?? null;
+
+            if (! class_exists($className)) {
+                return null;
+            }
+
+            $classRef = new ReflectionClass($className);
+            $classGroupAttr = $classRef->getAttributes(Group::class)[0] ?? null;
+
+            $methodGroupAttr = null;
+            if ($methodName !== null) {
+                $methodRef = new ReflectionMethod($className, $methodName);
+                $methodGroupAttr = $methodRef->getAttributes(Group::class)[0] ?? null;
+            }
+
+            if (! $classGroupAttr && ! $methodGroupAttr) {
+                return null;
+            }
+
+            $path = array_merge(
+                $this->pathFromAttribute($classGroupAttr),
+                $this->pathFromAttribute($methodGroupAttr),
+            );
+
+            return $path === [] ? null : $path;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @param  ReflectionAttribute<Group>|null  $attribute
+     * @return list<string>
+     */
+    private function pathFromAttribute(?ReflectionAttribute $attribute): array
+    {
+        if ($attribute === null) {
+            return [];
+        }
+
+        $group = $attribute->newInstance();
+
+        $path = $group->parent !== null ? GroupPathSplitter::split($group->parent) : [];
+
+        if ($group->name !== null && $group->name !== '') {
+            $path[] = $group->name;
+        }
+
+        return $path;
+    }
+}

--- a/src/Support/GroupTree/ConfigGroupResolver.php
+++ b/src/Support/GroupTree/ConfigGroupResolver.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Dedoc\Scramble\Support\GroupTree;
+
+use Dedoc\Scramble\Support\Generator\Operation;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+class ConfigGroupResolver implements GroupResolverStrategy
+{
+    public function resolve(Operation $operation, Route $route): ?array
+    {
+        /** @var array<int, array<string, mixed>> $rules */
+        $rules = config('scramble.groups.rules', []);
+
+        foreach ($rules as $rule) {
+            if (! isset($rule['group'], $rule['match'])) {
+                continue;
+            }
+
+            if (! is_array($rule['match']) || ! is_string($rule['group'])) {
+                continue;
+            }
+
+            if ($this->routeMatchesRules($route, $rule['match'])) {
+                // Supports nested groups, e.g. 'Admin/Security'.
+                $path = GroupPathSplitter::split($rule['group']);
+
+                if ($path !== []) {
+                    return $path;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Determine if the route matches the configured rules.
+     *
+     * @param  array<array-key, mixed>  $rules
+     */
+    protected function routeMatchesRules(Route $route, array $rules): bool
+    {
+        // 1. Match by middleware
+        if (isset($rules['middleware'])) {
+            $routeMiddlewares = $route->gatherMiddleware();
+            $matchMiddlewares = Arr::wrap($rules['middleware']);
+
+            foreach ($matchMiddlewares as $pattern) {
+                if (! is_string($pattern)) {
+                    continue;
+                }
+                foreach ($routeMiddlewares as $middleware) {
+                    $middlewareName = is_string($middleware) ? $middleware : $middleware::class;
+                    if (Str::is($pattern, $middlewareName)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // 2. Match by route prefix / URI path pattern
+        if (isset($rules['prefix'])) {
+            $patterns = Arr::wrap($rules['prefix']);
+            $uri = $route->uri();
+            foreach ($patterns as $pattern) {
+                if (! is_string($pattern)) {
+                    continue;
+                }
+                if (Str::is($pattern, $uri) || Str::is($pattern, (string) $route->getPrefix())) {
+                    return true;
+                }
+            }
+        }
+
+        // 3. Match by controller namespace
+        if (isset($rules['namespace'])) {
+            $patterns = Arr::wrap($rules['namespace']);
+            $controller = $route->getAction('controller');
+            if (is_string($controller)) {
+                foreach ($patterns as $pattern) {
+                    if (is_string($pattern) && Str::is($pattern, $controller)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Support/GroupTree/FallbackGroupResolver.php
+++ b/src/Support/GroupTree/FallbackGroupResolver.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Dedoc\Scramble\Support\GroupTree;
+
+use Dedoc\Scramble\Support\Generator\Operation;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Str;
+
+/**
+ * Terminal resolver that always returns a group path, guaranteeing the pipeline
+ * never resolves to an empty hierarchy. It prefers the controller base name
+ * (without the "Controller" suffix) and falls back to a single configurable
+ * default group.
+ */
+class FallbackGroupResolver implements GroupResolverStrategy
+{
+    public function __construct(
+        private readonly string $default = 'General',
+    ) {}
+
+    public function resolve(Operation $operation, Route $route): array
+    {
+        $controller = $route->getAction('controller');
+
+        if (is_string($controller) && $controller !== '') {
+            $class = class_basename(explode('@', $controller)[0]);
+            $name = (string) Str::of($class)->replace('Controller', '')->trim();
+
+            if ($name !== '') {
+                return [$name];
+            }
+        }
+
+        return [$this->default];
+    }
+}

--- a/src/Support/GroupTree/GroupPathSplitter.php
+++ b/src/Support/GroupTree/GroupPathSplitter.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Dedoc\Scramble\Support\GroupTree;
+
+/**
+ * Splits a human-readable group path (e.g. "Admin / Security > Users") into
+ * its individual, ordered segments.
+ */
+class GroupPathSplitter
+{
+    /**
+     * @return list<string>
+     */
+    public static function split(string $path): array
+    {
+        $segments = preg_split('/\s*[\/>.]\s*/', trim($path)) ?: [];
+
+        return array_values(array_filter(
+            array_map('trim', $segments),
+            fn (string $segment) => $segment !== '',
+        ));
+    }
+}

--- a/src/Support/GroupTree/GroupResolverPipeline.php
+++ b/src/Support/GroupTree/GroupResolverPipeline.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Dedoc\Scramble\Support\GroupTree;
+
+use Dedoc\Scramble\Support\Generator\Operation;
+use Illuminate\Routing\Route;
+
+/**
+ * Runs an ordered set of {@see GroupResolverStrategy} instances and returns the
+ * first non-empty group path. A terminal strategy (typically
+ * {@see FallbackGroupResolver}) is expected to guarantee a non-empty result.
+ */
+class GroupResolverPipeline
+{
+    /** @var list<GroupResolverStrategy> */
+    protected array $strategies;
+
+    /**
+     * @param  iterable<GroupResolverStrategy>  $strategies
+     */
+    public function __construct(iterable $strategies = [])
+    {
+        $this->strategies = is_array($strategies) ? array_values($strategies) : iterator_to_array($strategies, false);
+
+        if ($this->strategies === []) {
+            $this->strategies = self::defaultStrategies();
+        }
+    }
+
+    /**
+     * The default, ordered resolution strategies.
+     *
+     * @return list<GroupResolverStrategy>
+     */
+    public static function defaultStrategies(): array
+    {
+        return [
+            new AttributeGroupResolver,
+            new ConfigGroupResolver,
+            new RouteGroupResolver,
+            new FallbackGroupResolver,
+        ];
+    }
+
+    /**
+     * Register an additional strategy.
+     */
+    public function registerStrategy(GroupResolverStrategy $strategy, bool $prepend = false): void
+    {
+        if ($prepend) {
+            array_unshift($this->strategies, $strategy);
+        } else {
+            $this->strategies[] = $strategy;
+        }
+    }
+
+    /**
+     * Resolve the group path hierarchy for the given operation and route.
+     *
+     * @return list<string>
+     */
+    public function resolve(Operation $operation, Route $route): array
+    {
+        foreach ($this->strategies as $strategy) {
+            $path = $strategy->resolve($operation, $route);
+
+            if ($path !== null && $path !== []) {
+                return $path;
+            }
+        }
+
+        return [];
+    }
+}

--- a/src/Support/GroupTree/GroupResolverStrategy.php
+++ b/src/Support/GroupTree/GroupResolverStrategy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Dedoc\Scramble\Support\GroupTree;
+
+use Dedoc\Scramble\Support\Generator\Operation;
+use Illuminate\Routing\Route;
+
+interface GroupResolverStrategy
+{
+    /**
+     * Resolve the group path (top-down hierarchy of group names) for the given
+     * operation and route. Return null when this strategy cannot resolve a path,
+     * allowing the next strategy in the pipeline to attempt resolution.
+     *
+     * @return list<string>|null
+     */
+    public function resolve(Operation $operation, Route $route): ?array;
+}

--- a/src/Support/GroupTree/RouteGroupResolver.php
+++ b/src/Support/GroupTree/RouteGroupResolver.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Dedoc\Scramble\Support\GroupTree;
+
+use Dedoc\Scramble\Support\Generator\Operation;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Str;
+
+/**
+ * Resolves a group hierarchy from the route definition itself, using the route
+ * prefix first and falling back to the dotted route name.
+ *
+ * Namespace-based resolution is intentionally avoided: it relies on
+ * application-specific conventions and produces unpredictable results for
+ * package or modular controllers.
+ */
+class RouteGroupResolver implements GroupResolverStrategy
+{
+    public function resolve(Operation $operation, Route $route): ?array
+    {
+        return $this->fromPrefix($route)
+            ?? $this->fromName($route);
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    private function fromPrefix(Route $route): ?array
+    {
+        $prefix = trim((string) $route->getPrefix(), '/');
+        if ($prefix === '') {
+            return null;
+        }
+
+        // Strip the leading api/ and version (v1, v2, ...) segments.
+        $prefix = (string) preg_replace('#^(?:api/)?(?:v\d+/)?#i', '', $prefix);
+
+        return $this->studlySegments(explode('/', $prefix));
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    private function fromName(Route $route): ?array
+    {
+        $name = (string) $route->getName();
+        if ($name === '') {
+            return null;
+        }
+
+        $parts = array_values(array_filter(explode('.', $name), fn ($p) => $p !== ''));
+        if (count($parts) <= 1) {
+            return null;
+        }
+
+        // Drop the trailing action segment (index, store, ...).
+        array_pop($parts);
+
+        return $this->studlySegments($parts);
+    }
+
+    /**
+     * @param  array<int, string>  $segments
+     * @return list<string>|null
+     */
+    private function studlySegments(array $segments): ?array
+    {
+        $path = array_values(array_map(
+            fn (string $segment) => (string) Str::of($segment)->studly(),
+            array_filter($segments, fn (string $segment) => trim($segment) !== ''),
+        ));
+
+        return $path === [] ? null : $path;
+    }
+}

--- a/src/Support/GroupTree/TreeBuilder.php
+++ b/src/Support/GroupTree/TreeBuilder.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Dedoc\Scramble\Support\GroupTree;
+
+/**
+ * Builds a hierarchical documentation explorer tree from resolved group paths.
+ *
+ * The builder is deliberately decoupled from Scramble's generator objects: it
+ * accepts plain group paths and route node arrays, which keeps it trivially
+ * unit-testable and free of reflection or routing concerns.
+ */
+class TreeBuilder
+{
+    /** @var array<string, TreeNode> */
+    protected array $nodes = [];
+
+    /** @var list<TreeNode> */
+    protected array $roots = [];
+
+    /**
+     * Insert a route under the given group path, creating intermediate group
+     * nodes as needed. Duplicate group paths are merged automatically.
+     *
+     * @param  list<string>  $groupPath
+     * @param  array<string, mixed>  $routeNode
+     * @param  array<string, int>  $groupOrders  Map of group name to sort order.
+     */
+    public function addRoute(array $groupPath, array $routeNode, array $groupOrders = []): void
+    {
+        $leaf = $this->ensureGroupPath($groupPath, $groupOrders);
+
+        $leaf->routes[] = $routeNode;
+    }
+
+    /**
+     * @param  list<string>  $groupPath
+     * @param  array<string, int>  $groupOrders
+     */
+    protected function ensureGroupPath(array $groupPath, array $groupOrders): TreeNode
+    {
+        $parentKey = null;
+        $depth = 0;
+
+        foreach ($groupPath as $segment) {
+            $key = $parentKey === null ? $segment : $parentKey.'/'.$segment;
+
+            if (! isset($this->nodes[$key])) {
+                $node = new TreeNode($key, $segment);
+                $node->parent = $parentKey;
+                $node->depth = $depth;
+
+                $this->nodes[$key] = $node;
+
+                if ($parentKey === null) {
+                    $this->roots[] = $node;
+                } else {
+                    $this->nodes[$parentKey]->children[] = $node;
+                }
+            }
+
+            if (isset($groupOrders[$segment])) {
+                // Keep the lowest (most significant) order seen for a group.
+                $this->nodes[$key]->order = min($this->nodes[$key]->order, $groupOrders[$segment]);
+            }
+
+            $parentKey = $key;
+            $depth++;
+        }
+
+        return $this->nodes[$parentKey];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        $roots = $this->roots;
+
+        usort($roots, function (TreeNode $a, TreeNode $b) {
+            return $a->order <=> $b->order ?: strnatcasecmp($a->name, $b->name);
+        });
+
+        return array_map(fn (TreeNode $node) => $node->toArray(), $roots);
+    }
+}

--- a/src/Support/GroupTree/TreeNode.php
+++ b/src/Support/GroupTree/TreeNode.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Dedoc\Scramble\Support\GroupTree;
+
+/**
+ * A single node in the documentation explorer tree. A node is either a "group"
+ * (a folder that can contain child groups and routes) or a "route" leaf.
+ */
+class TreeNode
+{
+    public ?string $parent = null;
+
+    public int $depth = 0;
+
+    public int $order = PHP_INT_MAX;
+
+    public string $type = 'group';
+
+    public ?string $icon = 'folder';
+
+    /** @var list<TreeNode> */
+    public array $children = [];
+
+    /** @var list<array<string, mixed>> */
+    public array $routes = [];
+
+    /** @var array<string, mixed> */
+    public array $metadata = [];
+
+    public function __construct(
+        public string $id,
+        public string $name,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        // Groups first, then by explicit order, then by natural (case-insensitive) name.
+        // usort is stable as of PHP 8.0, so equal nodes keep their insertion order.
+        $children = $this->children;
+        usort($children, function (TreeNode $a, TreeNode $b) {
+            return [$a->type === 'group' ? 0 : 1, $a->order]
+                <=> [$b->type === 'group' ? 0 : 1, $b->order]
+                ?: strnatcasecmp($a->name, $b->name);
+        });
+
+        $children = array_map(fn (TreeNode $child) => $child->toArray(), $children);
+
+        return array_filter([
+            'id' => $this->id,
+            'name' => $this->name,
+            'parent' => $this->parent,
+            'depth' => $this->depth,
+            'order' => $this->order,
+            'type' => $this->type,
+            'icon' => $this->icon,
+            'children' => $children,
+            'routes' => $this->routes,
+            'metadata' => $this->metadata,
+        ], fn ($value) => $value !== null && $value !== []);
+    }
+}

--- a/src/Support/OperationExtensions/RequestEssentialsExtension.php
+++ b/src/Support/OperationExtensions/RequestEssentialsExtension.php
@@ -86,6 +86,7 @@ class RequestEssentialsExtension extends OperationExtension
         }
 
         $operation->setAttribute('operationId', $this->getOperationId($routeInfo));
+        $operation->setAttribute('route', $routeInfo->route);
 
         $this->setTitleAndDescriptionFromEndpointAttribute($operation, $routeInfo);
     }

--- a/tests/DocumentTransformers/TagGroupsTest.php
+++ b/tests/DocumentTransformers/TagGroupsTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Dedoc\Scramble\Tests\DocumentTransformers;
+
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Support\Facades\Route;
+
+beforeEach(function () {
+    config()->set('scramble.groups.enabled', true);
+});
+
+it('does nothing when the feature is disabled (backward compatible)', function () {
+    config()->set('scramble.groups.enabled', false);
+
+    $document = generateForRoute(fn () => Route::get('test-flat', TagGroupsTest_ControllerA::class));
+
+    expect($document)->not->toHaveKey('x-tree');
+    expect($document)->not->toHaveKey('x-tagGroups');
+});
+
+it('generates parent tag and x-tree from the #[Group] attribute', function () {
+    $document = generateForRoute(fn () => Route::get('test-attr', TagGroupsTest_ControllerA::class));
+
+    $usersTag = collect($document['tags'] ?? [])->firstWhere('name', 'Users');
+    expect($usersTag)->not->toBeNull()
+        ->and($usersTag['parent'])->toBe('Admin');
+
+    $admin = collect($document['x-tree'] ?? [])->firstWhere('name', 'Admin');
+    expect($admin)->not->toBeNull()
+        ->and($admin['depth'])->toBe(0);
+
+    $users = collect($admin['children'])->firstWhere('name', 'Users');
+    expect($users)->not->toBeNull()
+        ->and($users['parent'])->toBe('Admin')
+        ->and($users['depth'])->toBe(1)
+        ->and($users['routes'][0]['path'])->toBe('test-attr');
+});
+
+it('assigns only the leaf group as the operation tag', function () {
+    $document = generateForRoute(fn () => Route::get('test-attr-leaf', TagGroupsTest_ControllerA::class));
+
+    $operation = $document['paths']['/test-attr-leaf']['get'];
+    expect($operation['tags'])->toBe(['Users']);
+});
+
+it('generates x-tagGroups and a nested tree from config rules', function () {
+    config()->set('scramble.groups.rules', [
+        ['group' => 'ConfigGroup/SubGroup', 'match' => ['prefix' => 'test-config*']],
+    ]);
+
+    $document = generateForRoute(fn () => Route::get('test-config-route', TagGroupsTest_ControllerB::class));
+
+    $group = collect($document['x-tagGroups'] ?? [])->firstWhere('name', 'ConfigGroup');
+    expect($group)->not->toBeNull()
+        ->and($group['tags'])->toContain('SubGroup');
+
+    $node = collect($document['x-tree'] ?? [])->firstWhere('name', 'ConfigGroup');
+    expect($node)->not->toBeNull()
+        ->and(collect($node['children'])->firstWhere('name', 'SubGroup'))->not->toBeNull();
+});
+
+it('resolves nested Laravel route group prefixes', function () {
+    $document = generateForRoute(function () {
+        $route = null;
+        Route::prefix('admin-panel')->name('admin.')->group(function () use (&$route) {
+            Route::prefix('billing-info')->group(function () use (&$route) {
+                $route = Route::get('test-route-group', TagGroupsTest_ControllerC::class);
+            });
+        });
+
+        return $route;
+    });
+
+    $admin = collect($document['x-tree'] ?? [])->firstWhere('name', 'AdminPanel');
+    expect($admin)->not->toBeNull();
+
+    $billing = collect($admin['children'])->firstWhere('name', 'BillingInfo');
+    expect($billing)->not->toBeNull()
+        ->and($billing['routes'])->not->toBeEmpty();
+});
+
+it('groups routes by a middleware config rule', function () {
+    config()->set('scramble.groups.rules', [
+        ['group' => 'Secured/Admin', 'match' => ['middleware' => 'auth:admin']],
+    ]);
+
+    $document = generateForRoute(
+        fn () => Route::get('test-mw', TagGroupsTest_ControllerB::class)->middleware('auth:admin')
+    );
+
+    $secured = collect($document['x-tree'] ?? [])->firstWhere('name', 'Secured');
+    expect($secured)->not->toBeNull()
+        ->and(collect($secured['children'])->firstWhere('name', 'Admin'))->not->toBeNull();
+});
+
+it('groups every operation of a resource controller under one group', function () {
+    $document = generateForRoute(function () {
+        Route::apiResource('test-photos', TagGroupsTest_ResourceController::class);
+
+        return app('router')->getRoutes()->getByName('test-photos.index');
+    });
+
+    $photos = collect($document['x-tree'] ?? [])->firstWhere('name', 'Photos');
+    expect($photos)->not->toBeNull();
+
+    // index (GET) and store (POST) share the `test-photos` URI and must both be grouped.
+    $methods = collect($photos['routes'])->pluck('method')->sort()->values()->all();
+    expect($methods)->toBe(['get', 'post']);
+});
+
+it('falls back to the controller name when nothing else resolves', function () {
+    $document = generateForRoute(fn () => Route::get('test-fallback', TagGroupsTest_ControllerB::class));
+
+    // The "Controller" token is stripped from the class base name:
+    // TagGroupsTest_ControllerB -> TagGroupsTest_B.
+    $node = collect($document['x-tree'] ?? [])->firstWhere('name', 'TagGroupsTest_B');
+    expect($node)->not->toBeNull();
+});
+
+#[Group('Users', parent: 'Admin')]
+class TagGroupsTest_ControllerA
+{
+    public function __invoke()
+    {
+        return 'test';
+    }
+}
+
+class TagGroupsTest_ControllerB
+{
+    public function __invoke()
+    {
+        return 'test';
+    }
+}
+
+class TagGroupsTest_ControllerC
+{
+    public function __invoke()
+    {
+        return 'test';
+    }
+}
+
+#[Group('Photos')]
+class TagGroupsTest_ResourceController
+{
+    public function index()
+    {
+        return 'index';
+    }
+
+    public function store()
+    {
+        return 'store';
+    }
+
+    public function show(string $id)
+    {
+        return 'show';
+    }
+
+    public function update(string $id)
+    {
+        return 'update';
+    }
+
+    public function destroy(string $id)
+    {
+        return 'destroy';
+    }
+}

--- a/tests/Support/GroupTreeTest.php
+++ b/tests/Support/GroupTreeTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Dedoc\Scramble\Tests\Support;
+
+use Dedoc\Scramble\Support\Generator\Operation;
+use Dedoc\Scramble\Support\GroupTree\FallbackGroupResolver;
+use Dedoc\Scramble\Support\GroupTree\GroupPathSplitter;
+use Dedoc\Scramble\Support\GroupTree\GroupResolverPipeline;
+use Dedoc\Scramble\Support\GroupTree\TreeBuilder;
+use Illuminate\Routing\Route;
+
+dataset('splitter paths', [
+    ['Admin/Security', ['Admin', 'Security']],
+    ['Admin > Security > Users', ['Admin', 'Security', 'Users']],
+    ['Admin.Security', ['Admin', 'Security']],
+    ['  /Admin/Security/  ', ['Admin', 'Security']],
+    ['Single', ['Single']],
+    ['', []],
+    ['   ', []],
+]);
+
+it('splits group paths on /, > and . separators', function (string $input, array $expected) {
+    expect(GroupPathSplitter::split($input))->toBe($expected);
+})->with('splitter paths');
+
+it('merges duplicate group paths and attaches every route to the shared leaf', function () {
+    $tree = new TreeBuilder;
+    $tree->addRoute(['Admin', 'Users'], ['id' => 'a', 'name' => 'a', 'type' => 'route']);
+    $tree->addRoute(['Admin', 'Users'], ['id' => 'b', 'name' => 'b', 'type' => 'route']);
+
+    $roots = $tree->toArray();
+
+    expect($roots)->toHaveCount(1)
+        ->and($roots[0]['name'])->toBe('Admin')
+        ->and($roots[0]['children'])->toHaveCount(1)
+        ->and($roots[0]['children'][0]['name'])->toBe('Users')
+        ->and($roots[0]['children'][0]['routes'])->toHaveCount(2);
+});
+
+it('supports unlimited nesting with correct depth', function () {
+    $tree = new TreeBuilder;
+    $tree->addRoute(['A', 'B', 'C', 'D'], ['id' => 'x', 'name' => 'x', 'type' => 'route']);
+
+    $roots = $tree->toArray();
+    $a = $roots[0];
+    $b = $a['children'][0];
+    $c = $b['children'][0];
+    $d = $c['children'][0];
+
+    expect($a['depth'])->toBe(0)
+        ->and($b['depth'])->toBe(1)
+        ->and($c['depth'])->toBe(2)
+        ->and($d['depth'])->toBe(3)
+        ->and($d['routes'])->toHaveCount(1);
+});
+
+it('orders sibling groups by explicit order then natural name', function () {
+    $tree = new TreeBuilder;
+    $tree->addRoute(['Zebra'], ['id' => 'z', 'name' => 'z', 'type' => 'route'], ['Zebra' => 1]);
+    $tree->addRoute(['Apple'], ['id' => 'a', 'name' => 'a', 'type' => 'route'], ['Apple' => 2]);
+    $tree->addRoute(['Mango'], ['id' => 'm', 'name' => 'm', 'type' => 'route']);
+
+    $names = array_column($tree->toArray(), 'name');
+
+    // Zebra (order 1) and Apple (order 2) come before Mango (default order, sorted by name).
+    expect($names)->toBe(['Zebra', 'Apple', 'Mango']);
+});
+
+it('falls back to the controller name without the Controller suffix', function () {
+    $resolver = new FallbackGroupResolver;
+    $route = new Route(['GET'], '/users', ['controller' => 'App\\Http\\Controllers\\UserController@index']);
+
+    expect($resolver->resolve(new Operation('get'), $route))->toBe(['User']);
+});
+
+it('falls back to the configured default group for closure routes', function () {
+    $resolver = new FallbackGroupResolver('Misc');
+    $route = new Route(['GET'], '/ping', ['uses' => fn () => 'pong']);
+
+    expect($resolver->resolve(new Operation('get'), $route))->toBe(['Misc']);
+});
+
+it('returns the first non-empty path from the pipeline', function () {
+    $pipeline = new GroupResolverPipeline;
+    $route = new Route(['GET'], '/users', ['controller' => 'App\\Http\\Controllers\\UserController@index']);
+
+    // No attribute, config rules or prefix -> fallback resolver wins.
+    expect($pipeline->resolve(new Operation('get'), $route))->toBe(['User']);
+});


### PR DESCRIPTION
﻿> Draft — opened early to get maintainer feedback on scope and direction.

## Motivation
Scramble currently groups endpoints one level deep, via `#[Group]` and tags. As an API grows, that flat list becomes hard to navigate, and there is currently no way to express nested groups (e.g. `Admin → Users`). This adds optional nesting as a natural extension of the grouping concept Scramble already exposes.

## Summary
When enabled, each operation is assigned to a (possibly nested) group, resolved in priority order from the `#[Group]` attribute, configuration rules, the route prefix/name, and finally the controller name. The result is emitted as standard tag `parent` relationships plus the `x-tagGroups` (Redoc-compatible) and `x-tree` document extensions. No UI is included in this PR.

## Features
- Nested endpoint groups (unlimited depth)
- Attribute-based grouping via `#[Group(parent: ...)]`
- Config-based grouping rules (middleware / prefix / namespace)
- Automatic grouping from route prefix or name, with a controller-name fallback

## Backward compatibility
- Disabled by default (`scramble.groups.enabled = false`).
- `parent` is added only as an optional, last parameter on `#[Group]` and `Tag`; no existing call sites change.
- With the feature disabled, generated documents are byte-identical to current output (verified against the full suite).

## Maintainability
Responsibilities are isolated: a strategy pipeline resolves group paths, a self-contained builder assembles the tree, and a thin document transformer wires them together. No duplicated logic, no oversized classes.

## Testing (executed locally)
- Pest: 21 new tests covering attribute, config, route-prefix, middleware and resource-controller grouping, tree building, and the disabled path — all pass.
- Full suite: no regressions versus the base branch.
- PHPStan (level 9) and Pint: clean on all files in this PR.

## Note to maintainers
Feedback is very welcome — I am happy to adjust the public API (e.g. promoting the resolver interface to a contract, or making grouping per-`registerApi()`).

> A follow-up Pull Request containing an optional documentation explorer UI has been prepared separately but is intentionally excluded from this review to keep the scope focused.
