### PR TITLE
Avoid passing null to Str functions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3394,12 +3394,6 @@ parameters:
 			path: src/Support/OperationExtensions/RequestEssentialsExtension.php
 
 		-
-			message: '#^Parameter \#1 \.\.\.\$values of method Illuminate\\Support\\Collection\<int,string\>\:\:push\(\) expects non\-falsy\-string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Support/OperationExtensions/RequestEssentialsExtension.php
-
-		-
 			message: '#^Using nullsafe property access "\?\-\>expr" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
 			identifier: nullsafe.neverNull
 			count: 1

--- a/src/Support/OperationExtensions/RequestEssentialsExtension.php
+++ b/src/Support/OperationExtensions/RequestEssentialsExtension.php
@@ -170,8 +170,6 @@ class RequestEssentialsExtension extends OperationExtension
 
     private function getOperationId(RouteInfo $routeInfo)
     {
-        $routeClassName = $routeInfo->className() ?: '';
-
         return new UniqueNameOptions(
             eloquent: (function () use ($routeInfo) {
                 // Manual operation ID setting.
@@ -199,19 +197,20 @@ class RequestEssentialsExtension extends OperationExtension
                 // If no name and no operationId manually set, falling back to controller and method name (unique implementation).
                 return null;
             })(),
-            unique: collect(explode('\\', Str::endsWith($routeClassName, 'Controller') ? Str::replaceLast('Controller', '', $routeClassName) : $routeClassName))
+            unique: Str::of($routeInfo->className() ?? '')
+                ->replaceEnd('Controller', '')
+                ->explode('\\')
+                ->push($routeInfo->methodName() ?? '')
                 ->filter()
-                ->push($routeInfo->methodName())
-                ->map(function ($part) {
-                    if ($part === Str::upper($part)) {
-                        return Str::lower($part);
-                    }
-
-                    return Str::camel($part);
-                })
-                ->reject(fn ($p) => in_array(Str::lower($p), ['app', 'http', 'api', 'controllers', 'invoke']))
+                ->map(static fn (string $part) => Str::upper($part) === $part
+                    ? Str::lower($part)
+                    : Str::camel($part)
+                )
+                ->reject(static fn (string $p) => in_array(Str::lower($p), [
+                    'app', 'http', 'api', 'controllers', 'invoke',
+                ]))
                 ->values()
-                ->toArray(),
+                ->all(),
         );
     }
 


### PR DESCRIPTION
I see these logs in my project's `deprecation.log` file.

```
[2026-07-13 08:37:41] local.WARNING: ErrorException: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/vendor/laravel/framework/src/Illuminate/Support/Str.php:1284
Stack trace:
#0 /var/www/vendor/laravel/framework/src/Illuminate/Support/helpers.php(526): Illuminate\Foundation\Bootstrap\HandleExceptions->{closure:Illuminate\Foundation\Bootstrap\HandleExceptions::handleDeprecationError():109}(Object(Illuminate\Log\Logger))
#1 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(109): with(Object(Illuminate\Log\Logger), Object(Closure))
#2 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(74): Illuminate\Foundation\Bootstrap\HandleExceptions->handleDeprecationError('str_replace(): ...', '/var/www/vendor...', 1284, 8192)
#3 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(263): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(8192, 'str_replace(): ...', '/var/www/vendor...', 1284)
#4 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->{closure:Illuminate\Foundation\Bootstrap\HandleExceptions::forwardsTo():262}(8192, 'str_replace(): ...', '/var/www/vendor...', 1284)
#5 /var/www/vendor/laravel/framework/src/Illuminate/Support/Str.php(1284): str_replace(Array, ' ', NULL)
#6 /var/www/vendor/laravel/framework/src/Illuminate/Support/Str.php(1756): Illuminate\Support\Str::replace(Array, ' ', NULL)
#7 /var/www/vendor/laravel/framework/src/Illuminate/Support/Str.php(241): Illuminate\Support\Str::studly(NULL)
#8 /var/www/vendor/dedoc/scramble/src/Support/OperationExtensions/RequestEssentialsExtension.php(214): Illuminate\Support\Str::camel(NULL)
```
and
```
[2026-07-13 08:37:43] local.WARNING: ErrorException: mb_strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/vendor/laravel/framework/src/Illuminate/Support/Str.php:1454
Stack trace:
#0 /var/www/vendor/laravel/framework/src/Illuminate/Support/helpers.php(526): Illuminate\Foundation\Bootstrap\HandleExceptions->{closure:Illuminate\Foundation\Bootstrap\HandleExceptions::handleDeprecationError():109}(Object(Illuminate\Log\Logger))
#1 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(109): with(Object(Illuminate\Log\Logger), Object(Closure))
#2 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(74): Illuminate\Foundation\Bootstrap\HandleExceptions->handleDeprecationError('mb_strtoupper()...', '/var/www/vendor...', 1454, 8192)
#3 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(263): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(8192, 'mb_strtoupper()...', '/var/www/vendor...', 1454)
#4 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->{closure:Illuminate\Foundation\Bootstrap\HandleExceptions::forwardsTo():262}(8192, 'mb_strtoupper()...', '/var/www/vendor...', 1454)
#5 /var/www/vendor/laravel/framework/src/Illuminate/Support/Str.php(1454): mb_strtoupper(NULL, 'UTF-8')
#6 /var/www/vendor/dedoc/scramble/src/Support/OperationExtensions/RequestEssentialsExtension.php(210): Illuminate\Support\Str::upper(NULL)
#7 [internal function]: Dedoc\Scramble\Support\OperationExtensions\RequestEssentialsExtension->{closure:Dedoc\Scramble\Support\OperationExtensions\RequestEssentialsExtension::getOperationId():209}(NULL, 0)
```
It is because the `$routeInfo->methodName()` can return `null` when it is not a class controller, and it will reach the `map` method and the `Str::` methods as null.
I move `filter` just after pushing the `$routeInfo->methodName()` into the collection.
Also, I've done some small improvements, like adding the `static` keyword to Closures, which do not use `$this` and convert anonymous functions to arrow functions.