### PR TITLE
Fix request body parameter order when merging nested rules

### DIFF
--- a/src/Support/OperationExtensions/RulesExtractor/DeepParametersMerger.php
+++ b/src/Support/OperationExtensions/RulesExtractor/DeepParametersMerger.php
@@ -37,6 +37,8 @@ class DeepParametersMerger
      */
     private function handleNested(Collection $parameters): Collection
     {
+        $originalKeys = $parameters->keys();
+
         /**
          * @var Collection<string, Parameter> $forcedFlatParameters
          * @var Collection<string, Parameter> $maybeDeepParameters
@@ -93,7 +95,10 @@ class DeepParametersMerger
 
         return $parameters
             ->merge($forcedFlatParameters)
-            ->merge($nested);
+            ->merge($nested)
+            ->sortBy(fn ($_, $key) => $originalKeys->search(
+                fn ($k) => $k === $key || self::splitOnUnescapedDots($k)[0] === $key
+            ));
     }
 
     private function setDeepType(Type &$base, string $key, Parameter $parameter): void

--- a/tests/ValidationRulesDocumentingTest.php
+++ b/tests/ValidationRulesDocumentingTest.php
@@ -35,6 +35,19 @@ function validationRulesToDocumentationWithDeep($rulesToParameters)
 }
 
 // @todo: move rules from here to Generator/Request/ValidationRulesDocumentation test
+it('maintains parameter order when merging nested rules', function () {
+    $rules = [
+        'name' => 'string|required',
+        'status' => 'array|required',
+        'status.*' => 'string',
+        'type' => 'string|nullable',
+    ];
+
+    $params = validationRulesToDocumentationWithDeep(($this->buildRulesToParameters)($rules));
+
+    expect(collect($params)->pluck('name')->all())->toBe(['name', 'status', 'type']);
+});
+
 it('supports present rule', function () {
     $rules = [
         'password' => ['present'],


### PR DESCRIPTION
`DeepParametersMerger` was appending nested parents (`status`, `development.*`, etc.) after all flat fields, so later simple keys like `type` / `job` jumped ahead in the OpenAPI schema.

After the usual merge, parameters are sorted back to the order of their first key in the ruleset. 

fixes #900