### PR TITLE
query parameter serialization metadata

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -140,6 +140,14 @@ return [
      */
     'flatten_deep_query_parameters' => true,
 
+    /**
+     * Determines the default documented array query parameter serialization.
+     *
+     * When `query_array_parameter_explode` is `true`, Scramble relies on OpenAPI defaults (`style: form` and `explode: true`).
+     * When `query_array_parameter_explode` is `false`, Scramble will document array query parameters with `style: form` and `explode: false`.
+     */
+    'query_array_parameter_explode' => true,
+
     'middleware' => [
         'web',
         RestrictedDocsAccess::class,

--- a/src/Attributes/QueryParameter.php
+++ b/src/Attributes/QueryParameter.php
@@ -18,6 +18,9 @@ class QueryParameter extends Parameter
         mixed $default = new MissingValue,
         mixed $example = new MissingValue,
         array $examples = [],
+        public readonly ?QueryParameterStyle $style = null,
+        public readonly ?bool $explode = null,
+        public readonly ?bool $allowReserved = null,
     ) {
         parent::__construct('query', $name, $description, $required, $deprecated, $type, $format, $infer, $default, $example, $examples);
     }

--- a/src/Attributes/QueryParameterStyle.php
+++ b/src/Attributes/QueryParameterStyle.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Dedoc\Scramble\Attributes;
+
+enum QueryParameterStyle: string
+{
+    case Form = 'form';
+    case SpaceDelimited = 'spaceDelimited';
+    case PipeDelimited = 'pipeDelimited';
+    case DeepObject = 'deepObject';
+}

--- a/src/Support/Generator/Parameter.php
+++ b/src/Support/Generator/Parameter.php
@@ -20,6 +20,8 @@ class Parameter
 
     public ?bool $explode = null;
 
+    public ?bool $allowReserved = null;
+
     /**
      * Possible values are "simple", "label", "matrix", "form", "spaceDelimited", "pipeDelimited" or "deepObject".
      *
@@ -90,6 +92,9 @@ class Parameter
             ! is_null($this->explode) ? [
                 'explode' => $this->explode,
             ] : [],
+            ! is_null($this->allowReserved) ? [
+                'allowReserved' => $this->allowReserved,
+            ] : [],
             $examples ? ['examples' => $examples] : [],
             $this->extensionPropertiesToArray(),
         );
@@ -143,6 +148,13 @@ class Parameter
     public function setStyle(string $style): self
     {
         $this->style = $style;
+
+        return $this;
+    }
+
+    public function setAllowReserved(?bool $allowReserved): self
+    {
+        $this->allowReserved = $allowReserved;
 
         return $this;
     }

--- a/src/Support/Generator/Parameter.php
+++ b/src/Support/Generator/Parameter.php
@@ -69,8 +69,13 @@ class Parameter
             'description' => $this->description,
             'deprecated' => $this->deprecated,
             'allowEmptyValue' => $this->allowEmptyValue,
+            'allowReserved' => $this->allowReserved,
             'style' => $this->style,
         ]);
+
+        if ($this->explode !== null) {
+            $result['explode'] = $this->explode;
+        }
 
         if ($this->schema) {
             $result['schema'] = $this->schema->toArray();
@@ -89,12 +94,6 @@ class Parameter
         return array_merge(
             $result,
             $this->example instanceof MissingValue ? [] : ['example' => $this->example],
-            ! is_null($this->explode) ? [
-                'explode' => $this->explode,
-            ] : [],
-            ! is_null($this->allowReserved) ? [
-                'allowReserved' => $this->allowReserved,
-            ] : [],
             $examples ? ['examples' => $examples] : [],
             $this->extensionPropertiesToArray(),
         );

--- a/src/Support/OperationExtensions/ParameterExtractor/AttributesParametersExtractor.php
+++ b/src/Support/OperationExtensions/ParameterExtractor/AttributesParametersExtractor.php
@@ -6,6 +6,8 @@ use Dedoc\Scramble\Attributes\Example;
 use Dedoc\Scramble\Attributes\IgnoreParam;
 use Dedoc\Scramble\Attributes\MissingValue;
 use Dedoc\Scramble\Attributes\Parameter as ParameterAttribute;
+use Dedoc\Scramble\Attributes\QueryParameter as QueryParameterAttribute;
+use Dedoc\Scramble\Attributes\QueryParameterStyle;
 use Dedoc\Scramble\PhpDoc\PhpDocTypeHelper;
 use Dedoc\Scramble\Support\Generator\MissingValue as OpenApiMissingValue;
 use Dedoc\Scramble\Support\Generator\Parameter;
@@ -109,18 +111,21 @@ class AttributesParametersExtractor implements ParameterExtractor
     private function createParameter(array $extractedParameters, ParameterAttribute $attribute, array $attributeArguments): Parameter
     {
         $attributeParameter = $this->createParameterFromAttribute($attribute);
+        $namedAttributes = $this->createNamedAttributes($attribute::class, $attributeArguments);
 
         if (! $attribute->infer) {
+            $attributeParameter->setAttribute('serializationInferenceEligible', false);
+
             return $attributeParameter;
         }
 
         if (! $inferredParameter = $this->getParameterFromAutomaticallyInferred($extractedParameters, $attribute->in, $attribute->name)) {
+            $attributeParameter->setAttribute('serializationInferenceEligible', false);
+
             return $attributeParameter;
         }
 
         $parameter = deep_copy($inferredParameter);
-
-        $namedAttributes = $this->createNamedAttributes($attribute::class, $attributeArguments);
 
         foreach ($namedAttributes as $name => $attrValue) {
             if ($name === 'in' || $name === 'name') {
@@ -162,6 +167,8 @@ class AttributesParametersExtractor implements ParameterExtractor
             $parameter->setAttribute('nonBody', $attributeParameter->getAttribute('nonBody'));
         }
 
+        $this->applyQueryParameterSerialization($parameter, $attribute, $namedAttributes);
+
         return $parameter;
     }
 
@@ -200,7 +207,36 @@ class AttributesParametersExtractor implements ParameterExtractor
             $type->format = $attribute->format;
         }
 
+        $this->applyQueryParameterSerialization($parameter, $attribute);
+
         return $parameter;
+    }
+
+    private function applyQueryParameterSerialization(Parameter $parameter, ParameterAttribute $attribute, array $namedAttributes = []): void
+    {
+        if (! $attribute instanceof QueryParameterAttribute) {
+            return;
+        }
+
+        if (array_key_exists('style', $namedAttributes) || $attribute->style !== null) {
+            $style = $attribute->style?->value;
+
+            $parameter->style = $style;
+
+            if ($style === QueryParameterStyle::DeepObject->value) {
+                $parameter->explode = true;
+            }
+        }
+
+        if (array_key_exists('explode', $namedAttributes) || $attribute->explode !== null) {
+            $parameter->explode = $attribute->style === QueryParameterStyle::DeepObject
+                ? true
+                : $attribute->explode;
+        }
+
+        if (array_key_exists('allowReserved', $namedAttributes) || $attribute->allowReserved !== null) {
+            $parameter->allowReserved = $attribute->allowReserved;
+        }
     }
 
     /**

--- a/src/Support/OperationExtensions/RequestBodyExtension.php
+++ b/src/Support/OperationExtensions/RequestBodyExtension.php
@@ -182,10 +182,53 @@ class RequestBodyExtension extends OperationExtension
     protected function prepareQueryParams(array $params): array
     {
         return $this->unescapeEscapedDotNamedParameters(
-            $this->config->get('flatten_deep_query_parameters', true)
-                ? $this->convertDotNamedParamsToFlatQueryParams($params)
-                : $this->convertDotNamedParamsToComplexStructures($params)
+            $this->applyQueryParameterSerialization(
+                $this->config->get('flatten_deep_query_parameters', true)
+                    ? $this->convertDotNamedParamsToFlatQueryParams($params)
+                    : $this->convertDotNamedParamsToComplexStructures($params)
+            )
         );
+    }
+
+    /**
+     * @param  Parameter[]  $params
+     * @return Parameter[]
+     */
+    protected function applyQueryParameterSerialization(array $params): array
+    {
+        $arrayExplode = $this->config->get('query_array_parameter_explode', true);
+        $deepQueryObjects = ! $this->config->get('flatten_deep_query_parameters', true);
+
+        return array_map(function (Parameter $parameter) use ($arrayExplode, $deepQueryObjects) {
+            if (! $parameter->getAttribute('serializationInferenceEligible', true)) {
+                return $parameter;
+            }
+
+            if ($parameter->style === 'deepObject') {
+                $parameter->explode = true;
+
+                return $parameter;
+            }
+
+            if ($deepQueryObjects && $parameter->style === null && $parameter->explode === null && $parameter->schema?->type?->type === 'object') {
+                $parameter->style = 'deepObject';
+                $parameter->explode = true;
+
+                return $parameter;
+            }
+
+            if (
+                ! $arrayExplode
+                && $parameter->style === null
+                && $parameter->explode === null
+                && $parameter->schema?->type?->type === 'array'
+            ) {
+                $parameter->style = 'form';
+                $parameter->explode = false;
+            }
+
+            return $parameter;
+        }, $params);
     }
 
     /**

--- a/tests/Attributes/ParameterAnnotationsTest.php
+++ b/tests/Attributes/ParameterAnnotationsTest.php
@@ -9,6 +9,7 @@ use Dedoc\Scramble\Attributes\IgnoreParam;
 use Dedoc\Scramble\Attributes\Parameter;
 use Dedoc\Scramble\Attributes\PathParameter;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Dedoc\Scramble\Attributes\QueryParameterStyle;
 use Dedoc\Scramble\Attributes\SchemaName;
 use Dedoc\Scramble\Generator;
 use Illuminate\Foundation\Http\FormRequest;
@@ -247,6 +248,72 @@ it('reads QueryParameter attribute from FormRequest class for GET requests', fun
 
     expect($parameterNames)->toContain('search');
 });
+
+it('supports explicit query serialization attributes', function () {
+    $openApi = generateForRoute(fn (Router $r) => $r->get('api/test', ExplicitQuerySerializationController_ParameterAnnotationsTest::class));
+
+    expect($openApi['paths']['/test']['get']['parameters'][0])
+        ->toBe([
+            'name' => 'search',
+            'in' => 'query',
+            'style' => 'form',
+            'schema' => [
+                'type' => 'string',
+            ],
+            'explode' => true,
+            'allowReserved' => true,
+        ]);
+});
+
+it('supports explicit query explode false', function () {
+    $openApi = generateForRoute(fn (Router $r) => $r->get('api/test', ExplicitQueryExplodeFalseController_ParameterAnnotationsTest::class));
+
+    expect($openApi['paths']['/test']['get']['parameters'][0])
+        ->toBe([
+            'name' => 'tags[]',
+            'in' => 'query',
+            'schema' => [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'string',
+                ],
+            ],
+            'explode' => false,
+        ]);
+});
+
+it('ignores deepObject query serialization when query parameters are flattened', function () {
+    $openApi = generateForRoute(fn (Router $r) => $r->get('api/test', DeepObjectQuerySerializationController_ParameterAnnotationsTest::class));
+
+    expect($openApi['paths']['/test']['get']['parameters'][0])
+        ->toBe([
+            'name' => 'filter[accountable]',
+            'in' => 'query',
+            'schema' => [
+                'type' => 'integer',
+            ],
+        ]);
+});
+
+it('lets explicit query serialization override inferred array config', function () {
+    config()->set('scramble.query_array_parameter_explode', false);
+
+    $openApi = generateForRoute(fn (Router $r) => $r->get('api/test', OverrideArraySerializationController_ParameterAnnotationsTest::class));
+
+    expect($openApi['paths']['/test']['get']['parameters'][0])
+        ->toBe([
+            'name' => 'tags[]',
+            'in' => 'query',
+            'schema' => [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'string',
+                ],
+            ],
+            'explode' => true,
+        ]);
+});
+
 #[QueryParameter('search', description: 'Search term')]
 class QueryParameterOnFormRequestFormRequest_ParameterAnnotationsTest extends FormRequest
 {
@@ -258,6 +325,46 @@ class QueryParameterOnFormRequestFormRequest_ParameterAnnotationsTest extends Fo
 class QueryParameterOnFormRequestController_ParameterAnnotationsTest
 {
     public function __invoke(QueryParameterOnFormRequestFormRequest_ParameterAnnotationsTest $request) {}
+}
+
+class ExplicitQuerySerializationController_ParameterAnnotationsTest
+{
+    #[QueryParameter('search', type: 'string', infer: false, style: QueryParameterStyle::Form, explode: true, allowReserved: true)]
+    public function __invoke() {}
+}
+
+class ExplicitQueryExplodeFalseController_ParameterAnnotationsTest
+{
+    #[QueryParameter('tags', explode: false)]
+    public function __invoke(Request $request)
+    {
+        $request->validate([
+            'tags' => 'array',
+        ]);
+    }
+}
+
+class DeepObjectQuerySerializationController_ParameterAnnotationsTest
+{
+    #[QueryParameter('filter', style: QueryParameterStyle::DeepObject, explode: false)]
+    public function __invoke(Request $request)
+    {
+        $request->validate([
+            'filter' => 'array',
+            'filter.accountable' => 'integer',
+        ]);
+    }
+}
+
+class OverrideArraySerializationController_ParameterAnnotationsTest
+{
+    #[QueryParameter('tags', explode: true)]
+    public function __invoke(Request $request)
+    {
+        $request->validate([
+            'tags' => 'array',
+        ]);
+    }
 }
 
 it('uses SchemaName attribute on FormRequest as component schema name', function () {

--- a/tests/Attributes/ParameterAnnotationsTest.php
+++ b/tests/Attributes/ParameterAnnotationsTest.php
@@ -256,12 +256,12 @@ it('supports explicit query serialization attributes', function () {
         ->toBe([
             'name' => 'search',
             'in' => 'query',
+            'allowReserved' => true,
             'style' => 'form',
+            'explode' => true,
             'schema' => [
                 'type' => 'string',
             ],
-            'explode' => true,
-            'allowReserved' => true,
         ]);
 });
 
@@ -272,13 +272,13 @@ it('supports explicit query explode false', function () {
         ->toBe([
             'name' => 'tags[]',
             'in' => 'query',
+            'explode' => false,
             'schema' => [
                 'type' => 'array',
                 'items' => [
                     'type' => 'string',
                 ],
             ],
-            'explode' => false,
         ]);
 });
 
@@ -304,13 +304,13 @@ it('lets explicit query serialization override inferred array config', function 
         ->toBe([
             'name' => 'tags[]',
             'in' => 'query',
+            'explode' => true,
             'schema' => [
                 'type' => 'array',
                 'items' => [
                     'type' => 'string',
                 ],
             ],
-            'explode' => true,
         ]);
 });
 

--- a/tests/ParametersSerializationTest.php
+++ b/tests/ParametersSerializationTest.php
@@ -17,6 +17,7 @@ it('checks return type of param when "style" and "explode" specified', function 
         'name' => 'includes',
         'in' => 'query',
         'style' => 'form',
+        'explode' => false,
         'schema' => [
             'type' => 'string',
             'enum' => [
@@ -25,7 +26,6 @@ it('checks return type of param when "style" and "explode" specified', function 
                 'condition',
             ],
         ],
-        'explode' => false,
     ]);
 });
 
@@ -60,9 +60,9 @@ it('checks return type of param when "allowReserved" specified', function () {
     expect($parameter->toArray())->toBe([
         'name' => 'filter',
         'in' => 'query',
+        'allowReserved' => true,
         'schema' => [
             'type' => 'string',
         ],
-        'allowReserved' => true,
     ]);
 });

--- a/tests/ParametersSerializationTest.php
+++ b/tests/ParametersSerializationTest.php
@@ -49,3 +49,20 @@ it('checks return type of param when "style" and "explode" not specified', funct
         ],
     ]);
 });
+
+it('checks return type of param when "allowReserved" specified', function () {
+    $type = new StringType;
+
+    $parameter = new Parameter('filter', 'query');
+    $parameter->setSchema(Schema::fromType($type));
+    $parameter->setAllowReserved(true);
+
+    expect($parameter->toArray())->toBe([
+        'name' => 'filter',
+        'in' => 'query',
+        'schema' => [
+            'type' => 'string',
+        ],
+        'allowReserved' => true,
+    ]);
+});

--- a/tests/Support/OperationExtensions/ParameterExtractor/JsonApiResourceParametersExtractorTest.php
+++ b/tests/Support/OperationExtensions/ParameterExtractor/JsonApiResourceParametersExtractorTest.php
@@ -24,6 +24,7 @@ test('extracts includes parameter', function () {
     expect($parameters->firstWhere('name', 'include'))->toBe([
         'name' => 'include',
         'in' => 'query',
+        'explode' => false,
         'schema' => [
             'type' => 'array',
             'items' => [
@@ -34,7 +35,6 @@ test('extracts includes parameter', function () {
                 ],
             ],
         ],
-        'explode' => false,
     ]);
 });
 
@@ -48,6 +48,7 @@ test('extracts includes parameter when resource transformed to response', functi
     expect($parameters->firstWhere('name', 'include'))->toBe([
         'name' => 'include',
         'in' => 'query',
+        'explode' => false,
         'schema' => [
             'type' => 'array',
             'items' => [
@@ -58,7 +59,6 @@ test('extracts includes parameter when resource transformed to response', functi
                 ],
             ],
         ],
-        'explode' => false,
     ]);
 });
 
@@ -72,6 +72,7 @@ test('extracts fields parameter', function () {
     expect($parameters->firstWhere('name', 'fields[sample_post_resource__json_apis]'))->toBe([
         'name' => 'fields[sample_post_resource__json_apis]',
         'in' => 'query',
+        'explode' => false,
         'schema' => [
             'type' => 'array',
             'items' => [
@@ -81,7 +82,6 @@ test('extracts fields parameter', function () {
                 ],
             ],
         ],
-        'explode' => false,
     ]);
 });
 /**

--- a/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
+++ b/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
@@ -656,6 +656,7 @@ it('documents deep query parameters without flattening', function () {
         ->toBe([
             'name' => 'filter',
             'in' => 'query',
+            'style' => 'deepObject',
             'schema' => [
                 'type' => 'object',
                 'properties' => [
@@ -664,6 +665,7 @@ it('documents deep query parameters without flattening', function () {
                     ],
                 ],
             ],
+            'explode' => true,
         ]);
 });
 
@@ -783,6 +785,26 @@ it('documents array query parameters as arrays of some type', function () {
                     'type' => 'string',
                 ],
             ],
+        ]);
+});
+
+it('documents inferred array query parameters with form style when explode config disabled', function () {
+    config()->set('scramble.query_array_parameter_explode', false);
+
+    $document = generateForRoute(fn () => RouteFacade::get('test', RequestBodyExtensionTest_ArrayQueryParametersController::class));
+
+    expect($document['paths']['/test']['get']['parameters'][0])
+        ->toBe([
+            'name' => 'tags[]',
+            'in' => 'query',
+            'style' => 'form',
+            'schema' => [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'string',
+                ],
+            ],
+            'explode' => false,
         ]);
 });
 class RequestBodyExtensionTest_ArrayQueryParametersController

--- a/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
+++ b/tests/Support/OperationExtensions/RequestBodyExtensionTest.php
@@ -657,6 +657,7 @@ it('documents deep query parameters without flattening', function () {
             'name' => 'filter',
             'in' => 'query',
             'style' => 'deepObject',
+            'explode' => true,
             'schema' => [
                 'type' => 'object',
                 'properties' => [
@@ -665,7 +666,6 @@ it('documents deep query parameters without flattening', function () {
                     ],
                 ],
             ],
-            'explode' => true,
         ]);
 });
 
@@ -798,13 +798,13 @@ it('documents inferred array query parameters with form style when explode confi
             'name' => 'tags[]',
             'in' => 'query',
             'style' => 'form',
+            'explode' => false,
             'schema' => [
                 'type' => 'array',
                 'items' => [
                     'type' => 'string',
                 ],
             ],
-            'explode' => false,
         ]);
 });
 class RequestBodyExtensionTest_ArrayQueryParametersController


### PR DESCRIPTION
## Summary

Adds query parameter serialization metadata support to generated OpenAPI Parameter Objects [spec](https://swagger.io/docs/specification/v3_0/serialization/#query-parameters).

Some openapi client generators (like hey-api or orval) uses this parameters to generate the client code to correctly serialize query parameters. 
This is particulary important when not using flattened query parameters because the default `style` is `form` but should be `deepObject` to correctly handle object params (this is an [issue](https://github.com/hey-api/hey-api/issues/3747) I encountered while testing hey-api).

Whit this changes the `style` is always set to `deepObject` for object parameters. I also added a new config `query_array_parameter_explode` that allows to globally set the preferred format for arrays (repeated fields or comma separated).

This allows Scramble to emit standard OpenAPI fields for query parameters:

- `style`
- `explode`
- `allowReserved`

The new API is exposed through `#[QueryParameter]` and a query-specific `QueryParameterStyle` enum.

## Changes

- Added `Dedoc\Scramble\Attributes\QueryParameterStyle` with supported query styles:
  - `form`
  - `spaceDelimited`
  - `pipeDelimited`
  - `deepObject`
- Extended `#[QueryParameter]` with optional serialization arguments:
  - `style`
  - `explode`
  - `allowReserved`
- Added support for serializing `style`, `explode`, and `allowReserved` in OpenAPI parameters.
- Added automatic `deepObject` metadata when `flatten_deep_query_parameters` is disabled and query parameters are documented as object parameters.
- Added `query_array_parameter_explode` config option to document array query parameters as `style: form`, `explode: false` globally.
- Preserved explicit `explode: false` and `allowReserved: false` values in serialized output.
- Kept existing behavior unchanged unless serialization metadata is explicitly configured or inferred from the new config/deep-object behavior.

## Notes

When `flatten_deep_query_parameters` is enabled, object query parameters continue to be flattened and `deepObject` serialization is not forced onto the flattened parameters.

