### PR TITLE
Fix missing enum case name and descriptions for `Rule::enum()->only()/except()`

### DIFF
--- a/src/RuleTransformers/EnumRule.php
+++ b/src/RuleTransformers/EnumRule.php
@@ -4,14 +4,12 @@ namespace Dedoc\Scramble\RuleTransformers;
 
 use BackedEnum;
 use Dedoc\Scramble\Contracts\RuleTransformer;
+use Dedoc\Scramble\Support\EnumTransformer;
 use Dedoc\Scramble\Support\Generator\Types\Type;
-use Dedoc\Scramble\Support\Generator\Types\UnknownType;
 use Dedoc\Scramble\Support\Generator\TypeTransformer;
 use Dedoc\Scramble\Support\RuleTransforming\NormalizedRule;
 use Dedoc\Scramble\Support\RuleTransforming\RuleTransformerContext;
 use Dedoc\Scramble\Support\Type\ObjectType;
-use Dedoc\Scramble\Support\Type\TypeHelper;
-use Dedoc\Scramble\Support\Type\Union;
 use Illuminate\Validation\Rules\Enum;
 
 class EnumRule implements RuleTransformer
@@ -35,18 +33,25 @@ class EnumRule implements RuleTransformer
         /** @var class-string<BackedEnum> $enumName */
         $enumName = $this->getProtectedValue($rule, 'type');
 
-        $objectType = new ObjectType($enumName);
-
         /** @var BackedEnum[] $except */
         $except = method_exists(Enum::class, 'except') ? $this->getProtectedValue($rule, 'except') : []; // @phpstan-ignore function.alreadyNarrowedType
         /** @var BackedEnum[] $only */
         $only = method_exists(Enum::class, 'only') ? $this->getProtectedValue($rule, 'only') : []; // @phpstan-ignore function.alreadyNarrowedType
 
         if ($except || $only) {
-            return $this->preservePreviousRules($this->createPartialEnum($enumName, $only, $except), $previous);
+            return $this->preservePreviousRules(
+                EnumTransformer::make($enumName)
+                    ->except($except)
+                    ->only($only)
+                    ->transform(),
+                $previous,
+            );
         }
 
-        return $this->preservePreviousRules($this->openApiTransformer->transform($objectType), $previous);
+        return $this->preservePreviousRules(
+            $this->openApiTransformer->transform(new ObjectType($enumName)),
+            $previous,
+        );
     }
 
     private function preservePreviousRules(Type $current, Type $previous): Type
@@ -56,26 +61,6 @@ class EnumRule implements RuleTransformer
         }
 
         return $current;
-    }
-
-    /**
-     * @param  class-string<BackedEnum>  $enumName
-     * @param  BackedEnum[]  $only
-     * @param  BackedEnum[]  $except
-     */
-    private function createPartialEnum(string $enumName, array $only, array $except): Type
-    {
-        $cases = collect($enumName::cases())
-            ->reject(fn ($case) => in_array($case, $except))
-            ->filter(fn ($case) => ! $only || in_array($case, $only));
-
-        if (! isset($cases->first()->value)) {
-            return new UnknownType; // $enumName enum doesnt have values (only/except context)
-        }
-
-        return $this->openApiTransformer->transform(Union::wrap(
-            $cases->map(fn ($c) => TypeHelper::createTypeFromValue($c->value))->all()
-        ));
     }
 
     private function getProtectedValue(object $obj, string $name): mixed

--- a/src/Support/EnumTransformer.php
+++ b/src/Support/EnumTransformer.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Dedoc\Scramble\Support;
+
+use BackedEnum;
+use Dedoc\Scramble\Support\Generator\Types as OpenApi;
+use Dedoc\Scramble\Support\Generator\Types\IntegerType;
+use Dedoc\Scramble\Support\Generator\Types\StringType;
+use Dedoc\Scramble\Support\Generator\Types\UnknownType;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use ReflectionEnum;
+use ReflectionEnumBackedCase;
+
+class EnumTransformer
+{
+    /** @var BackedEnum[] */
+    private array $except = [];
+
+    /** @var BackedEnum[] */
+    private array $only = [];
+
+    /**
+     * @param  class-string  $enumClassName
+     * @param  array{nameStrategy?: 'name'|'varnames'|null|false, descriptionStrategy?: 'description'|'extension'|null|false}  $config
+     */
+    public function __construct(
+        private string $enumClassName,
+        private array $config = [],
+    ) {}
+
+    /**
+     * @param  class-string  $enumClassName
+     */
+    public static function make(string $enumClassName): self
+    {
+        return new self($enumClassName, [
+            'nameStrategy' => config('scramble.enum_cases_names_strategy'),
+            'descriptionStrategy' => config('scramble.enum_cases_description_strategy'),
+        ]);
+    }
+
+    /**
+     * @param  BackedEnum[]  $except
+     */
+    public function except(array $except): self
+    {
+        $this->except = $except;
+
+        return $this;
+    }
+
+    /**
+     * @param  BackedEnum[]  $only
+     */
+    public function only(array $only): self
+    {
+        $this->only = $only;
+
+        return $this;
+    }
+
+    public function transform(): OpenApi\Type
+    {
+        $name = $this->enumClassName;
+
+        if (! isset($name::cases()[0]->value)) { // only backed enums support
+            return new UnknownType;
+        }
+
+        $cases = $this->cases();
+
+        if ($cases->isEmpty()) {
+            return new UnknownType;
+        }
+
+        $values = $cases->map(fn (BackedEnum $case) => $case->value)->values()->all();
+
+        $schemaType = is_string($values[0]) ? new StringType : new IntegerType;
+
+        if (count($values) === 1 && ($this->only || $this->except)) {
+            $schemaType->const($values[0]);
+        } else {
+            $schemaType->enum($values);
+        }
+
+        $this->addEnumCasesDescriptions($schemaType, $cases);
+
+        $this->addEnumDescription($schemaType);
+
+        $this->addEnumNames($schemaType, $cases);
+
+        return $schemaType;
+    }
+
+    /**
+     * @return Collection<int, BackedEnum>
+     */
+    private function cases(): Collection
+    {
+        return collect($this->enumClassName::cases())
+            ->reject(fn ($case) => in_array($case, $this->except))
+            ->filter(fn ($case) => ! $this->only || in_array($case, $this->only))
+            ->values();
+    }
+
+    /**
+     * @param  Collection<int, BackedEnum>  $cases
+     */
+    private function addEnumCasesDescriptions(OpenApi\Type $schemaType, Collection $cases): void
+    {
+        $descriptions = $cases
+            ->mapWithKeys(function (BackedEnum $case) {
+                $reflection = new ReflectionEnumBackedCase($case::class, $case->name);
+                $doc = PhpDoc::parse($reflection->getDocComment() ?: '/** */');
+
+                return [
+                    $case->value => trim(Str::replace("\n", ' ', $doc->getAttribute('summary').' '.$doc->getAttribute('description'))), // @phpstan-ignore binaryOp.invalid, binaryOp.invalid
+                ];
+            });
+
+        if (! $descriptions->some(fn ($description) => (bool) $description)) {
+            return;
+        }
+
+        $enumDescriptionStrategy = $this->config['descriptionStrategy'] ?? null;
+
+        if ($enumDescriptionStrategy === 'description') {
+            $description = $descriptions
+                ->map(fn ($description, $value) => "| `{$value}` <br/> {$description} |")
+                ->prepend('|---|')
+                ->prepend('| |')
+                ->join("\n");
+
+            $schemaType->setDescription($description);
+
+            /*
+             * Cases description are stored in attribute due to if enum is used as a property in some object,
+             * users may override enum class description and some way is needed
+             */
+            $schemaType->setAttribute('casesDescription', $description);
+
+            return;
+        }
+
+        if ($enumDescriptionStrategy === 'extension') {
+            $schemaType->setExtensionProperty('enumDescriptions', $descriptions->all());
+        }
+    }
+
+    private function addEnumDescription(OpenApi\Type $schemaType): void
+    {
+        $enumReflection = new ReflectionEnum($this->enumClassName); // @phpstan-ignore argument.type
+
+        $doc = PhpDoc::parse($enumReflection->getDocComment() ?: '/** */');
+        $description = trim(Str::replace("\n", ' ', $doc->getAttribute('summary').' '.$doc->getAttribute('description'))); // @phpstan-ignore binaryOp.invalid, binaryOp.invalid
+
+        if (! $description) {
+            return;
+        }
+
+        $schemaType->setDescription($description."\n".$schemaType->description);
+
+        /*
+         * Cases description are stored in attribute due to if enum is used as a property in some object,
+         * users may override enum class description and some way is needed
+         */
+        $schemaType->setAttribute('description', $description);
+    }
+
+    /**
+     * @param  Collection<int, BackedEnum>  $cases
+     */
+    private function addEnumNames(OpenApi\Type $schemaType, Collection $cases): void
+    {
+        /** @var 'name'|'varnames'|null $enumNameStrategy */
+        $enumNameStrategy = $this->config['nameStrategy'] ?? null;
+
+        if (! $enumNameStrategy) {
+            return;
+        }
+
+        $extensionKey = $enumNameStrategy === 'varnames' ? 'enum-varnames' : 'enumNames';
+
+        $schemaType->setExtensionProperty(
+            $extensionKey,
+            $cases->map(fn (BackedEnum $case) => $case->name)->values()->all(),
+        );
+    }
+}

--- a/src/Support/TypeToSchemaExtensions/EnumToSchema.php
+++ b/src/Support/TypeToSchemaExtensions/EnumToSchema.php
@@ -3,20 +3,12 @@
 namespace Dedoc\Scramble\Support\TypeToSchemaExtensions;
 
 use Dedoc\Scramble\Extensions\TypeToSchemaExtension;
+use Dedoc\Scramble\Support\EnumTransformer;
 use Dedoc\Scramble\Support\Generator\ClassBasedReference;
 use Dedoc\Scramble\Support\Generator\Reference;
 use Dedoc\Scramble\Support\Generator\Types as OpenApi;
-use Dedoc\Scramble\Support\Generator\Types\IntegerType;
-use Dedoc\Scramble\Support\Generator\Types\StringType;
-use Dedoc\Scramble\Support\Generator\Types\UnknownType;
-use Dedoc\Scramble\Support\PhpDoc;
 use Dedoc\Scramble\Support\Type\ObjectType;
 use Dedoc\Scramble\Support\Type\Type;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
-use ReflectionEnum;
-use ReflectionEnumBackedCase;
-use ReflectionEnumUnitCase;
 
 class EnumToSchema extends TypeToSchemaExtension
 {
@@ -32,146 +24,11 @@ class EnumToSchema extends TypeToSchemaExtension
      */
     public function toSchema(Type $type): OpenApi\Type
     {
-        $name = $type->name;
-
-        if (! isset($name::cases()[0]->value)) { // only backed enums support
-            return new UnknownType;
-        }
-
-        $values = array_map(fn ($s) => $s->value, $name::cases());
-
-        $schemaType = is_string($values[0]) ? new StringType : new IntegerType;
-        $schemaType->enum($values);
-
-        $this->addEnumCasesDescriptions($type, $schemaType);
-
-        $this->addEnumDescription($type, $schemaType);
-
-        $this->addEnumNames($type, $schemaType);
-
-        return $schemaType;
+        return EnumTransformer::make($type->name)->transform();
     }
 
     public function reference(ObjectType $type): Reference
     {
         return ClassBasedReference::create('schemas', $type->name, $this->components);
-    }
-
-    protected function addEnumCasesDescriptions(ObjectType $type, OpenApi\Type $schemaType): void
-    {
-        $enumReflection = new ReflectionEnum($type->name); // @phpstan-ignore argument.type
-
-        $cases = collect(array_filter(
-            $enumReflection->getCases(),
-            fn ($case) => $case instanceof ReflectionEnumBackedCase,
-        ))
-            ->keyBy(fn (ReflectionEnumBackedCase $case): int|string => $case->getBackingValue())
-            ->map(function (ReflectionEnumBackedCase $case) {
-                $doc = PhpDoc::parse($case->getDocComment() ?: '/** */');
-
-                return trim(Str::replace("\n", ' ', $doc->getAttribute('summary').' '.$doc->getAttribute('description'))); // @phpstan-ignore binaryOp.invalid, binaryOp.invalid
-            });
-
-        if (! $cases->some(fn ($description) => (bool) $description)) {
-            return;
-        }
-
-        $enumDescriptionStrategy = config('scramble.enum_cases_description_strategy');
-
-        if ($enumDescriptionStrategy === 'description') {
-            $this->handleDescriptionEnumStrategy($schemaType, $cases);
-
-            return;
-        }
-
-        if ($enumDescriptionStrategy === 'extension') {
-            $this->handleExtensionEnumStrategy($schemaType, $cases);
-
-            return;
-        }
-    }
-
-    protected function addEnumDescription(ObjectType $type, OpenApi\Type $schemaType): void
-    {
-        $enumReflection = new ReflectionEnum($type->name); // @phpstan-ignore argument.type
-
-        $doc = PhpDoc::parse($enumReflection->getDocComment() ?: '/** */');
-        $description = trim(Str::replace("\n", ' ', $doc->getAttribute('summary').' '.$doc->getAttribute('description'))); // @phpstan-ignore binaryOp.invalid, binaryOp.invalid
-
-        if (! $description) {
-            return;
-        }
-
-        $schemaType->setDescription($description."\n".$schemaType->description);
-
-        /*
-         * Cases description are stored in attribute due to if enum is used as a property in some object,
-         * users may override enum class description and some way is needed
-         */
-        $schemaType->setAttribute('description', $description);
-    }
-
-    protected function addEnumNames(ObjectType $type, OpenApi\Type $schemaType): void
-    {
-        /** @var 'name'|'varnames'|null $enumNameStrategy */
-        $enumNameStrategy = config('scramble.enum_cases_names_strategy');
-
-        if (! $enumNameStrategy) {
-            return;
-        }
-
-        $enumReflection = new ReflectionEnum($type->name); // @phpstan-ignore argument.type
-
-        $nameCases = collect($enumReflection->getCases())
-            ->filter(fn (ReflectionEnumUnitCase $case) => $case instanceof ReflectionEnumBackedCase)
-            ->keyBy(fn (ReflectionEnumBackedCase $case): int|string => $case->getBackingValue())
-            ->map(fn (ReflectionEnumBackedCase $case) => $case->getName());
-
-        $this->handleEnumNames($schemaType, $nameCases, $enumNameStrategy);
-    }
-
-    /**
-     * @param  Collection<array-key, string>  $cases
-     */
-    protected function handleDescriptionEnumStrategy(OpenApi\Type $schema, Collection $cases): void
-    {
-        $description = $cases
-            ->map(fn ($description, $value) => "| `{$value}` <br/> {$description} |")
-            ->prepend('|---|')
-            ->prepend('| |')
-            ->join("\n");
-
-        $schema->setDescription($description);
-
-        /*
-         * Cases description are stored in attribute due to if enum is used as a property in some object,
-         * users may override enum class description and some way is needed
-         */
-        $schema->setAttribute('casesDescription', $description);
-    }
-
-    /**
-     * @param  Collection<array-key, string>  $cases
-     */
-    protected function handleExtensionEnumStrategy(OpenApi\Type $schema, Collection $cases): void
-    {
-        $schema->setExtensionProperty(
-            'enumDescriptions',
-            $cases->all()
-        );
-    }
-
-    /**
-     * @param  'name'|'varnames'  $strategy
-     * @param  Collection<int|string, string>  $cases
-     */
-    protected function handleEnumNames(OpenApi\Type $schema, Collection $cases, string $strategy): void
-    {
-        $extensionKey = $strategy === 'varnames' ? 'enum-varnames' : 'enumNames';
-
-        $schema->setExtensionProperty(
-            $extensionKey,
-            $cases->values()->all()
-        );
     }
 }

--- a/tests/Support/OperationExtensions/RulesExtractor/RuleSetToSchemaTransformersTest.php
+++ b/tests/Support/OperationExtensions/RulesExtractor/RuleSetToSchemaTransformersTest.php
@@ -55,6 +55,30 @@ describe(EnumRule::class, function () {
             ]);
     })->skip(! method_exists(Enum::class, 'only'));
 
+    test('enum rule with only keeps case descriptions', function () {
+        config()->set('scramble.enum_cases_description_strategy', 'description');
+
+        $rules = [
+            Rule::enum(DocumentedEnum_RuleSetToSchemaTransformerTest::class)->only([
+                DocumentedEnum_RuleSetToSchemaTransformerTest::FOO,
+                DocumentedEnum_RuleSetToSchemaTransformerTest::BAR,
+            ]),
+        ];
+
+        $schema = $this->transformer->transform($rules);
+
+        expect($schema->toArray())->toBe([
+            'type' => 'string',
+            'description' => <<<'EOF'
+| |
+|---|
+| `foo` <br/> Foo case description. |
+| `bar` <br/> Bar case description. |
+EOF,
+            'enum' => ['foo', 'bar'],
+        ]);
+    })->skip(! method_exists(Enum::class, 'only'));
+
     test('enum rule with except', function () {
         $rules = [
             Rule::enum(Enum_RuleSetToSchemaTransformerTest::class)->except([
@@ -70,6 +94,51 @@ describe(EnumRule::class, function () {
                 'const' => 'bar',
             ]);
     })->skip(! method_exists(Enum::class, 'except'));
+
+    test('enum rule with except keeps case descriptions', function () {
+        config()->set('scramble.enum_cases_description_strategy', 'description');
+
+        $rules = [
+            Rule::enum(DocumentedEnum_RuleSetToSchemaTransformerTest::class)->except([
+                DocumentedEnum_RuleSetToSchemaTransformerTest::BAZ,
+            ]),
+        ];
+
+        $schema = $this->transformer->transform($rules);
+
+        expect($schema->toArray())->toBe([
+            'type' => 'string',
+            'description' => <<<'EOF'
+| |
+|---|
+| `foo` <br/> Foo case description. |
+| `bar` <br/> Bar case description. |
+EOF,
+            'enum' => ['foo', 'bar'],
+        ]);
+    })->skip(! method_exists(Enum::class, 'except'));
+
+    test('enum rule with only keeps case descriptions as extension', function () {
+        config()->set('scramble.enum_cases_description_strategy', 'extension');
+
+        $rules = [
+            Rule::enum(DocumentedEnum_RuleSetToSchemaTransformerTest::class)->only([
+                DocumentedEnum_RuleSetToSchemaTransformerTest::FOO,
+                DocumentedEnum_RuleSetToSchemaTransformerTest::BAR,
+            ]),
+        ];
+
+        $schema = $this->transformer->transform($rules);
+
+        expect($schema->toArray())->toBe([
+            'type' => 'string',
+            'enum' => ['foo', 'bar'],
+            'x-enumDescriptions' => [
+                'foo' => 'Foo case description.',
+                'bar' => 'Bar case description.',
+            ],
+        ]);
+    })->skip(! method_exists(Enum::class, 'only'));
 
     test('nullable enum rule', function () {
         $rules = ['nullable', new Enum(Enum_RuleSetToSchemaTransformerTest::class)];
@@ -185,4 +254,20 @@ enum Enum_RuleSetToSchemaTransformerTest: string
 {
     case FOO = 'foo';
     case BAR = 'bar';
+}
+
+enum DocumentedEnum_RuleSetToSchemaTransformerTest: string
+{
+    /**
+     * Foo case description.
+     */
+    case FOO = 'foo';
+    /**
+     * Bar case description.
+     */
+    case BAR = 'bar';
+    /**
+     * Baz case description.
+     */
+    case BAZ = 'baz';
 }


### PR DESCRIPTION
`Rule::enum` with `only`/`except` was building a literal union, so case descriptions from `EnumToSchema` never showed up.

Pulled enum schema building into `EnumTransformer`, which filters cases first and then attaches descriptions/names — same path for full enums and partial ones.

fixes #1207 