### PR TITLE
Collapse duplicate self types in unions

### DIFF
--- a/src/Support/Type/SelfType.php
+++ b/src/Support/Type/SelfType.php
@@ -6,7 +6,7 @@ class SelfType extends ObjectType
 {
     public function isSame(Type $type)
     {
-        return false;
+        return parent::isSame($type);
     }
 
     public function toString(): string

--- a/tests/Infer/ReferenceResolutionTest.php
+++ b/tests/Infer/ReferenceResolutionTest.php
@@ -282,6 +282,18 @@ it('collapses the same types in union', function () {
 
     expect($type->toString())->toBe('int(1)');
 });
+
+it('collapses the same self types in union', function () {
+    $type = Type\Union::wrap([
+        new Type\SelfType(SameSelfUnionTypes_Foo::class),
+        new Type\SelfType(SameSelfUnionTypes_Foo::class),
+    ]);
+
+    expect($type)->toBeInstanceOf(Type\SelfType::class);
+});
+
+class SameSelfUnionTypes_Foo {}
+
 class SameUnionTypes_Foo
 {
     public function foo()

--- a/tests/Support/Type/TypeWidenerTest.php
+++ b/tests/Support/Type/TypeWidenerTest.php
@@ -5,8 +5,12 @@ namespace Dedoc\Scramble\Tests\Support\Type;
 use Dedoc\Scramble\Support\Type\MixedType;
 use Dedoc\Scramble\Support\Type\ObjectType;
 use Dedoc\Scramble\Support\Type\StringType;
+use Dedoc\Scramble\Support\Type\Type;
+use Dedoc\Scramble\Support\Type\TypeWidener;
 use Dedoc\Scramble\Support\Type\Union;
+use Dedoc\Scramble\Tests\Files\SampleUserModel;
 use Dedoc\Scramble\Tests\TestUtils;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Resources\MissingValue;
@@ -14,6 +18,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Traits\Conditionable;
 
 test('types widening', function (string $type, string $expectedType) {
     $type = TestUtils::parseType($type);
@@ -55,3 +60,40 @@ test('does not widen anonymous resource collection templates as key value pairs'
     expect($type->widen()->toString())->toBe(AnonymousResourceCollection::class.'<unknown, array<mixed>, App\Http\Brands\Events\Resources\EventResource>'
         .'|'.AnonymousResourceCollection::class.'<'.LengthAwarePaginator::class.', array<mixed>, App\Http\Brands\Events\Resources\EventResource>');
 });
+
+test('keeps equivalent self types collapsed through conditional builder chains', function () {
+    app()->instance(TypeWidener::class, $widener = new RecordingTypeWidener);
+
+    $type = getStatementType(
+        '(new '.ConditionalBuilderChain::class.')->applyFilters('.SampleUserModel::class.'::query())',
+    );
+
+    expect($type->toString())->toBe(Builder::class.'|'.ConditionalBuilderChain::class)
+        ->and($widener->largestUnionSize)->toBe(2);
+});
+
+class RecordingTypeWidener extends TypeWidener
+{
+    public int $largestUnionSize = 0;
+
+    public function widen(array $types): Type
+    {
+        $this->largestUnionSize = max($this->largestUnionSize, count($types));
+
+        return parent::widen($types);
+    }
+}
+
+class ConditionalBuilderChain
+{
+    use Conditionable;
+
+    public function applyFilters(Builder $builder)
+    {
+        return $builder
+            ->when(true, fn (): static => $this)
+            ->when(true, fn (): static => $this)
+            ->when(true, fn (): static => $this)
+            ->when(true, fn (): static => $this);
+    }
+}


### PR DESCRIPTION
Fixes exponential union growth in long conditional builder chains by comparing `SelfType` instances structurally. 

fixes #1233.