### PR TITLE
Fix optional fields in JSON resources marked as required in some cases 

### DIFF
--- a/src/Support/Type/TypeWidener.php
+++ b/src/Support/Type/TypeWidener.php
@@ -6,6 +6,7 @@ use Dedoc\Scramble\Support\Type\Literal\LiteralBooleanType;
 use Dedoc\Scramble\Support\Type\Literal\LiteralFloatType;
 use Dedoc\Scramble\Support\Type\Literal\LiteralIntegerType;
 use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
+use Illuminate\Http\Resources\MissingValue;
 use Illuminate\Support\Enumerable;
 
 class TypeWidener
@@ -44,6 +45,12 @@ class TypeWidener
 
     private function widenPair(Type $a, Type $b): ?Type
     {
+        // MissingValue carries property-presence information and must survive widening.
+        // mixed|MissingValue -> mixed|MissingValue
+        if ($a instanceof MixedType && $b->isInstanceOf(MissingValue::class)) {
+            return null;
+        }
+
         // mixed|* -> mixed
         if ($a instanceof MixedType) {
             return new MixedType;

--- a/tests/Support/Type/TypeWidenerTest.php
+++ b/tests/Support/Type/TypeWidenerTest.php
@@ -2,9 +2,14 @@
 
 namespace Dedoc\Scramble\Tests\Support\Type;
 
+use Dedoc\Scramble\Support\Type\MixedType;
+use Dedoc\Scramble\Support\Type\ObjectType;
+use Dedoc\Scramble\Support\Type\StringType;
+use Dedoc\Scramble\Support\Type\Union;
 use Dedoc\Scramble\Tests\TestUtils;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Resources\MissingValue;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
@@ -21,6 +26,16 @@ test('types widening', function (string $type, string $expectedType) {
     ['42|69', 'int(42)|int(69)'],
     ['string|"wow"', 'string'],
 ]);
+
+test('preserves missing value when widening mixed types', function () {
+    $type = new Union([
+        new MixedType,
+        new ObjectType(MissingValue::class),
+    ]);
+
+    expect($type->widen()->toString())->toBe('mixed|'.MissingValue::class)
+        ->and((new Union([new MixedType, new StringType]))->widen()->toString())->toBe('mixed');
+});
 
 test('widens allowed key value generic collections', function (string $collectionClass) {
     $type = TestUtils::parseType("$collectionClass<int, string>|$collectionClass<string, int>");

--- a/tests/TypeToSchemaTransformerTest.php
+++ b/tests/TypeToSchemaTransformerTest.php
@@ -258,6 +258,21 @@ it('gets json resource type with when', function () {
     assertMatchesSnapshot($extension->toSchema($type)->toArray());
 });
 
+it('keeps a when value optional when its array item has a var annotation', function () {
+    $transformer = new TypeTransformer($infer = app(Infer::class), $this->context, [JsonResourceTypeToSchema::class]);
+    $extension = new JsonResourceTypeToSchema($infer, $transformer, $this->context->openApi->components, $this->context);
+
+    $schema = $extension
+        ->toSchema(new ObjectType(ComplexTypeHandlersWithAnnotatedWhen_SampleType::class))
+        ->toArray();
+
+    expect($schema['properties'])->toBe([
+        'required_prop' => ['type' => 'integer'],
+        'conditional_prop' => ['type' => 'boolean'],
+    ])->and($schema['required'] ?? [])
+        ->toBe(['required_prop']);
+});
+
 it('gets json resource type with when loaded', function () {
     $transformer = new TypeTransformer($infer = app(Infer::class), $this->context, [
         JsonResourceTypeToSchema::class,
@@ -617,6 +632,34 @@ class ComplexTypeHandlersWithWhen_SampleType extends JsonResource
             'bar' => $this->when(true, fn () => 'b', null),
         ];
     }
+}
+
+/**
+ * @property ComplexTypeHandlersWithAnnotatedWhen_Dto $resource
+ */
+class ComplexTypeHandlersWithAnnotatedWhen_SampleType extends JsonResource
+{
+    public function toArray($request)
+    {
+        /** @var array{prop_1: int, prop_2?: bool} $props */
+        $props = $this->resource->props;
+
+        return [
+            /** @var int */
+            'required_prop' => $props['prop_1'],
+            /** @var bool */
+            'conditional_prop' => $this->when(
+                array_key_exists('prop_2', $props),
+                fn () => $props['prop_2'],
+            ),
+        ];
+    }
+}
+
+class ComplexTypeHandlersWithAnnotatedWhen_Dto
+{
+    /** @var array<string, mixed> */
+    public array $props;
 }
 
 class ComplexTypeHandlersWithWhenLoaded_SampleType extends JsonResource


### PR DESCRIPTION
fixes #1230 

Fix `JsonResource::when*()` fields being marked as required when the callback value is inferred as `mixed`.

`mixed|MissingValue` was widened to `mixed`, losing the signal that Laravel omits the key. Preserve that signal so conditional fields remain optional while PHPDoc annotations can still define their OpenAPI value type.