### PR TITLE
Add `#[Api]` attribute for route-level API assignment

### DIFF
--- a/src/Attributes/Api.php
+++ b/src/Attributes/Api.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Dedoc\Scramble\Attributes;
+
+use Attribute;
+
+/**
+ * Restricts a route to one or more registered APIs.
+ *
+ * Routes without this attribute are not further restricted and continue to follow
+ * existing route resolver / filtering rules.
+ *
+ * Method-level attributes override class-level attributes.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_FUNCTION)]
+class Api
+{
+    /**
+     * @var list<string>
+     */
+    public readonly array $names;
+
+    public function __construct(string ...$names)
+    {
+        $this->names = array_values($names);
+    }
+}

--- a/src/Attributes/Api.php
+++ b/src/Attributes/Api.php
@@ -18,10 +18,10 @@ class Api
     /**
      * @var list<string>
      */
-    public readonly array $names;
+    public readonly array $only;
 
-    public function __construct(string ...$names)
+    public function __construct(string|array $only)
     {
-        $this->names = array_values($names);
+        $this->only = is_array($only) ? array_values($only) : [$only];
     }
 }

--- a/src/CacheableGenerator.php
+++ b/src/CacheableGenerator.php
@@ -22,7 +22,7 @@ class CacheableGenerator
             return ($this->generator)($config);
         }
 
-        $key = $keyBase.':'.$this->resolveApi($config);
+        $key = $keyBase.':'.$config->name;
 
         $cached = cache()->store($store)->get($key);
         if (is_array($cached)) {
@@ -30,16 +30,5 @@ class CacheableGenerator
         }
 
         return ($this->generator)($config);
-    }
-
-    private function resolveApi(GeneratorConfig $config): string
-    {
-        foreach (Scramble::getConfigurationsInstance()->all() as $api => $generatorConfig) {
-            if ($generatorConfig === $config) {
-                return $api;
-            }
-        }
-
-        return Scramble::DEFAULT_API;
     }
 }

--- a/src/Configuration/GeneratorConfigCollection.php
+++ b/src/Configuration/GeneratorConfigCollection.php
@@ -5,6 +5,7 @@ namespace Dedoc\Scramble\Configuration;
 use Dedoc\Scramble\GeneratorConfig;
 use Dedoc\Scramble\Scramble;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Collection;
 use LogicException;
 
 class GeneratorConfigCollection

--- a/src/Configuration/GeneratorConfigCollection.php
+++ b/src/Configuration/GeneratorConfigCollection.php
@@ -5,7 +5,6 @@ namespace Dedoc\Scramble\Configuration;
 use Dedoc\Scramble\GeneratorConfig;
 use Dedoc\Scramble\Scramble;
 use Illuminate\Routing\Router;
-use Illuminate\Support\Collection;
 use LogicException;
 
 class GeneratorConfigCollection

--- a/src/Configuration/GeneratorConfigCollection.php
+++ b/src/Configuration/GeneratorConfigCollection.php
@@ -21,7 +21,7 @@ class GeneratorConfigCollection
 
     private function buildDefaultApiConfiguration(): GeneratorConfig
     {
-        return (new GeneratorConfig)
+        return (new GeneratorConfig(name: Scramble::DEFAULT_API))
             ->expose(
                 ui: fn (Router $router, $action) => $router->get('docs/api', $action)->name('scramble.docs.ui'),
                 document: fn (Router $router, $action) => $router->get('docs/api.json', $action)->name('scramble.docs.document'),
@@ -40,7 +40,7 @@ class GeneratorConfigCollection
     public function register(string $name, array $config): GeneratorConfig
     {
         $this->apis[$name] = $generatorConfig = $this->apis[Scramble::DEFAULT_API]
-            ->cloneWithoutExposing()
+            ->cloneWithoutExposing($name)
             ->useConfig(array_merge(config('scramble') ?: [], $config));
 
         return $generatorConfig;

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -245,7 +245,7 @@ class Generator
                 }
 
                 $apiNames = $this->getApiAttributeNames($reflection);
-                if ($apiNames !== null && ! in_array($this->resolveApi($config), $apiNames, true)) {
+                if ($apiNames !== null && ! in_array($config->name, $apiNames, true)) {
                     return false;
                 }
 
@@ -270,17 +270,6 @@ class Generator
         }
 
         return $attributes[0]->newInstance()->names;
-    }
-
-    private function resolveApi(GeneratorConfig $config): string
-    {
-        foreach (Scramble::getConfigurationsInstance()->all() as $api => $generatorConfig) {
-            if ($generatorConfig === $config) {
-                return $api;
-            }
-        }
-
-        return Scramble::DEFAULT_API;
     }
 
     private function buildTypeTransformer(OpenApiContext $context): TypeTransformer

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -30,6 +30,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route as RouteFacade;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use LogicException;
 use ReflectionException;
 use ReflectionMethod;
 use Throwable;
@@ -269,7 +270,25 @@ class Generator
             return null;
         }
 
-        return $attributes[0]->newInstance()->only;
+        $apiNames = $attributes[0]->newInstance()->only;
+
+        $this->ensureRegisteredApiNames($apiNames);
+
+        return $apiNames;
+    }
+
+    /**
+     * @param list<string> $apiNames
+     */
+    private function ensureRegisteredApiNames(array $apiNames): void
+    {
+        $registeredApis = array_keys(Scramble::getConfigurationsInstance()->all());
+
+        foreach ($apiNames as $apiName) {
+            if (! in_array($apiName, $registeredApis, true)) {
+                throw new LogicException("$apiName API is not registered. Register the API using `Scramble::registerApi` first.");
+            }
+        }
     }
 
     private function buildTypeTransformer(OpenApiContext $context): TypeTransformer

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -278,7 +278,7 @@ class Generator
     }
 
     /**
-     * @param list<string> $apiNames
+     * @param  list<string>  $apiNames
      */
     private function ensureRegisteredApiNames(array $apiNames): void
     {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -269,7 +269,7 @@ class Generator
             return null;
         }
 
-        return $attributes[0]->newInstance()->names;
+        return $attributes[0]->newInstance()->only;
     }
 
     private function buildTypeTransformer(OpenApiContext $context): TypeTransformer

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -3,6 +3,7 @@
 namespace Dedoc\Scramble;
 
 use Closure;
+use Dedoc\Scramble\Attributes\Api;
 use Dedoc\Scramble\Attributes\ExcludeAllRoutesFromDocs;
 use Dedoc\Scramble\Attributes\ExcludeRouteFromDocs;
 use Dedoc\Scramble\Configuration\SecurityDocumentationContext;
@@ -220,7 +221,7 @@ class Generator
                 return ! ($name = $route->getAction('as')) || ! Str::startsWith($name, 'scramble');
             })
             ->filter($config->routes())
-            ->filter(function (Route $route) {
+            ->filter(function (Route $route) use ($config) {
                 if (! is_string($route->getAction('uses'))) {
                     return true;
                 }
@@ -243,9 +244,43 @@ class Generator
                     return false;
                 }
 
+                $apiNames = $this->getApiAttributeNames($reflection);
+                if ($apiNames !== null && ! in_array($this->resolveApi($config), $apiNames, true)) {
+                    return false;
+                }
+
                 return true;
             })
             ->values();
+    }
+
+    /**
+     * @return list<string>|null `null` when the route has no #[Api] restriction
+     */
+    private function getApiAttributeNames(ReflectionMethod $reflection): ?array
+    {
+        $attributes = $reflection->getAttributes(Api::class);
+
+        if (! count($attributes)) {
+            $attributes = $reflection->getDeclaringClass()->getAttributes(Api::class);
+        }
+
+        if (! count($attributes)) {
+            return null;
+        }
+
+        return $attributes[0]->newInstance()->names;
+    }
+
+    private function resolveApi(GeneratorConfig $config): string
+    {
+        foreach (Scramble::getConfigurationsInstance()->all() as $api => $generatorConfig) {
+            if ($generatorConfig === $config) {
+                return $api;
+            }
+        }
+
+        return Scramble::DEFAULT_API;
     }
 
     private function buildTypeTransformer(OpenApiContext $context): TypeTransformer

--- a/src/GeneratorConfig.php
+++ b/src/GeneratorConfig.php
@@ -42,6 +42,7 @@ class GeneratorConfig
     public Closure $operationMethodsResolver;
 
     public function __construct(
+        public readonly string $name = Scramble::DEFAULT_API,
         private array $config = [],
         private ?Closure $routeResolver = null,
         public readonly ParametersExtractors $parametersExtractors = new ParametersExtractors,
@@ -148,9 +149,10 @@ class GeneratorConfig
         return $this;
     }
 
-    public function cloneWithoutExposing(): self
+    public function cloneWithoutExposing(?string $name = null): self
     {
         return new self(
+            name: $name ?? $this->name,
             config: $this->config,
             routeResolver: $this->routeResolver,
             parametersExtractors: clone $this->parametersExtractors,

--- a/tests/Generator/ApiAttributeFilteringTest.php
+++ b/tests/Generator/ApiAttributeFilteringTest.php
@@ -73,6 +73,18 @@ it('does not include Api-annotated routes rejected by the route resolver', funct
     expect(ApiAttributeFilteringTest_paths('internal'))->toBe([]);
 });
 
+it('fails when Api attribute references an unregistered api', function () {
+    RouteFacade::get('api-attr/bogus', [ApiAttributeFilteringTest_BogusController::class, 'index']);
+
+    app(Generator::class)(Scramble::getGeneratorConfig('public'));
+})->throws(LogicException::class, 'bogus API is not registered');
+
+class ApiAttributeFilteringTest_BogusController
+{
+    #[Api('bogus')]
+    public function index() {}
+}
+
 class ApiAttributeFilteringTest_Controller
 {
     public function open() {}

--- a/tests/Generator/ApiAttributeFilteringTest.php
+++ b/tests/Generator/ApiAttributeFilteringTest.php
@@ -80,7 +80,7 @@ class ApiAttributeFilteringTest_Controller
     #[Api('internal')]
     public function internalOnly() {}
 
-    #[Api('public', 'internal')]
+    #[Api(['public', 'internal'])]
     public function both() {}
 
     #[Api('internal')]

--- a/tests/Generator/ApiAttributeFilteringTest.php
+++ b/tests/Generator/ApiAttributeFilteringTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use Dedoc\Scramble\Attributes\Api;
+use Dedoc\Scramble\Attributes\ExcludeRouteFromDocs;
+use Dedoc\Scramble\Generator;
+use Dedoc\Scramble\Scramble;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Route as RouteFacade;
+
+function ApiAttributeFilteringTest_paths(string $api): array
+{
+    return array_keys(app(Generator::class)(Scramble::getGeneratorConfig($api))['paths'] ?? []);
+}
+
+beforeEach(function () {
+    Scramble::ignoreDefaultRoutes();
+
+    Scramble::registerApi('public', [
+        'api_path' => '',
+    ])->routes(fn (Route $r) => str_starts_with($r->uri, 'api-attr/'));
+
+    Scramble::registerApi('internal', [
+        'api_path' => '',
+    ])->routes(fn (Route $r) => str_starts_with($r->uri, 'api-attr/'));
+});
+
+it('includes routes without Api attribute in every matching API', function () {
+    RouteFacade::get('api-attr/open', [ApiAttributeFilteringTest_Controller::class, 'open']);
+
+    expect(ApiAttributeFilteringTest_paths('public'))->toBe(['/api-attr/open'])
+        ->and(ApiAttributeFilteringTest_paths('internal'))->toBe(['/api-attr/open']);
+});
+
+it('includes Api-annotated routes only in the named APIs', function () {
+    RouteFacade::get('api-attr/internal-only', [ApiAttributeFilteringTest_Controller::class, 'internalOnly']);
+    RouteFacade::get('api-attr/both', [ApiAttributeFilteringTest_Controller::class, 'both']);
+
+    expect(ApiAttributeFilteringTest_paths('public'))->toBe(['/api-attr/both'])
+        ->and(ApiAttributeFilteringTest_paths('internal'))->toBe([
+            '/api-attr/internal-only',
+            '/api-attr/both',
+        ]);
+});
+
+it('applies class-level Api attribute to all controller methods', function () {
+    RouteFacade::get('api-attr/class-a', [ApiAttributeFilteringTest_InternalController::class, 'a']);
+    RouteFacade::get('api-attr/class-b', [ApiAttributeFilteringTest_InternalController::class, 'b']);
+
+    expect(ApiAttributeFilteringTest_paths('public'))->toBe([])
+        ->and(ApiAttributeFilteringTest_paths('internal'))->toBe([
+            '/api-attr/class-a',
+            '/api-attr/class-b',
+        ]);
+});
+
+it('lets method-level Api attribute override class-level attribute', function () {
+    RouteFacade::get('api-attr/override-default', [ApiAttributeFilteringTest_OverrideController::class, 'defaulted']);
+    RouteFacade::get('api-attr/override-public', [ApiAttributeFilteringTest_OverrideController::class, 'publicOnly']);
+
+    expect(ApiAttributeFilteringTest_paths('public'))->toBe(['/api-attr/override-public'])
+        ->and(ApiAttributeFilteringTest_paths('internal'))->toBe(['/api-attr/override-default']);
+});
+
+it('does not re-include routes excluded by ExcludeRouteFromDocs', function () {
+    RouteFacade::get('api-attr/excluded', [ApiAttributeFilteringTest_Controller::class, 'excluded']);
+
+    expect(ApiAttributeFilteringTest_paths('internal'))->toBe([]);
+});
+
+it('does not include Api-annotated routes rejected by the route resolver', function () {
+    RouteFacade::get('other/internal-only', [ApiAttributeFilteringTest_Controller::class, 'internalOnly']);
+
+    expect(ApiAttributeFilteringTest_paths('internal'))->toBe([]);
+});
+
+class ApiAttributeFilteringTest_Controller
+{
+    public function open() {}
+
+    #[Api('internal')]
+    public function internalOnly() {}
+
+    #[Api('public', 'internal')]
+    public function both() {}
+
+    #[Api('internal')]
+    #[ExcludeRouteFromDocs]
+    public function excluded() {}
+}
+
+#[Api('internal')]
+class ApiAttributeFilteringTest_InternalController
+{
+    public function a() {}
+
+    public function b() {}
+}
+
+#[Api('internal')]
+class ApiAttributeFilteringTest_OverrideController
+{
+    public function defaulted() {}
+
+    #[Api('public')]
+    public function publicOnly() {}
+}


### PR DESCRIPTION
When you register multiple APIs with Scramble, routes can now declare which docs they belong to:

```php
Scramble::registerApi('internal');

class UserController
{
    public function index() {}

    #[Api('internal')]
    public function destroy() {}
}
```

`index` shows up in the `default` and `internal` docs, `destroy` only in `internal`.

You can also put the attribute on the controller class; a method-level attribute overrides it:

```php
#[Api('internal')]
class AdminController
{
    public function index() {}

    #[Api('default')]
    public function status() {}
}
```

Routes without `#[Api]` behave as before — they follow the existing route resolver and filtering rules. The attribute only narrows inclusion further; it won't bring back routes excluded by `ExcludeRouteFromDocs` or other filters.

fixes #751