### PR TITLE
Improve JSON schema examples: add multiple `@example` support, avoid using `example` (deprecated, using `examples` instead) when serializing JSON schemas

### DIFF
--- a/src/Support/ExceptionToResponseExtensions/HttpExceptionToResponseExtension.php
+++ b/src/Support/ExceptionToResponseExtensions/HttpExceptionToResponseExtension.php
@@ -63,7 +63,7 @@ class HttpExceptionToResponseExtension extends ExceptionToResponseExtension
                     if (! $messageType instanceof LiteralStringType) {
                         return;
                     }
-                    $t->example($messageType->value);
+                    $t->examples([$messageType->value]);
                 })
             )
             ->setRequired(['message']);

--- a/src/Support/Generator/Parameter.php
+++ b/src/Support/Generator/Parameter.php
@@ -135,7 +135,6 @@ class Parameter
 
     /**
      * @param  array<string, Example>  $examples
-     *
      * @return $this
      */
     public function examples(array $examples): self

--- a/src/Support/Generator/Parameter.php
+++ b/src/Support/Generator/Parameter.php
@@ -134,7 +134,7 @@ class Parameter
     }
 
     /**
-     * @param  array<string, Example>  $example
+     * @param  array<string, Example>  $examples
      *
      * @return $this
      */

--- a/src/Support/Generator/Parameter.php
+++ b/src/Support/Generator/Parameter.php
@@ -133,6 +133,18 @@ class Parameter
         return $this;
     }
 
+    /**
+     * @param  array<string, Example>  $example
+     *
+     * @return $this
+     */
+    public function examples(array $examples): self
+    {
+        $this->examples = $examples;
+
+        return $this;
+    }
+
     public function setExplode(bool $explode): self
     {
         $this->explode = $explode;

--- a/src/Support/Generator/Schema.php
+++ b/src/Support/Generator/Schema.php
@@ -57,7 +57,7 @@ class Schema
                 $paramType = $paramType instanceof Schema ? $paramType->type : $paramType;
 
                 $paramType->setDescription($parameter->description);
-                $paramType->example($parameter->example);
+                $paramType->examples([$parameter->example]);
 
                 $type->addProperty($parameter->name, $paramType);
             })

--- a/src/Support/Generator/Types/Type.php
+++ b/src/Support/Generator/Types/Type.php
@@ -21,7 +21,10 @@ abstract class Type
 
     public string $contentEncoding = '';
 
-    /** @var array|scalar|null|MissingValue */
+    /**
+     * @deprecated
+     * @var array|scalar|null|MissingValue
+     */
     public $example;
 
     /** @var array|scalar|null|MissingValue */
@@ -44,7 +47,7 @@ abstract class Type
     public function __construct(string $type)
     {
         $this->type = $type;
-        $this->example = new MissingValue;
+        $this->example = new MissingValue; // @phpstan-ignore property.deprecated
         $this->default = new MissingValue;
     }
 
@@ -103,7 +106,7 @@ abstract class Type
         $this->description = $fromType->description;
         $this->contentMediaType = $fromType->contentMediaType;
         $this->contentEncoding = $fromType->contentEncoding;
-        $this->example = $fromType->example;
+        $this->example = $fromType->example; // @phpstan-ignore property.deprecated, property.deprecated
         $this->default = $fromType->default;
         $this->examples = $fromType->examples;
         $this->enum = $fromType->enum;
@@ -144,7 +147,7 @@ abstract class Type
             $this->default instanceof MissingValue ? [] : ['default' => $this->default],
             count(
                 $examples = collect($this->examples)
-                    ->push($this->example)
+                    ->prepend($this->example) // @phpstan-ignore property.deprecated
                     ->reject(fn ($example) => $example instanceof MissingValue)
                     ->values()
                     ->toArray()
@@ -185,6 +188,7 @@ abstract class Type
     }
 
     /**
+     * @deprecated
      * @param  array|scalar|null|MissingValue  $example
      * @return $this
      */

--- a/src/Support/Generator/Types/Type.php
+++ b/src/Support/Generator/Types/Type.php
@@ -23,6 +23,7 @@ abstract class Type
 
     /**
      * @deprecated
+     *
      * @var array|scalar|null|MissingValue
      */
     public $example;
@@ -189,6 +190,7 @@ abstract class Type
 
     /**
      * @deprecated
+     *
      * @param  array|scalar|null|MissingValue  $example
      * @return $this
      */

--- a/src/Support/Generator/Types/Type.php
+++ b/src/Support/Generator/Types/Type.php
@@ -141,10 +141,10 @@ abstract class Type
                 'enum' => count($enum) ? $enum : null,
                 'const' => $const,
             ]),
-            $this->example instanceof MissingValue ? [] : ['example' => $this->example],
             $this->default instanceof MissingValue ? [] : ['default' => $this->default],
             count(
                 $examples = collect($this->examples)
+                    ->push($this->example)
                     ->reject(fn ($example) => $example instanceof MissingValue)
                     ->values()
                     ->toArray()

--- a/src/Support/OperationExtensions/RulesExtractor/DeepParametersMerger.php
+++ b/src/Support/OperationExtensions/RulesExtractor/DeepParametersMerger.php
@@ -236,7 +236,7 @@ class DeepParametersMerger
         }
 
         $paramType->setDescription($parameter->description);
-        $paramType->example($parameter->example);
+        $paramType->examples([$parameter->example]);
 
         return $paramType;
     }

--- a/src/Support/OperationExtensions/RulesExtractor/PhpDocSchemaTransformer.php
+++ b/src/Support/OperationExtensions/RulesExtractor/PhpDocSchemaTransformer.php
@@ -36,7 +36,7 @@ class PhpDocSchemaTransformer
         }
 
         if ($examples = ExamplesExtractor::make($docNode)->extract(preferString: $type instanceof StringType)) {
-            $type->example($examples[0]);
+            $type->examples($examples);
         }
 
         if ($default = ExamplesExtractor::make($docNode, '@default')->extract(preferString: $type instanceof StringType)) {

--- a/src/Support/OperationExtensions/RulesExtractor/SchemaBagToParametersTransformer.php
+++ b/src/Support/OperationExtensions/RulesExtractor/SchemaBagToParametersTransformer.php
@@ -55,16 +55,25 @@ class SchemaBagToParametersTransformer
             || (bool) ($rulesDocs?->getTagsByName('@hidden') ?? []);
     }
 
+    /**
+     * When incoming JSON schema has one example, we move it from the schema to the resulting parameter. If
+     * incoming JSON schema has many parameters – we keep it on JSON schema instead. This is due to examples on
+     * parameter are named (array<string, Example>) and examples on JSON schema are just values (value[]).
+     */
     protected function makeParameterFromSchema(OpenApiSchema $schema, string $name): Parameter
     {
         $description = $schema->description;
-        $example = $schema->example;
 
-        $schema->setDescription('')->example(new MissingValue);
+        $schemaExamples = $schema->examples;
+
+        $schema->setDescription('');
+        if (count($schemaExamples) < 2) {
+            $schema->examples([]);
+        }
 
         return Parameter::make($name, $schema->getAttribute('isInQuery') ? 'query' : $this->in)
             ->setSchema(Schema::fromType($schema))
-            ->example($example)
+            ->example(count($schemaExamples) === 1 ? $schemaExamples[0] : new MissingValue)
             ->required((bool) $schema->getAttribute('required', false))
             ->description($description);
     }

--- a/src/Support/TypeToSchemaExtensions/ResponsableTypeToSchema.php
+++ b/src/Support/TypeToSchemaExtensions/ResponsableTypeToSchema.php
@@ -3,10 +3,10 @@
 namespace Dedoc\Scramble\Support\TypeToSchemaExtensions;
 
 use Dedoc\Scramble\Extensions\TypeToSchemaExtension;
-use Dedoc\Scramble\Support\Generator\Reference;
-use Dedoc\Scramble\Support\Generator\Response;
 use Dedoc\Scramble\Infer\Scope\GlobalScope;
 use Dedoc\Scramble\Infer\Services\ReferenceTypeResolver;
+use Dedoc\Scramble\Support\Generator\Reference;
+use Dedoc\Scramble\Support\Generator\Response;
 use Dedoc\Scramble\Support\Type\ObjectType;
 use Dedoc\Scramble\Support\Type\Reference\MethodCallReferenceType;
 use Dedoc\Scramble\Support\Type\Type;

--- a/src/Support/TypeToSchemaExtensions/StreamedResponseToSchema.php
+++ b/src/Support/TypeToSchemaExtensions/StreamedResponseToSchema.php
@@ -123,7 +123,7 @@ class StreamedResponseToSchema extends TypeToSchemaExtension
 
         if ($this->isServerSentEventsResponse($type)) {
             $schema = (new ObjectType)
-                ->addProperty('event', (new StringType)->example('update'))
+                ->addProperty('event', (new StringType)->examples(['update']))
                 ->addProperty('data', new MixedType)
                 ->setRequired(['event', 'data']);
 

--- a/tests/Generator/AbortHelpersResponseDocumentationTest.php
+++ b/tests/Generator/AbortHelpersResponseDocumentationTest.php
@@ -22,7 +22,7 @@ it('documents abort helper as not referenced error response', function () {
         ->toHaveKey('content')
         ->and($response)
         ->not->toHaveKey('$ref')
-        ->toHaveKey('content.application/json.schema.properties.message.example', 'Something is wrong.');
+        ->toHaveKey('content.application/json.schema.properties.message.examples', ['Something is wrong.']);
 });
 
 it('documents abort_if helper', function () {
@@ -35,7 +35,7 @@ it('documents abort_if helper', function () {
         ->toHaveKey('content')
         ->and($response)
         ->not->toHaveKey('$ref')
-        ->toHaveKey('content.application/json.schema.properties.message.example', 'Something is wrong.');
+        ->toHaveKey('content.application/json.schema.properties.message.examples', ['Something is wrong.']);
 });
 
 it('documents abort_unless helper', function () {
@@ -48,7 +48,7 @@ it('documents abort_unless helper', function () {
         ->toHaveKey('content')
         ->and($response)
         ->not->toHaveKey('$ref')
-        ->toHaveKey('content.application/json.schema.properties.message.example', 'Something is wrong.');
+        ->toHaveKey('content.application/json.schema.properties.message.examples', ['Something is wrong.']);
 });
 
 class AbortHelpersResponseDocumentation_Test extends \Illuminate\Routing\Controller

--- a/tests/Support/Helpers/ExamplesExtractorTest.php
+++ b/tests/Support/Helpers/ExamplesExtractorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Dedoc\Scramble\Support\Helpers\ExamplesExtractor;
+use Dedoc\Scramble\Support\PhpDoc;
+
+it('extracts a single @example tag', function () {
+    $docNode = PhpDoc::parse(<<<'DOC'
+/**
+ * @example foo
+ */
+DOC);
+
+    expect(ExamplesExtractor::make($docNode)->extract())->toBe(['foo']);
+});
+
+it('extracts multiple @example tags', function () {
+    $docNode = PhpDoc::parse(<<<'DOC'
+/**
+ * @example foo
+ * @example bar
+ * @example Multiword example
+ */
+DOC);
+
+    expect(ExamplesExtractor::make($docNode)->extract())->toBe([
+        'foo',
+        'bar',
+        'Multiword example',
+    ]);
+});
+
+it('extracts typed @example values', function () {
+    $docNode = PhpDoc::parse(<<<'DOC'
+/**
+ * @example 42
+ * @example true
+ * @example null
+ * @example {"key":"value"}
+ */
+DOC);
+
+    expect(ExamplesExtractor::make($docNode)->extract())->toBe([
+        42,
+        true,
+        null,
+        ['key' => 'value'],
+    ]);
+});
+
+it('keeps @example values as strings when preferString is true', function () {
+    $docNode = PhpDoc::parse(<<<'DOC'
+/**
+ * @example 42
+ * @example 3.14
+ */
+DOC);
+
+    expect(ExamplesExtractor::make($docNode)->extract(preferString: true))->toBe([
+        '42',
+        '3.14',
+    ]);
+});
+
+it('returns an empty array when no @example tags are present', function () {
+    $docNode = PhpDoc::parse(<<<'DOC'
+/**
+ * A description.
+ */
+DOC);
+
+    expect(ExamplesExtractor::make($docNode)->extract())->toBe([]);
+});

--- a/tests/Support/TypeToSchemaExtensions/StreamedResponseToSchemaTest.php
+++ b/tests/Support/TypeToSchemaExtensions/StreamedResponseToSchemaTest.php
@@ -58,7 +58,7 @@ it('transforms SSE inferred type to response', function () {
                         "event: update\ndata: {data}\n\nevent: update\ndata: </stream>\n\n",
                     ],
                     'properties' => [
-                        'event' => ['type' => 'string', 'example' => 'update'],
+                        'event' => ['type' => 'string', 'examples' => ['update']],
                         'data' => (object) [],
                     ],
                     'required' => ['event', 'data'],
@@ -89,7 +89,7 @@ it('transforms SSE without string end event to response', function () {
                         "event: update\ndata: {data}\n\n",
                     ],
                     'properties' => [
-                        'event' => ['type' => 'string', 'example' => 'update'],
+                        'event' => ['type' => 'string', 'examples' => ['update']],
                         'data' => (object) [],
                     ],
                     'required' => ['event', 'data'],

--- a/tests/ValidationRulesDocumentingTest.php
+++ b/tests/ValidationRulesDocumentingTest.php
@@ -953,6 +953,59 @@ it('extracts rules docs from form request', function () {
     assertMatchesSnapshot($openApiDocument['paths']['/test']['get']['parameters']);
 });
 
+it('moves a single @example from schema to parameter when transforming schema bag to parameters', function () {
+    $openApiDocument = generateForRoute(fn () => RouteFacade::get('api/test', [ValidationRulesWithSingleExampleOnParameterDocs_Test::class, 'index']));
+
+    expect($openApiDocument['paths']['/test']['get']['parameters'][0])->toBe([
+        'name' => 'foo',
+        'in' => 'query',
+        'required' => true,
+        'schema' => ['type' => 'string'],
+        'example' => 'wow',
+    ]);
+});
+
+class ValidationRulesWithSingleExampleOnParameterDocs_Test
+{
+    public function index(Request $request)
+    {
+        $request->validate([
+            /**
+             * @example wow
+             */
+            'foo' => ['required', 'string'],
+        ]);
+    }
+}
+
+it('keeps multiple @example values on schema when transforming schema bag to parameters', function () {
+    $openApiDocument = generateForRoute(fn () => RouteFacade::get('api/test', [ValidationRulesWithMultipleExamplesOnSchemaDocs_Test::class, 'index']));
+
+    expect($openApiDocument['paths']['/test']['get']['parameters'][0])->toBe([
+        'name' => 'foo',
+        'in' => 'query',
+        'required' => true,
+        'schema' => [
+            'type' => 'string',
+            'examples' => ['wow', 'another'],
+        ],
+    ]);
+});
+
+class ValidationRulesWithMultipleExamplesOnSchemaDocs_Test
+{
+    public function index(Request $request)
+    {
+        $request->validate([
+            /**
+             * @example wow
+             * @example another
+             */
+            'foo' => ['required', 'string'],
+        ]);
+    }
+}
+
 it('extracts rules docs when using consts in form request', function ($action) {
     $openApiDocument = generateForRoute(fn () => RouteFacade::get('api/test', $action));
 


### PR DESCRIPTION
Related: https://github.com/dedoc/scramble/discussions/1166