### PR TITLE
Add uniqueItems support for the distinct validation rule

### DIFF
--- a/src/Configuration/RuleTransformers.php
+++ b/src/Configuration/RuleTransformers.php
@@ -6,6 +6,7 @@ use Dedoc\Scramble\Contracts\AllRulesSchemasTransformer;
 use Dedoc\Scramble\Contracts\RuleTransformer;
 use Dedoc\Scramble\RuleTransformers\AcceptedRule;
 use Dedoc\Scramble\RuleTransformers\ConfirmedRule;
+use Dedoc\Scramble\RuleTransformers\DistinctRule;
 use Dedoc\Scramble\RuleTransformers\EnumRule;
 use Dedoc\Scramble\RuleTransformers\ExistsRule;
 use Dedoc\Scramble\RuleTransformers\FileRule;
@@ -88,6 +89,7 @@ class RuleTransformers
             InRule::class,
             FileRule::class,
             ConfirmedRule::class,
+            DistinctRule::class,
             ExistsRule::class,
             RegexRule::class,
         ];

--- a/src/RuleTransformers/DistinctRule.php
+++ b/src/RuleTransformers/DistinctRule.php
@@ -9,11 +9,8 @@ use Dedoc\Scramble\Support\OperationExtensions\RulesExtractor\DeepParametersMerg
 use Dedoc\Scramble\Support\RuleTransforming\NormalizedRule;
 use Dedoc\Scramble\Support\RuleTransforming\RuleTransformerContext;
 use Dedoc\Scramble\Support\RuleTransforming\SchemaBag;
+use Illuminate\Support\Str;
 
-/**
- * The `distinct` rule is applied to the items of an array (`foo.*`, `foo.*.id`), while `uniqueItems` documents
- * the array itself (`foo`), hence the containing array's schema is the one being transformed here.
- */
 class DistinctRule implements AllRulesSchemasTransformer
 {
     public function shouldHandle(NormalizedRule $rule): bool
@@ -27,39 +24,27 @@ class DistinctRule implements AllRulesSchemasTransformer
             return;
         }
 
-        $schema = $schemaBag->get($arrayField);
+        $schema = $schemaBag->get($arrayField) ?? new ArrayType;
 
-        $arraySchema = match (true) {
-            $schema === null => new ArrayType,
-            $schema instanceof ArrayType => $schema,
-            $schema instanceof UnknownType => (new ArrayType)->addProperties($schema),
-            default => null,
-        };
+        if ($schema instanceof UnknownType) {
+            $schema = (new ArrayType)->addProperties($schema);
+        }
 
-        if (! $arraySchema instanceof ArrayType) {
+        if (! $schema instanceof ArrayType) {
             return;
         }
 
-        $schemaBag->set($arrayField, $arraySchema->setUniqueItems());
+        $schemaBag->set($arrayField, $schema->setUniqueItems(true));
     }
 
-    /**
-     * Gets the name of the array containing the items the rule is applied to: `foo.*.id` results in `foo`.
-     */
     private function getContainingArrayField(string $field): ?string
     {
-        $parts = preg_split(DeepParametersMerger::DOT_REGEX, $field) ?: [$field];
+        $parts = Str::of($field)->split(DeepParametersMerger::DOT_REGEX);
 
-        $wildcardKeys = array_keys($parts, '*', true);
-
-        $lastWildcardKey = end($wildcardKeys);
-
-        // The rule is either not applied to array items, or applied to the items of the root
-        // array, which is not documented as a separate schema.
-        if (! is_int($lastWildcardKey) || $lastWildcardKey === 0) {
+        if (! $lastWildcardKey = $parts->reverse()->search('*')) {
             return null;
         }
 
-        return implode('.', array_slice($parts, 0, $lastWildcardKey));
+        return $parts->take($lastWildcardKey)->join('.');
     }
 }

--- a/src/RuleTransformers/DistinctRule.php
+++ b/src/RuleTransformers/DistinctRule.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Dedoc\Scramble\RuleTransformers;
+
+use Dedoc\Scramble\Contracts\AllRulesSchemasTransformer;
+use Dedoc\Scramble\Support\Generator\Types\ArrayType;
+use Dedoc\Scramble\Support\Generator\Types\UnknownType;
+use Dedoc\Scramble\Support\OperationExtensions\RulesExtractor\DeepParametersMerger;
+use Dedoc\Scramble\Support\RuleTransforming\NormalizedRule;
+use Dedoc\Scramble\Support\RuleTransforming\RuleTransformerContext;
+use Dedoc\Scramble\Support\RuleTransforming\SchemaBag;
+
+/**
+ * The `distinct` rule is applied to the items of an array (`foo.*`, `foo.*.id`), while `uniqueItems` documents
+ * the array itself (`foo`), hence the containing array's schema is the one being transformed here.
+ */
+class DistinctRule implements AllRulesSchemasTransformer
+{
+    public function shouldHandle(NormalizedRule $rule): bool
+    {
+        return $rule->is('distinct');
+    }
+
+    public function transformAll(SchemaBag $schemaBag, NormalizedRule $rule, RuleTransformerContext $context): void
+    {
+        if (! $arrayField = $this->getContainingArrayField($context->field)) {
+            return;
+        }
+
+        $schema = $schemaBag->get($arrayField);
+
+        $arraySchema = match (true) {
+            $schema === null => new ArrayType,
+            $schema instanceof ArrayType => $schema,
+            $schema instanceof UnknownType => (new ArrayType)->addProperties($schema),
+            default => null,
+        };
+
+        if (! $arraySchema instanceof ArrayType) {
+            return;
+        }
+
+        $schemaBag->set($arrayField, $arraySchema->setUniqueItems());
+    }
+
+    /**
+     * Gets the name of the array containing the items the rule is applied to: `foo.*.id` results in `foo`.
+     */
+    private function getContainingArrayField(string $field): ?string
+    {
+        $parts = preg_split(DeepParametersMerger::DOT_REGEX, $field) ?: [$field];
+
+        $wildcardKeys = array_keys($parts, '*', true);
+
+        $lastWildcardKey = end($wildcardKeys);
+
+        // The rule is either not applied to array items, or applied to the items of the root
+        // array, which is not documented as a separate schema.
+        if (! is_int($lastWildcardKey) || $lastWildcardKey === 0) {
+            return null;
+        }
+
+        return implode('.', array_slice($parts, 0, $lastWildcardKey));
+    }
+}

--- a/src/Support/Generator/Types/ArrayType.php
+++ b/src/Support/Generator/Types/ArrayType.php
@@ -75,7 +75,7 @@ class ArrayType extends Type
         return $this;
     }
 
-    public function setUniqueItems(bool $uniqueItems = true): static
+    public function setUniqueItems(bool $uniqueItems): static
     {
         $this->uniqueItems = $uniqueItems;
 

--- a/src/Support/Generator/Types/ArrayType.php
+++ b/src/Support/Generator/Types/ArrayType.php
@@ -16,6 +16,8 @@ class ArrayType extends Type
 
     public $additionalItems = null;
 
+    public ?bool $uniqueItems = null;
+
     public function __construct()
     {
         parent::__construct('array');
@@ -73,6 +75,13 @@ class ArrayType extends Type
         return $this;
     }
 
+    public function setUniqueItems(bool $uniqueItems = true): static
+    {
+        $this->uniqueItems = $uniqueItems;
+
+        return $this;
+    }
+
     public function toArray()
     {
         $shouldOmitItems = $this->items->getAttribute('missing')
@@ -90,6 +99,7 @@ class ArrayType extends Type
                 'minItems' => $this->minItems,
                 'maxItems' => $this->maxItems,
                 'additionalItems' => $this->additionalItems,
+                'uniqueItems' => $this->uniqueItems,
             ], fn ($v) => $v !== null)
         );
     }

--- a/tests/ValidationRulesDocumentingTest.php
+++ b/tests/ValidationRulesDocumentingTest.php
@@ -132,6 +132,124 @@ it('does not override explicit minItems when required rule is used on array', fu
         ]);
 });
 
+it('converts distinct rule into "uniqueItems" on the containing array', function () {
+    $rules = [
+        'items' => ['required', 'array'],
+        'items.*' => ['integer', 'distinct'],
+    ];
+
+    $params = validationRulesToDocumentationWithDeep(($this->buildRulesToParameters)($rules));
+
+    expect($params = collect($params)->map->toArray()->all())
+        ->toHaveCount(1)
+        ->and($params[0])
+        ->toMatchArray([
+            'name' => 'items',
+            'in' => 'query',
+            'schema' => [
+                'type' => 'array',
+                'items' => ['type' => 'integer'],
+                'minItems' => 1,
+                'uniqueItems' => true,
+            ],
+            'required' => true,
+        ]);
+});
+
+it('converts distinct rule into "uniqueItems" when the containing array has no rules on its own', function () {
+    $rules = [
+        'items.*' => ['integer', 'distinct'],
+    ];
+
+    $params = validationRulesToDocumentationWithDeep(($this->buildRulesToParameters)($rules));
+
+    expect($params = collect($params)->map->toArray()->all())
+        ->toHaveCount(1)
+        ->and($params[0])
+        ->toMatchArray([
+            'name' => 'items',
+            'schema' => [
+                'type' => 'array',
+                'items' => ['type' => 'integer'],
+                'uniqueItems' => true,
+            ],
+        ]);
+});
+
+it('converts distinct rule on array items property into "uniqueItems" on the containing array', function () {
+    $rules = [
+        'items' => ['array'],
+        'items.*.id' => ['integer', 'distinct:strict'],
+    ];
+
+    $params = validationRulesToDocumentationWithDeep(($this->buildRulesToParameters)($rules));
+
+    expect($params = collect($params)->map->toArray()->all())
+        ->toHaveCount(1)
+        ->and($params[0])
+        ->toMatchArray([
+            'name' => 'items',
+            'schema' => [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => ['type' => 'integer'],
+                    ],
+                ],
+                'uniqueItems' => true,
+            ],
+        ]);
+});
+
+it('converts distinct rule into "uniqueItems" on the closest containing array', function () {
+    $rules = [
+        'groups' => ['array'],
+        'groups.*.items' => ['array'],
+        'groups.*.items.*' => ['string', 'distinct:ignore_case'],
+    ];
+
+    $params = validationRulesToDocumentationWithDeep(($this->buildRulesToParameters)($rules));
+
+    expect($params = collect($params)->map->toArray()->all())
+        ->toHaveCount(1)
+        ->and($params[0])
+        ->toMatchArray([
+            'name' => 'groups',
+            'schema' => [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'items' => [
+                            'type' => 'array',
+                            'items' => ['type' => 'string'],
+                            'uniqueItems' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ])
+        ->and($params[0]['schema'])
+        ->not->toHaveKey('uniqueItems');
+});
+
+it('ignores distinct rule when it is not applied to array items', function () {
+    $rules = [
+        'name' => ['string', 'distinct'],
+    ];
+
+    $params = ($this->buildRulesToParameters)($rules)->handle();
+
+    expect($params = collect($params)->map->toArray()->all())
+        ->toHaveCount(1)
+        ->and($params[0])
+        ->toMatchArray([
+            'name' => 'name',
+            'schema' => ['type' => 'string'],
+        ]);
+});
+
 it('supports present rule in array', function () {
     $rules = [
         'user.password' => ['present'],


### PR DESCRIPTION
This PR adds support for [uniqueItems](https://swagger.io/docs/specification/v3_0/data-models/data-types/#uniqueitems) when validation uses the distinct rule.

Full disclosure, I am not familiar with this codebase and the code was written by an LLM. I have tested it in my projects.