### PR TITLE
Preserve nullable JSON resources in documentation

### DIFF
--- a/src/Support/TypeToSchemaExtensions/FlattensMergeValues.php
+++ b/src/Support/TypeToSchemaExtensions/FlattensMergeValues.php
@@ -6,6 +6,7 @@ use Dedoc\Scramble\Support\Type\ArrayItemType_;
 use Dedoc\Scramble\Support\Type\Generic;
 use Dedoc\Scramble\Support\Type\KeyedArrayType;
 use Dedoc\Scramble\Support\Type\Literal\LiteralBooleanType;
+use Dedoc\Scramble\Support\Type\NullType;
 use Dedoc\Scramble\Support\Type\Type;
 use Dedoc\Scramble\Support\Type\TypeWalker;
 use Dedoc\Scramble\Support\Type\Union;
@@ -38,6 +39,10 @@ trait FlattensMergeValues
 
                     if ($resource->isInstanceOf(MissingValue::class)) {
                         return [];
+                    }
+
+                    if ($this->isNullableResourceValue($resource)) {
+                        $item->value = Union::wrap([$item->value, new NullType]);
                     }
 
                     if (
@@ -147,5 +152,15 @@ trait FlattensMergeValues
         }
 
         return new UnknownType;
+    }
+
+    private function isNullableResourceValue(Type $type): bool
+    {
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        return $type instanceof Union
+            && (bool) array_filter($type->types, fn (Type $t) => $t instanceof NullType);
     }
 }

--- a/tests/TypeToSchemaTransformerTest.php
+++ b/tests/TypeToSchemaTransformerTest.php
@@ -270,6 +270,24 @@ it('gets json resource type with when loaded', function () {
     assertMatchesSnapshot($extension->toSchema($type)->toArray());
 });
 
+it('keeps resources made from nullable loaded relations nullable', function () {
+    $transformer = new TypeTransformer($infer = app(Infer::class), $this->context, [
+        JsonResourceTypeToSchema::class,
+    ]);
+    $extension = new JsonResourceTypeToSchema($infer, $transformer, $this->context->openApi->components, $this->context);
+
+    $schema = $extension
+        ->toSchema(new ObjectType(ComplexTypeHandlersWithNullableWhenLoaded_SampleType::class))
+        ->toArray();
+
+    expect($schema['properties']['submitted_by'])->toBe([
+        'anyOf' => [
+            ['$ref' => '#/components/schemas/ComplexTypeHandlersWithWhen_SampleType'],
+            ['type' => 'null'],
+        ],
+    ])->and($schema['required'] ?? [])->not->toContain('submitted_by');
+});
+
 it('gets json resource type with when counted', function () {
     $transformer = new TypeTransformer($infer = app(Infer::class), $this->context, [
         JsonResourceTypeToSchema::class,
@@ -616,6 +634,34 @@ class ComplexTypeHandlersWithWhenLoaded_SampleType extends JsonResource
             'bar_nullable' => $this->whenLoaded('bar', fn () => 's', null),
         ];
     }
+}
+
+/**
+ * @property ComplexTypeHandlersWithNullableRelationModel $resource
+ */
+class ComplexTypeHandlersWithNullableWhenLoaded_SampleType extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'submitted_by' => ComplexTypeHandlersWithWhen_SampleType::make($this->whenLoaded('submittedBy')),
+        ];
+    }
+}
+
+class ComplexTypeHandlersWithNullableRelationModel extends \Illuminate\Database\Eloquent\Model
+{
+    protected $table = 'relation_nullability_models';
+
+    public function submittedBy()
+    {
+        return $this->belongsTo(ComplexTypeHandlersWithSubmitterModel::class, 'nullable_owner_id');
+    }
+}
+
+class ComplexTypeHandlersWithSubmitterModel extends \Illuminate\Database\Eloquent\Model
+{
+    protected $table = 'relation_nullability_owners';
 }
 
 class ComplexTypeHandlersWithWhenCounted_SampleType extends JsonResource


### PR DESCRIPTION
Document resources created from nullable loaded relations as nullable, while keeping conditionally loaded relations optional. Adds regression coverage for `Resource::make($this->whenLoaded(...))`.