### PR TITLE
Fix file min/max/size/between rules emitting minLength/maxLength

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
+++ b/src/Support/OperationExtensions/RulesExtractor/RulesMapper.php
@@ -116,6 +116,10 @@ class RulesMapper
 
     public function min(Type $type, $params)
     {
+        if ($this->isFileType($type)) {
+            return $this->appendFileSizeDescription($type, "Minimum file size: {$params[0]} kilobytes.");
+        }
+
         if (
             $type instanceof NumberType
             || $type instanceof ArrayType
@@ -129,6 +133,10 @@ class RulesMapper
 
     public function max(Type $type, $params)
     {
+        if ($this->isFileType($type)) {
+            return $this->appendFileSizeDescription($type, "Maximum file size: {$params[0]} kilobytes.");
+        }
+
         if (
             $type instanceof NumberType
             || $type instanceof ArrayType
@@ -142,6 +150,10 @@ class RulesMapper
 
     public function size(Type $type, $params)
     {
+        if ($this->isFileType($type)) {
+            return $this->appendFileSizeDescription($type, "File size must be {$params[0]} kilobytes.");
+        }
+
         $type = $this->min($type, $params);
 
         return $this->max($type, $params);
@@ -156,9 +168,25 @@ class RulesMapper
             return $type;
         }
 
+        if ($this->isFileType($type)) {
+            return $this->appendFileSizeDescription($type, "File size must be between {$params[0]} kilobytes and {$params[1]} kilobytes.");
+        }
+
         $type = $this->min($type, [$params[0]]);
 
         return $this->max($type, [$params[1]]);
+    }
+
+    private function isFileType(Type $type): bool
+    {
+        return $type instanceof StringType && $type->format === 'binary';
+    }
+
+    private function appendFileSizeDescription(Type $type, string $description): Type
+    {
+        $type->setDescription(trim($type->description ? "{$type->description} {$description}" : $description));
+
+        return $type;
     }
 
     public function image(Type $type)

--- a/tests/Support/OperationExtensions/RulesExtractor/RuleSetToSchemaTransformersTest.php
+++ b/tests/Support/OperationExtensions/RulesExtractor/RuleSetToSchemaTransformersTest.php
@@ -227,10 +227,69 @@ describe(File::class, function () {
                 'type' => 'string',
                 'format' => 'binary',
                 'contentMediaType' => 'application/octet-stream',
-                'minLength' => 1024.0,
-                'maxLength' => 12288.0,
+                'description' => 'File size must be between 1024 kilobytes and 12288 kilobytes.',
             ]);
     });
+
+    test('file min rule', function ($rules) {
+        $schema = $this->transformer->transform($rules);
+
+        expect($schema->toArray())
+            ->toBe([
+                'type' => 'string',
+                'format' => 'binary',
+                'contentMediaType' => 'application/octet-stream',
+                'description' => 'Minimum file size: 1024 kilobytes.',
+            ]);
+    })->with([
+        'file first' => [['file', 'min:1024']],
+        'min first' => [['min:1024', 'file']],
+    ]);
+
+    test('file max rule', function ($rules) {
+        $schema = $this->transformer->transform($rules);
+
+        expect($schema->toArray())
+            ->toBe([
+                'type' => 'string',
+                'format' => 'binary',
+                'contentMediaType' => 'application/octet-stream',
+                'description' => 'Maximum file size: 4096 kilobytes.',
+            ]);
+    })->with([
+        'file first' => [['file', 'max:4096']],
+        'max first' => [['max:4096', 'file']],
+    ]);
+
+    test('file size rule', function ($rules) {
+        $schema = $this->transformer->transform($rules);
+
+        expect($schema->toArray())
+            ->toBe([
+                'type' => 'string',
+                'format' => 'binary',
+                'contentMediaType' => 'application/octet-stream',
+                'description' => 'File size must be 2048 kilobytes.',
+            ]);
+    })->with([
+        'file first' => [['file', 'size:2048']],
+        'size first' => [['size:2048', 'file']],
+    ]);
+
+    test('file between rule', function ($rules) {
+        $schema = $this->transformer->transform($rules);
+
+        expect($schema->toArray())
+            ->toBe([
+                'type' => 'string',
+                'format' => 'binary',
+                'contentMediaType' => 'application/octet-stream',
+                'description' => 'File size must be between 1024 kilobytes and 4096 kilobytes.',
+            ]);
+    })->with([
+        'file first' => [['file', 'between:1024,4096']],
+        'between first' => [['between:1024,4096', 'file']],
+    ]);
 
     test('image file rule', function () {
         $rules = [

--- a/tests/ValidationRulesDocumentingTest.php
+++ b/tests/ValidationRulesDocumentingTest.php
@@ -702,6 +702,72 @@ it('supports file rule', function () {
         ->and($type->contentMediaType)->toBe('application/octet-stream');
 });
 
+it('documents file min rule as description instead of minLength', function ($rules) {
+    $params = ($this->buildRulesToParameters)(['file' => $rules])->handle();
+
+    expect($params[0]->description)->toBe('Minimum file size: 1024 kilobytes.')
+        ->and($params[0]->schema->type->toArray())
+        ->toMatchArray([
+            'type' => 'string',
+            'format' => 'binary',
+            'contentMediaType' => 'application/octet-stream',
+        ])
+        ->not->toHaveKey('minLength');
+})->with([
+    'file first' => [['file', 'min:1024']],
+    'min first' => [['min:1024', 'file']],
+]);
+
+it('documents file max rule as description instead of maxLength', function ($rules) {
+    $params = ($this->buildRulesToParameters)(['file' => $rules])->handle();
+
+    expect($params[0]->description)->toBe('Maximum file size: 4096 kilobytes.')
+        ->and($params[0]->schema->type->toArray())
+        ->toMatchArray([
+            'type' => 'string',
+            'format' => 'binary',
+            'contentMediaType' => 'application/octet-stream',
+        ])
+        ->not->toHaveKey('maxLength');
+})->with([
+    'file first' => [['file', 'max:4096']],
+    'max first' => [['max:4096', 'file']],
+]);
+
+it('documents file size rule as description instead of length constraints', function ($rules) {
+    $params = ($this->buildRulesToParameters)(['file' => $rules])->handle();
+
+    expect($params[0]->description)->toBe('File size must be 2048 kilobytes.')
+        ->and($params[0]->schema->type->toArray())
+        ->toMatchArray([
+            'type' => 'string',
+            'format' => 'binary',
+            'contentMediaType' => 'application/octet-stream',
+        ])
+        ->not->toHaveKey('minLength')
+        ->not->toHaveKey('maxLength');
+})->with([
+    'file first' => [['file', 'size:2048']],
+    'size first' => [['size:2048', 'file']],
+]);
+
+it('documents file between rule as description instead of length constraints', function ($rules) {
+    $params = ($this->buildRulesToParameters)(['file' => $rules])->handle();
+
+    expect($params[0]->description)->toBe('File size must be between 1024 kilobytes and 4096 kilobytes.')
+        ->and($params[0]->schema->type->toArray())
+        ->toMatchArray([
+            'type' => 'string',
+            'format' => 'binary',
+            'contentMediaType' => 'application/octet-stream',
+        ])
+        ->not->toHaveKey('minLength')
+        ->not->toHaveKey('maxLength');
+})->with([
+    'file first' => [['file', 'between:1024,4096']],
+    'between first' => [['between:1024,4096', 'file']],
+]);
+
 it('converts min rule into "minimum" for numeric fields', function () {
     $rules = [
         'num' => ['int', 'min:8'],


### PR DESCRIPTION
fixes #764

For file fields, `min`, `max`, `size`, and `between` were mapped to `minLength`/`maxLength`, which is wrong — Laravel treats those values as kilobytes for files, not character count.

File schemas now skip length constraints and document the size limit in the parameter description instead (e.g. `Maximum file size: 4096 kilobytes.`). String, numeric, and array behavior is unchanged.