### PR TITLE
Avoid calling class_basename with null

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3388,12 +3388,6 @@ parameters:
 			path: src/Support/OperationExtensions/RequestEssentialsExtension.php
 
 		-
-			message: '#^Parameter \#1 \$class of function class_basename expects object\|string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Support/OperationExtensions/RequestEssentialsExtension.php
-
-		-
 			message: '#^Parameter \#1 \.\.\.\$values of method Illuminate\\Support\\Collection\<int,string\>\:\:push\(\) expects non\-falsy\-string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Support/OperationExtensions/RequestEssentialsExtension.php
+++ b/src/Support/OperationExtensions/RequestEssentialsExtension.php
@@ -43,7 +43,11 @@ class RequestEssentialsExtension extends OperationExtension
      */
     private function getDefaultTags(Operation $operation, RouteInfo $routeInfo): array
     {
-        $defaultName = (string) Str::of(class_basename($routeInfo->className()))->replace('Controller', '');
+        $defaultName = null;
+
+        if ($className = $routeInfo->className()) {
+            $defaultName = (string) Str::of(class_basename($className))->remove('Controller');
+        }
 
         if ($groupAttrsInstances = $this->getTagsAnnotatedByGroups($routeInfo)) {
             $attributeInstance = $groupAttrsInstances[0]->newInstance();


### PR DESCRIPTION
I see these logs in my `deprecation.log` of my project.
```
[2026-07-13 08:03:02] local.WARNING: ErrorException: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/vendor/laravel/framework/src/Illuminate/Support/helpers.php:90
Stack trace:
#0 /var/www/vendor/laravel/framework/src/Illuminate/Support/helpers.php(526): Illuminate\Foundation\Bootstrap\HandleExceptions->{closure:Illuminate\Foundation\Bootstrap\HandleExceptions::handleDeprecationError():109}(Object(Illuminate\Log\Logger))
#1 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(109): with(Object(Illuminate\Log\Logger), Object(Closure))
#2 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(74): Illuminate\Foundation\Bootstrap\HandleExceptions->handleDeprecationError('str_replace(): ...', '/var/www/vendor...', 90, 8192)
#3 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(263): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(8192, 'str_replace(): ...', '/var/www/vendor...', 90)
#4 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->{closure:Illuminate\Foundation\Bootstrap\HandleExceptions::forwardsTo():262}(8192, 'str_replace(): ...', '/var/www/vendor...', 90)
#5 /var/www/vendor/laravel/framework/src/Illuminate/Support/helpers.php(90): str_replace('\\', '/', NULL)
#6 /var/www/vendor/dedoc/scramble/src/Support/OperationExtensions/RequestEssentialsExtension.php(46): class_basename(NULL)
#7 /var/www/vendor/dedoc/scramble/src/Support/OperationExtensions/RequestEssentialsExtension.php(70): Dedoc\Scramble\Support\OperationExtensions\RequestEssentialsExtension->getDefaultTags(Object(Dedoc\Scramble\Support\Generator\Operation), Object(Dedoc\Scramble\Support\RouteInfo))
#8 /var/www/vendor/dedoc/scramble/src/Support/OperationExtensions/RequestEssentialsExtension.php(81): Dedoc\Scramble\Support\OperationExtensions\RequestEssentialsExtension->{closure:Dedoc\Scramble\Support\OperationExtensions\RequestEssentialsExtension::handle():70}(Object(Dedoc\Scramble\Support\RouteInfo), Object(Dedoc\Scramble\Support\Generator\Operation))
#9 /var/www/vendor/dedoc/scramble/src/Support/OperationBuilder.php(37): Dedoc\Scramble\Support\OperationExtensions\RequestEssentialsExtension->handle(Object(Dedoc\Scramble\Support\Generator\Operation), Object(Dedoc\Scramble\Support\RouteInfo))
#10 /var/www/vendor/dedoc/scramble/src/Generator.php(264): Dedoc\Scramble\Support\OperationBuilder->build(Object(Dedoc\Scramble\Support\RouteInfo), Object(Dedoc\Scramble\Support\Generator\OpenApi), Object(Dedoc\Scramble\GeneratorConfig), Object(Dedoc\Scramble\Support\Generator\TypeTransformer))
```

After some investigation, I realized the source of it.
When Scramble tries to get the tags of a route that is not a class (or, in other words, it is a closure), it calls `class_basename` with a null argument, and it triggers a deprecation message.

See:
https://github.com/dedoc/scramble/blob/af86ba277ee71640215ec4715bac1aa04e0767f6/src/Support/OperationExtensions/RequestEssentialsExtension.php#L46

I fixed it; also, I use the `remove` method of the `Str` helper instead of `replace` with an empty string.