### PR TITLE
Add support for extending the `Group` attribute

### DIFF
--- a/src/DocumentTransformers/AddDocumentTags.php
+++ b/src/DocumentTransformers/AddDocumentTags.php
@@ -25,16 +25,16 @@ class AddDocumentTags implements DocumentTransformer
     {
         /** @var Collection<string, Tag> $tags */
         $tags = $groupsAttributes->reduce(function (Collection $acc, ReflectionAttribute $attribute) {
-            $arguments = $attribute->getArguments();
+            $group = $attribute->newInstance();
 
-            $name = $arguments['name'] ?? $arguments[0] ?? null;
+            $name = $group->name;
 
             if (! $name) {
                 return $acc;
             }
 
-            $description = $arguments['description'] ?? $arguments[1] ?? null;
-            $weight = $arguments['weight'] ?? $arguments[2] ?? null;
+            $description = $group->description;
+            $weight = $group->weight !== PHP_INT_MAX ? $group->weight : null;
 
             /** @var Tag $tag */
             $tag = $acc->get($name, new Tag($name));

--- a/src/Support/OperationExtensions/RequestEssentialsExtension.php
+++ b/src/Support/OperationExtensions/RequestEssentialsExtension.php
@@ -223,11 +223,11 @@ class RequestEssentialsExtension extends OperationExtension
         $reflection = $routeInfo->reflectionAction();
 
         $methodClassGroupAttributes = $reflection instanceof ReflectionMethod
-            ? $reflection->getDeclaringClass()->getAttributes(Group::class)
+            ? $reflection->getDeclaringClass()->getAttributes(Group::class, ReflectionAttribute::IS_INSTANCEOF)
             : [];
 
         return [
-            ...($reflection?->getAttributes(Group::class) ?? []),
+            ...($reflection?->getAttributes(Group::class, ReflectionAttribute::IS_INSTANCEOF) ?? []),
             ...$methodClassGroupAttributes,
         ];
     }

--- a/tests/Attributes/GroupTest.php
+++ b/tests/Attributes/GroupTest.php
@@ -2,6 +2,7 @@
 
 namespace Dedoc\Scramble\Tests\Attributes;
 
+use Attribute;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Generator;
 use Dedoc\Scramble\Scramble;
@@ -140,5 +141,50 @@ class GroupTest_B4_Controller
 #[Group('C', weight: 0)]
 class GroupTest_C4_Controller
 {
+    public function __invoke() {}
+}
+
+it('allows using attributes extending the Group attribute', function () {
+    RouteFacade::get('api/a', GroupTest_A5_Controller::class);
+    RouteFacade::get('api/b', GroupTest_B5_Controller::class);
+
+    Scramble::routes(fn (Route $r) => in_array($r->uri, ['api/a', 'api/b']));
+
+    $openApiDoc = app()->make(Generator::class)();
+
+    expect(array_keys($openApiDoc['paths']))
+        ->toBe(['/b', '/a'])
+        ->and(data_get($openApiDoc['paths'], '*.*.tags.*'))
+        ->toBe(['Orders', 'Users'])
+        ->and($openApiDoc['tags'])
+        ->toBe([
+            ['name' => 'Orders', 'description' => 'Orders related endpoints'],
+            ['name' => 'Users'],
+        ]);
+});
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+class GroupTest_UsersGroup extends Group
+{
+    public function __construct()
+    {
+        parent::__construct(name: 'Users', weight: 2);
+    }
+}
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+class GroupTest_OrdersGroup extends Group
+{
+    public function __construct()
+    {
+        parent::__construct(name: 'Orders', description: 'Orders related endpoints', weight: 1);
+    }
+}
+#[GroupTest_UsersGroup]
+class GroupTest_A5_Controller
+{
+    public function __invoke() {}
+}
+class GroupTest_B5_Controller
+{
+    #[GroupTest_OrdersGroup]
     public function __invoke() {}
 }


### PR DESCRIPTION
## Problem

When many controllers belong to the same group, the group name, description and weight have to be retyped on every controller. Since `Group` is not final, it can be extended to define the group once and reuse it. Right now this doesn't work for two reasons:

1. `getAttributes(Group::class)` matches only the exact class, so subclasses are never found.
2. `AddDocumentTags` builds document tags from `ReflectionAttribute::getArguments()`, which returns the subclass constructor arguments (for example, an enum case), not the values passed to the parent constructor.

## Solution

Reflection lookups in `RequestEssentialsExtension` now use `ReflectionAttribute::IS_INSTANCEOF` instead of an exact class match, so attributes extending `Group` are collected. `AddDocumentTags` reads the name, description and weight from the attribute instance (`newInstance()`) instead of the raw constructor arguments, which works for subclasses and keeps working for plain `#[Group]` usage.

## Examples

Define the group once and reuse it on any controller or method:

```php
#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
class UsersGroup extends Group
{
    public function __construct()
    {
        parent::__construct(name: 'Users', weight: 1);
    }
}

#[UsersGroup]
class UserController
{
    // ...
}
```

The same approach also works with a single attribute backed by an enum, so all group names and weights live in one place:

```php
enum DocGroup
{
    case Users;
    case Orders;

    public function title(): string
    {
        // Use the enum case name as the group name.
        return $this->name;
        
        // Or we can use a match statement.
        return match ($this) {
            self::Users => 'Users',
            self::Orders => 'Orders',
        };
    }

    public function weight(): int
    {
        // Use the enum case ordering as the group weight.
        // PHP does not assign implicit values to enum cases, like in C#,
        // but we can use the array_search() function to get the index.
        return (int) array_search($this, self::cases(), true);
        
        // Or we can use a match statement.
        return match ($this) {
            self::Users => 1,
            self::Orders => 2,
        };
    }
}

#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
class OpenApiGroup extends Group
{
    public function __construct(DocGroup $case)
    {
        parent::__construct(name: $case->title(), weight: $case->weight());
    }
}

#[OpenApiGroup(DocGroup::Users)]
class UserController
{
    // ...
}
```

## Notes

`AddDocumentTags` needs to know whether a weight was actually passed, but after switching to `newInstance()`, there is no argument list to look at anymore, only the instance, where an omitted weight comes back as the `PHP_INT_MAX` default. So the code just compares against `PHP_INT_MAX` and treats that as "no weight". It keeps the merging and sorting behaviour exactly as it was before, but it feels hacky, and I don't really like it.

If you have a better idea how to handle this, I'm happy to rework that part.
