### PR TITLE
Add custom casts support for model attributes

### DIFF
--- a/src/Support/InferExtensions/ModelExtension.php
+++ b/src/Support/InferExtensions/ModelExtension.php
@@ -12,6 +12,7 @@ use Dedoc\Scramble\Infer\Extensions\MethodReturnTypeExtension;
 use Dedoc\Scramble\Infer\Extensions\PropertyTypeExtension;
 use Dedoc\Scramble\Infer\Extensions\StaticMethodReturnTypeExtension;
 use Dedoc\Scramble\Infer\Scope\GlobalScope;
+use Dedoc\Scramble\Infer\Scope\Scope;
 use Dedoc\Scramble\Infer\Services\ReferenceTypeResolver;
 use Dedoc\Scramble\Support\InferExtensions\Concerns\ExtractsLiteralArrayKeys;
 use Dedoc\Scramble\Support\ResponseExtractor\ModelInfo;
@@ -74,7 +75,7 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
         $info = $this->getModelInfo($event->getInstance());
 
         if ($attribute = $info->get('attributes')->get($event->getName())) {
-            $baseType = $this->getAttributeTypeFromEloquentCasts($attribute['cast'] ?? '')
+            $baseType = $this->getAttributeTypeFromEloquentCasts($attribute['cast'] ?? '', $event->scope)
                 ?? $this->getAttributeTypeFromDbColumnType($attribute['type'], $attribute['driver'])
                 ?? new UnknownType("Virtual attribute ({$attribute['name']}) type inference not supported.");
 
@@ -122,20 +123,25 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
         return new StringType;
     }
 
-    /**
-     * @todo Add support for custom castables.
-     */
-    private function getAttributeTypeFromEloquentCasts(string $cast): ?AbstractType
+    private function getAttributeTypeFromEloquentCasts(string $cast, Scope $scope): ?Type
     {
         if ($cast && enum_exists($cast)) {
             return new ObjectType($cast);
         }
 
         $castAsType = Str::before($cast, ':');
+        if ($castAsType === '') {
+            return null;
+        }
+
         $castAsParameters = str($cast)->after("{$castAsType}:")->explode(',');
 
-        if (Str::startsWith($castAsType, 'encrypted:')) {
+        if (Str::startsWith($cast, 'encrypted:')) {
             $castAsType = $castAsParameters->first(); // array, collection, json, object
+
+            if (! is_string($castAsType)) {
+                return null;
+            }
         }
 
         return match ($castAsType) {
@@ -152,8 +158,18 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
             ]),
             'date', 'datetime', 'custom_datetime' => $this->addDateFormatForCast(new ObjectType(Carbon::class), $castAsParameters),
             'immutable_date', 'immutable_datetime', 'immutable_custom_datetime' => $this->addDateFormatForCast(new ObjectType(CarbonImmutable::class), $castAsParameters),
-            default => null,
+            default => $this->getAttributeTypeFromCustomCast($castAsType, $scope),
         };
+    }
+
+    private function getAttributeTypeFromCustomCast(string $cast, Scope $scope): ?Type
+    {
+        $returnType = $scope->index
+            ->getClass($cast)
+            ?->getMethodDefinition('get', $scope)
+            ?->getReturnType();
+
+        return $returnType?->clone();
     }
 
     /**

--- a/src/Support/InferExtensions/ModelExtension.php
+++ b/src/Support/InferExtensions/ModelExtension.php
@@ -166,7 +166,7 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
     {
         $returnType = $scope->index
             ->getClass($cast)
-            ?->getMethodDefinition('get', $scope)
+            ?->getMethod('get')
             ?->getReturnType();
 
         return $returnType?->clone();

--- a/tests/InferExtensions/ModelExtensionTest.php
+++ b/tests/InferExtensions/ModelExtensionTest.php
@@ -10,6 +10,7 @@ use Dedoc\Scramble\Support\Type\Reference\MethodCallReferenceType;
 use Dedoc\Scramble\Support\Type\Reference\PropertyFetchReferenceType;
 use Dedoc\Scramble\Tests\Files\SamplePostModel;
 use Dedoc\Scramble\Tests\Files\SampleUserModel;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Attributes\UseResource;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Model;
@@ -147,6 +148,72 @@ if (method_exists(AsEnumCollection::class, 'of')) {
             ->toBe('Illuminate\Support\Collection<int, Role>');
     });
 }
+
+it('uses custom cast get definition return type for model attributes', function () {
+    $this->infer->analyzeClass(ModelExtensionTest_CustomCastModel::class);
+
+    $object = new ObjectType(ModelExtensionTest_CustomCastModel::class);
+
+    expect($object->getPropertyType('title')->toString())
+        ->toBe(ModelExtensionTest_CustomCastValue::class);
+});
+
+it('uses custom cast get PHPDoc return type for model attributes', function () {
+    $this->infer->configure()->buildDefinitionsUsingReflectionFor([
+        ModelExtensionTest_CustomPhpDocCast::class,
+    ]);
+    $this->infer->analyzeClass(ModelExtensionTest_CustomPhpDocCastModel::class);
+
+    $object = new ObjectType(ModelExtensionTest_CustomPhpDocCastModel::class);
+
+    expect($object->getPropertyType('body')->toString())
+        ->toBe('array<string, '.ModelExtensionTest_CustomCastValue::class.'>');
+});
+
+class ModelExtensionTest_CustomCastModel extends SamplePostModel
+{
+    protected $casts = [
+        'title' => ModelExtensionTest_CustomCast::class.':with-arguments',
+    ];
+}
+
+class ModelExtensionTest_CustomPhpDocCastModel extends SamplePostModel
+{
+    protected $casts = [
+        'body' => ModelExtensionTest_CustomPhpDocCast::class,
+    ];
+}
+
+/** @implements CastsAttributes<ModelExtensionTest_CustomCastValue, mixed> */
+class ModelExtensionTest_CustomCast implements CastsAttributes
+{
+    public function get(Model $model, string $key, mixed $value, array $attributes): ModelExtensionTest_CustomCastValue
+    {
+        return new ModelExtensionTest_CustomCastValue;
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        return $value;
+    }
+}
+
+/** @implements CastsAttributes<array<string, ModelExtensionTest_CustomCastValue>, mixed> */
+class ModelExtensionTest_CustomPhpDocCast implements CastsAttributes
+{
+    /** @return array<string, ModelExtensionTest_CustomCastValue> */
+    public function get(Model $model, string $key, mixed $value, array $attributes): array
+    {
+        return [];
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        return $value;
+    }
+}
+
+class ModelExtensionTest_CustomCastValue {}
 
 /*
  * When resolving property types from models that are in vendor directory,


### PR DESCRIPTION
Adds support for custom Eloquent casts by using the caster’s `get` method return type, including PHPDoc types and parameterized casts. Also fixes parsing for encrypted cast variants and adds regression coverage.