### PR TITLE
use ReflectionMethod::createFromMethodName as of PHP 8.3

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -192,20 +192,33 @@ class Generator
      */
     private function getRoutes(GeneratorConfig $config): Collection
     {
+        $buildReflectionMethodFrom = function (string $action): ReflectionMethod {
+            if (PHP_VERSION_ID < 80300) { // Function 'createFromMethodName' is available since PHP 8.3
+                return new ReflectionMethod(...explode('@', $action));
+            }
+
+            // Using: `public function ReflectionMethod::__construct(string $classMethod)` signature is deprecated as of PHP 8.4.0
+            // We should use ReflectionMethod::createFromMethodName() instead.
+            return strpos($action, '@') === false
+                ? ReflectionMethod::createFromMethodName($action)
+                : new ReflectionMethod(...explode('@', $action));
+        };
+
         return collect(RouteFacade::getRoutes())
-            ->pipe(function (Collection $c) {
-                $onlyRoutes = $c->filter(function (Route $route) {
+            ->pipe(static function (Collection $c) use ($buildReflectionMethodFrom) {
+                $onlyRoutes = $c->filter(static function (Route $route) use ($buildReflectionMethodFrom) {
 
                     if (! is_string($route->getAction('controller'))) {
                         return false;
                     }
 
-                    if (! is_string($route->getAction('uses'))) {
+                    $action = $route->getAction('uses');
+                    if (! is_string($action)) {
                         return false;
                     }
 
                     try {
-                        $reflection = new ReflectionMethod(...explode('@', $route->getAction('uses')));
+                        $reflection = $buildReflectionMethodFrom($action);
 
                         if (str_contains($reflection->getDocComment() ?: '', '@only-docs')) {
                             return true;
@@ -222,13 +235,15 @@ class Generator
                 return ! ($name = $route->getAction('as')) || ! Str::startsWith($name, 'scramble');
             })
             ->filter($config->routes())
-            ->filter(function (Route $route) use ($config) {
-                if (! is_string($route->getAction('uses'))) {
+            ->filter(function (Route $route) use ($config, $buildReflectionMethodFrom) {
+                $action = $route->getAction('uses');
+
+                if (! is_string($action)) {
                     return true;
                 }
 
                 try {
-                    $reflection = new ReflectionMethod(...explode('@', $route->getAction('uses')));
+                    $reflection = $buildReflectionMethodFrom($action);
                 } catch (ReflectionException) {
                     /*
                      * If route is registered but route method doesn't exist, it will not be included


### PR DESCRIPTION
The `ReflectionMethod::__construct` has two signatures:

```php
public function ReflectionMethod::__construct(object|string $objectOrMethod, string $method)
```

Alternative signature (not supported with named arguments):

```php
public function ReflectionMethod::__construct(string $classMethod)
```

When Laravel optimizes routes (using the `php artisan optimize` command), it converts closures into a string that starts with [laravel-serializable-closure](https://github.com/laravel/serializable-closure).

As a result, calling `...explode('@', $action)` returns only one element, because only class controller actions contain `@`.

However, the alternative constructor signature has been deprecated as of PHP 8.4.0.

This results in deprecation entries being written to the `deprecation.log` file:

```text
[2026-07-13 10:28:42] local.WARNING: ErrorException: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in /var/www/vendor/dedoc/scramble/src/Generator.php:226
Stack trace:
#0 /var/www/vendor/laravel/framework/src/Illuminate/Support/helpers.php(526): Illuminate\Foundation\Bootstrap\HandleExceptions->{closure:Illuminate\Foundation\Bootstrap\HandleExceptions::handleDeprecationError():109}(Object(Illuminate\Log\Logger))
#1 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(109): with(Object(Illuminate\Log\Logger), Object(Closure))
#2 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(74): Illuminate\Foundation\Bootstrap\HandleExceptions->handleDeprecationError('Calling Reflect...', '/var/www/vendor...', 226, 8192)
#3 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(263): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(8192, 'Calling Reflect...', '/var/www/vendor...', 226)
#4 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->{closure:Illuminate\Foundation\Bootstrap\HandleExceptions::forwardsTo():262}(8192, 'Calling Reflect...', '/var/www/vendor...', 226)
#5 /var/www/vendor/dedoc/scramble/src/Generator.php(226): ReflectionMethod->__construct('O:55:"Laravel\\S...')
#6 [internal function]: Dedoc\Scramble\Generator->{closure:Dedoc\Scramble\Generator::getRoutes():220}(Object(Illuminate\Routing\Route), 825)
#7 /var/www/vendor/laravel/framework/src/Illuminate/Collections/Arr.php(1231): array_filter(Array, Object(Closure), 1)
#8 /var/www/vendor/laravel/framework/src/Illuminate/Collections/Collection.php(427): Illuminate\Support\Arr::where(Array, Object(Closure))
#9 /var/www/vendor/dedoc/scramble/src/Generator.php(220): Illuminate\Support\Collection->filter(Object(Closure))
#10 /var/www/vendor/dedoc/scramble/src/Generator.php(57): Dedoc\Scramble\Generator->getRoutes(Object(Dedoc\Scramble\GeneratorConfig))
#11 /var/www/vendor/dedoc/scramble/src/CacheableGenerator.php(28): Dedoc\Scramble\Generator->__invoke(Object(Dedoc\Scramble\GeneratorConfig))
#12 laravel-serializable-closure://function (\Dedoc\Scramble\CacheableGenerator $generator) use ($api) {
                    $config = \Dedoc\Scramble\Scramble::getGeneratorConfig($api);

                    return view($config->renderer()->view, [
                        'spec' => $generator($config),
                        'config' => $config,
                    ]);
                }(6): Dedoc\Scramble\CacheableGenerator->__invoke(Object(Dedoc\Scramble\GeneratorConfig))
#13 /var/www/vendor/laravel/framework/src/Illuminate/Routing/CallableDispatcher.php(39): Dedoc\Scramble\ScrambleServiceProvider::{closure:laravel-serializable-closure://function (\Dedoc\Scramble\CacheableGenerator $generator) use ($api) {
                    $config = \Dedoc\Scramble\Scramble::getGeneratorConfig($api);

                    return view($config->renderer()->view, [
                        'spec' => $generator($config),
                        'config' => $config,
                    ]);
                }:2}(Object(Dedoc\Scramble\CacheableGenerator))
#14 /var/www/vendor/laravel/framework/src/Illuminate/Routing/Route.php(253): Illuminate\Routing\CallableDispatcher->dispatch(Object(Illuminate\Routing\Route), Object(Closure))
#15 /var/www/vendor/laravel/framework/src/Illuminate/Routing/Route.php(218): Illuminate\Routing\Route->runCallable()
#16 /var/www/vendor/laravel/framework/src/Illuminate/Routing/Router.php(822): Illuminate\Routing\Route->run()
#17 /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Illuminate\Routing\Router->{closure:Illuminate\Routing\Router::runRouteWithinStack():821}(Object(Illuminate\Http\Request))
#18 /var/www/vendor/dedoc/scramble/src/Http/Middleware/RestrictedDocsAccess.php(12): Illuminate\Pipeline\Pipeline->{closure:Illuminate\Pipeline\Pipeline::prepareDestination():178}(Object(Illuminate\Http\Request))
#19 /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(219): Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess->handle(Object(Illuminate\Http\Request), Object(Closure))
```

The official PHP documentation recommends using [ReflectionMethod::createFromMethodName()](https://www.php.net/manual/en/reflectionmethod.createfrommethodname.php) instead.

`ReflectionMethod::createFromMethodName()` creates a reflection instance from the given method name. However, it is only available starting with PHP 8.3.

To fix this, I have to check `PHP_VERSION_ID` and choose the appropriate implementation depending on the PHP version.

Also, I suggest using a class controller for Scramble's own routes. If you're okay with this suggestion, I'll prepare a separate PR for that as well.