### PR TITLE
Add `IgnoreResponse` attribute to exclude responses from docs

### DIFF
--- a/src/Attributes/IgnoreResponse.php
+++ b/src/Attributes/IgnoreResponse.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Dedoc\Scramble\Attributes;
+
+use Attribute;
+
+/**
+ * Excludes responses with the given status from the generated documentation.
+ *
+ * Status may be an exact HTTP code (`200`, `"default"`) or a mask (`"30*"`).
+ */
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD | Attribute::TARGET_FUNCTION)]
+class IgnoreResponse
+{
+    public function __construct(
+        public readonly int|string $status,
+    ) {}
+
+    public function matches(int|string|null $status): bool
+    {
+        $actual = (string) ($status ?? 'default');
+        $ignored = (string) $this->status;
+
+        if (! str_contains($ignored, '*')) {
+            return $actual === $ignored;
+        }
+
+        return (bool) preg_match(
+            '/^'.str_replace('\*', '.*', preg_quote($ignored, '/')).'$/',
+            $actual,
+        );
+    }
+}

--- a/src/Support/OperationExtensions/ResponseExtension.php
+++ b/src/Support/OperationExtensions/ResponseExtension.php
@@ -2,6 +2,7 @@
 
 namespace Dedoc\Scramble\Support\OperationExtensions;
 
+use Dedoc\Scramble\Attributes\IgnoreResponse;
 use Dedoc\Scramble\Attributes\Response as ResponseAttribute;
 use Dedoc\Scramble\Extensions\OperationExtension;
 use Dedoc\Scramble\Infer\Services\FileNameResolver;
@@ -28,6 +29,8 @@ class ResponseExtension extends OperationExtension
         $inferredResponses = $this->collectInferredResponses($routeInfo);
 
         $responses = $this->applyResponsesAttributes($inferredResponses, $routeInfo);
+
+        $responses = $this->applyIgnoreResponseAttributes($responses, $routeInfo);
 
         foreach ($responses as $response) {
             if (in_array($routeInfo->method, static::HTTP_METHODS_WITHOUT_RESPONSE_BODY)) {
@@ -135,6 +138,36 @@ class ResponseExtension extends OperationExtension
         }
 
         return $inferredResponses;
+    }
+
+    /**
+     * @param  Collection<int, Response|Reference>  $responses
+     * @return Collection<int, Response|Reference>
+     */
+    private function applyIgnoreResponseAttributes(Collection $responses, RouteInfo $routeInfo): Collection
+    {
+        $ignoreAttributes = $routeInfo->reflectionAction()?->getAttributes(IgnoreResponse::class, ReflectionAttribute::IS_INSTANCEOF) ?: [];
+
+        if (! count($ignoreAttributes)) {
+            return $responses;
+        }
+
+        /** @var IgnoreResponse[] $ignoredResponses */
+        $ignoredResponses = array_map(fn (ReflectionAttribute $a) => $a->newInstance(), $ignoreAttributes);
+
+        return $responses
+            ->reject(function (Response|Reference $r) use ($ignoredResponses) {
+                $response = $r instanceof Reference ? $r->resolve() : $r;
+
+                foreach ($ignoredResponses as $ignoredResponse) {
+                    if ($ignoredResponse->matches($response->code)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            })
+            ->values();
     }
 
     /**

--- a/tests/Attributes/IgnoreResponseTest.php
+++ b/tests/Attributes/IgnoreResponseTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Dedoc\Scramble\Tests\Attributes;
+
+use Dedoc\Scramble\Attributes\IgnoreResponse;
+use Dedoc\Scramble\Attributes\Response;
+use Illuminate\Support\Facades\Route;
+
+it('ignores response by exact status code on controller method', function () {
+    $openApiDocument = generateForRoute(fn () => Route::get('test', ExactStatusController_IgnoreResponseTest::class));
+
+    expect($openApiDocument['paths']['/test']['get']['responses'])
+        ->toHaveKey(200)
+        ->not->toHaveKey(404);
+});
+
+it('ignores response by string status code', function () {
+    $openApiDocument = generateForRoute(fn () => Route::get('test', StringStatusController_IgnoreResponseTest::class));
+
+    expect($openApiDocument['paths']['/test']['get']['responses'])
+        ->toHaveKey(200)
+        ->not->toHaveKey(404);
+});
+
+it('ignores responses matching status mask', function () {
+    $openApiDocument = generateForRoute(fn () => Route::get('test', StatusMaskController_IgnoreResponseTest::class));
+
+    expect($openApiDocument['paths']['/test']['get']['responses'])
+        ->toHaveKey(200)
+        ->toHaveKey(404)
+        ->not->toHaveKey(301)
+        ->not->toHaveKey(302);
+});
+
+it('supports multiple IgnoreResponse attributes', function () {
+    $openApiDocument = generateForRoute(fn () => Route::get('test', MultipleIgnoreController_IgnoreResponseTest::class));
+
+    expect($openApiDocument['paths']['/test']['get']['responses'])
+        ->toHaveKey(200)
+        ->not->toHaveKey(301)
+        ->not->toHaveKey(404);
+});
+
+it('ignores response on closure route', function () {
+    $openApiDocument = generateForRoute(fn () => Route::get(
+        'test',
+        #[IgnoreResponse(404)]
+        function () {
+            abort_if(rand(0, 1) > 0, 404);
+
+            return ['ok' => true];
+        }
+    ));
+
+    expect($openApiDocument['paths']['/test']['get']['responses'])
+        ->toHaveKey(200)
+        ->not->toHaveKey(404);
+});
+
+class ExactStatusController_IgnoreResponseTest
+{
+    #[IgnoreResponse(404)]
+    public function __invoke()
+    {
+        abort_if(rand(0, 1) > 0, 404);
+
+        return ['ok' => true];
+    }
+}
+
+class StringStatusController_IgnoreResponseTest
+{
+    #[IgnoreResponse('404')]
+    public function __invoke()
+    {
+        abort_if(rand(0, 1) > 0, 404);
+
+        return ['ok' => true];
+    }
+}
+
+class StatusMaskController_IgnoreResponseTest
+{
+    #[Response(301)]
+    #[Response(302)]
+    #[Response(404)]
+    #[IgnoreResponse('30*')]
+    public function __invoke()
+    {
+        return ['ok' => true];
+    }
+}
+
+class MultipleIgnoreController_IgnoreResponseTest
+{
+    #[Response(301)]
+    #[Response(404)]
+    #[IgnoreResponse(301)]
+    #[IgnoreResponse(404)]
+    public function __invoke()
+    {
+        return ['ok' => true];
+    }
+}


### PR DESCRIPTION
Adds an `IgnoreResponse` attribute so you can drop statuses from the generated docs — exact codes or a simple mask:

```php
#[IgnoreResponse(302)]
#[IgnoreResponse('40*')]
public function store()
{
    // ...
}

Route::get('/login', #[IgnoreResponse('30*')] fn () => redirect('/dashboard'));
```

fixes #610 
