### PR TITLE
Tip Scramble PRO when Laravel Data or Query Builder is detected

### DIFF
--- a/src/Console/Commands/AnalyzeDocumentation.php
+++ b/src/Console/Commands/AnalyzeDocumentation.php
@@ -7,6 +7,7 @@ use Dedoc\Scramble\Exceptions\ConsoleRenderable;
 use Dedoc\Scramble\Exceptions\RouteAware;
 use Dedoc\Scramble\Generator;
 use Dedoc\Scramble\Scramble;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeReporter;
 use Illuminate\Console\Command;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Collection;
@@ -35,10 +36,14 @@ class AnalyzeDocumentation extends Command
         if (count($generator->exceptions)) {
             $this->error('[ERROR] Found '.count($generator->exceptions).' errors.');
 
+            (new ProNudgeReporter($generator->proNudge))->report($this);
+
             return static::FAILURE;
         }
 
         $this->info('Everything is fine! Documentation is generated without any errors 🍻');
+
+        (new ProNudgeReporter($generator->proNudge))->report($this);
 
         return static::SUCCESS;
     }

--- a/src/Console/Commands/ExportDocumentation.php
+++ b/src/Console/Commands/ExportDocumentation.php
@@ -4,6 +4,7 @@ namespace Dedoc\Scramble\Console\Commands;
 
 use Dedoc\Scramble\Generator;
 use Dedoc\Scramble\Scramble;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeReporter;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 
@@ -31,5 +32,7 @@ class ExportDocumentation extends Command
         File::put($filename, $specification);
 
         $this->info("OpenAPI document exported to {$filename}.");
+
+        (new ProNudgeReporter($generator->proNudge))->report($this);
     }
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -22,6 +22,7 @@ use Dedoc\Scramble\Support\Generator\TypeTransformer;
 use Dedoc\Scramble\Support\Generator\UniqueNameOptions;
 use Dedoc\Scramble\Support\Generator\UniqueNamesOptionsCollection;
 use Dedoc\Scramble\Support\OperationBuilder;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeCollector;
 use Dedoc\Scramble\Support\RouteInfo;
 use Dedoc\Scramble\Support\ServerFactory;
 use Illuminate\Routing\Route;
@@ -39,11 +40,15 @@ class Generator
 {
     public array $exceptions = [];
 
+    public ProNudgeCollector $proNudge;
+
     protected bool $throwExceptions = true;
 
     public function __construct(
         private OperationBuilder $operationBuilder,
-    ) {}
+    ) {
+        $this->proNudge = new ProNudgeCollector;
+    }
 
     public function setThrowExceptions(bool $throwExceptions): static
     {
@@ -54,6 +59,8 @@ class Generator
 
     public function __invoke(?GeneratorConfig $config = null)
     {
+        $this->proNudge = new ProNudgeCollector;
+
         $config ??= Scramble::getGeneratorConfig(Scramble::DEFAULT_API);
 
         $routes = $this->getRoutes($config);
@@ -307,7 +314,7 @@ class Generator
         foreach ($methods as $method) {
             $routeInfo = new RouteInfo($route, $method);
 
-            $operation = $this->operationBuilder->build($routeInfo, $openApi, $config, $typeTransformer);
+            $operation = $this->operationBuilder->build($routeInfo, $openApi, $config, $typeTransformer, $this->proNudge);
 
             $this->ensureSchemaTypes($route, $operation);
 

--- a/src/ScrambleServiceProvider.php
+++ b/src/ScrambleServiceProvider.php
@@ -4,6 +4,7 @@ namespace Dedoc\Scramble;
 
 use Dedoc\Scramble\Configuration\GeneratorConfigCollection;
 use Dedoc\Scramble\Configuration\OperationTransformers;
+use Dedoc\Scramble\Configuration\ParametersExtractors;
 use Dedoc\Scramble\Console\Commands\AnalyzeDocumentation;
 use Dedoc\Scramble\Console\Commands\CacheDocumentation;
 use Dedoc\Scramble\Console\Commands\ClearDocumentationCache;
@@ -62,6 +63,9 @@ use Dedoc\Scramble\Support\InferExtensions\TransformsToResourceCollectionExtensi
 use Dedoc\Scramble\Support\InferExtensions\TranslationReturnTypeExtension;
 use Dedoc\Scramble\Support\InferExtensions\TypeTraceInfer;
 use Dedoc\Scramble\Support\InferExtensions\ValidatorTypeInfer;
+use Dedoc\Scramble\Support\ProNudge\Extensions\LaravelDataRequestBodyNudgeExtractor;
+use Dedoc\Scramble\Support\ProNudge\Extensions\LaravelDataReturnTypeNudgeExtension;
+use Dedoc\Scramble\Support\ProNudge\Extensions\QueryBuilderUsageNudgeExtension;
 use Dedoc\Scramble\Support\Type\FunctionType;
 use Dedoc\Scramble\Support\Type\TemplateType;
 use Dedoc\Scramble\Support\Type\VoidType;
@@ -305,9 +309,27 @@ class ScrambleServiceProvider extends PackageServiceProvider
             Scramble::configure()->expose(false);
         }
 
+        $this->registerProNudge();
+
         $this->app->booted(function () {
             $this->registerRoutes();
         });
+    }
+
+    private function registerProNudge(): void
+    {
+        if (class_exists('Dedoc\ScramblePro\ScrambleProServiceProvider')) {
+            return;
+        }
+
+        Scramble::configure()
+            ->withOperationTransformers([
+                LaravelDataReturnTypeNudgeExtension::class,
+                QueryBuilderUsageNudgeExtension::class,
+            ])
+            ->withParametersExtractors(function (ParametersExtractors $extractors) {
+                $extractors->append(LaravelDataRequestBodyNudgeExtractor::class);
+            });
     }
 
     private function registerRoutes(): void

--- a/src/Support/OperationBuilder.php
+++ b/src/Support/OperationBuilder.php
@@ -8,13 +8,19 @@ use Dedoc\Scramble\OpenApiContext;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\Operation;
 use Dedoc\Scramble\Support\Generator\TypeTransformer;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeCollector;
 use InvalidArgumentException;
 
 /** @internal */
 class OperationBuilder
 {
-    public function build(RouteInfo $routeInfo, OpenApi $openApi, GeneratorConfig $config, TypeTransformer $typeTransformer)
-    {
+    public function build(
+        RouteInfo $routeInfo,
+        OpenApi $openApi,
+        GeneratorConfig $config,
+        TypeTransformer $typeTransformer,
+        ProNudgeCollector $proNudge,
+    ) {
         $operation = new Operation('get');
 
         foreach ($config->operationTransformers->all() as $operationTransformerClass) {
@@ -25,6 +31,7 @@ class OperationBuilder
                     OpenApiContext::class => $typeTransformer->context,
                     GeneratorConfig::class => $config,
                     TypeTransformer::class => $typeTransformer,
+                    ProNudgeCollector::class => $proNudge,
                 ]);
 
             if (is_callable($instance)) {

--- a/src/Support/OperationExtensions/RequestBodyExtension.php
+++ b/src/Support/OperationExtensions/RequestBodyExtension.php
@@ -4,6 +4,7 @@ namespace Dedoc\Scramble\Support\OperationExtensions;
 
 use Dedoc\Scramble\Extensions\OperationExtension;
 use Dedoc\Scramble\GeneratorConfig;
+use Dedoc\Scramble\Infer;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\ContainerUtils;
 use Dedoc\Scramble\Support\Factories\JsonApiQueryParameterFactory;
@@ -20,6 +21,7 @@ use Dedoc\Scramble\Support\OperationExtensions\ParameterExtractor\ParameterExtra
 use Dedoc\Scramble\Support\OperationExtensions\RulesExtractor\DeepParametersMerger;
 use Dedoc\Scramble\Support\OperationExtensions\RulesExtractor\ParametersExtractionResult;
 use Dedoc\Scramble\Support\OperationExtensions\RulesExtractor\QueryParametersConverter;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeCollector;
 use Dedoc\Scramble\Support\RouteInfo;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -29,6 +31,15 @@ use Throwable;
 class RequestBodyExtension extends OperationExtension
 {
     const HTTP_METHODS_WITHOUT_REQUEST_BODY = ['get', 'delete', 'head'];
+
+    public function __construct(
+        Infer $infer,
+        TypeTransformer $openApiTransformer,
+        GeneratorConfig $config,
+        private readonly ProNudgeCollector $proNudge,
+    ) {
+        parent::__construct($infer, $openApiTransformer, $config);
+    }
 
     public function handle(Operation $operation, RouteInfo $routeInfo): void
     {
@@ -261,6 +272,7 @@ class RequestBodyExtension extends OperationExtension
                 GeneratorConfig::class => $this->config,
                 TypeTransformer::class => $this->openApiTransformer,
                 Operation::class => $operation,
+                ProNudgeCollector::class => $this->proNudge,
                 JsonApiQueryParameterFactory::class => new JsonApiQueryParameterFactory(
                     arraySerialization: $this->config->jsonApi->arraySerialization,
                 ),

--- a/src/Support/ProNudge/Extensions/LaravelDataRequestBodyNudgeExtractor.php
+++ b/src/Support/ProNudge/Extensions/LaravelDataRequestBodyNudgeExtractor.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Dedoc\Scramble\Support\ProNudge\Extensions;
+
+use Dedoc\Scramble\Support\OperationExtensions\ParameterExtractor\ParameterExtractor;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeCollector;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeSignal;
+use Dedoc\Scramble\Support\RouteInfo;
+use ReflectionNamedType;
+use ReflectionParameter;
+
+/** @internal */
+class LaravelDataRequestBodyNudgeExtractor implements ParameterExtractor
+{
+    private const LARAVEL_DATA_CLASS = 'Spatie\LaravelData\Data';
+
+    public function __construct(
+        private ProNudgeCollector $collector,
+    ) {}
+
+    public function handle(RouteInfo $routeInfo, array $parameterExtractionResults): array
+    {
+        if (! $reflectionAction = $routeInfo->reflectionAction()) {
+            return $parameterExtractionResults;
+        }
+
+        $hasLaravelDataParameter = collect($reflectionAction->getParameters())
+            ->contains(fn (ReflectionParameter $parameter) => $this->isLaravelDataParameter($parameter));
+
+        if ($hasLaravelDataParameter) {
+            $this->collector->record(ProNudgeSignal::LaravelDataRequest, $routeInfo);
+        }
+
+        return $parameterExtractionResults;
+    }
+
+    private function isLaravelDataParameter(ReflectionParameter $parameter): bool
+    {
+        $type = $parameter->getType();
+
+        if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return false;
+        }
+
+        return class_exists(self::LARAVEL_DATA_CLASS)
+            && is_a($type->getName(), self::LARAVEL_DATA_CLASS, true);
+    }
+}

--- a/src/Support/ProNudge/Extensions/LaravelDataReturnTypeNudgeExtension.php
+++ b/src/Support/ProNudge/Extensions/LaravelDataReturnTypeNudgeExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Dedoc\Scramble\Support\ProNudge\Extensions;
+
+use Dedoc\Scramble\Contracts\OperationTransformer;
+use Dedoc\Scramble\Support\Generator\Operation;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeCollector;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeSignal;
+use Dedoc\Scramble\Support\RouteInfo;
+use Dedoc\Scramble\Support\Type\ObjectType;
+use Dedoc\Scramble\Support\Type\TypeWalker;
+
+/** @internal */
+class LaravelDataReturnTypeNudgeExtension implements OperationTransformer
+{
+    private const LARAVEL_DATA_CLASS = 'Spatie\LaravelData\Data';
+
+    public function __construct(
+        private ProNudgeCollector $collector,
+    ) {}
+
+    public function handle(Operation $operation, RouteInfo $routeInfo): void
+    {
+        $returnType = $routeInfo->getActionType()?->getReturnType();
+
+        if (! $returnType) {
+            return;
+        }
+
+        $dataType = (new TypeWalker)->first(
+            $returnType,
+            fn ($type) => $type instanceof ObjectType
+                && class_exists(self::LARAVEL_DATA_CLASS)
+                && is_a($type->name, self::LARAVEL_DATA_CLASS, true),
+        );
+
+        if (! $dataType) {
+            return;
+        }
+
+        $this->collector->record(ProNudgeSignal::LaravelDataReturn, $routeInfo);
+    }
+}

--- a/src/Support/ProNudge/Extensions/QueryBuilderUsageNudgeExtension.php
+++ b/src/Support/ProNudge/Extensions/QueryBuilderUsageNudgeExtension.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Dedoc\Scramble\Support\ProNudge\Extensions;
+
+use Dedoc\Scramble\Contracts\OperationTransformer;
+use Dedoc\Scramble\Support\Generator\Operation;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeCollector;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeSignal;
+use Dedoc\Scramble\Support\RouteInfo;
+use PhpParser\Node;
+use PhpParser\Node\FunctionLike;
+use PhpParser\NodeFinder;
+
+/**
+ * Detects Spatie Query Builder usage by looking for class references in the
+ * route action AST (StaticCall / ClassConstFetch / New_), without type-checking
+ * every expression.
+ *
+ * @internal
+ */
+class QueryBuilderUsageNudgeExtension implements OperationTransformer
+{
+    private const QUERY_BUILDER_CLASS = 'Spatie\QueryBuilder\QueryBuilder';
+
+    public function __construct(
+        private ProNudgeCollector $collector,
+    ) {}
+
+    public function handle(Operation $operation, RouteInfo $routeInfo): void
+    {
+        if (! $actionNode = $routeInfo->actionNode()) {
+            return;
+        }
+
+        if (! $this->referencesQueryBuilder($actionNode)) {
+            return;
+        }
+
+        $this->collector->record(ProNudgeSignal::QueryBuilder, $routeInfo);
+    }
+
+    private function referencesQueryBuilder(FunctionLike $actionNode): bool
+    {
+        return (new NodeFinder)->findFirst(
+            $actionNode,
+            fn (Node $node) => $this->isQueryBuilderClassReference($node),
+        ) !== null;
+    }
+
+    private function isQueryBuilderClassReference(Node $node): bool
+    {
+        $class = match (true) {
+            $node instanceof Node\Expr\ClassConstFetch,
+            $node instanceof Node\Expr\StaticCall,
+            $node instanceof Node\Expr\New_ => $node->class,
+            default => null,
+        };
+
+        return $class instanceof Node\Name
+            && class_exists(self::QUERY_BUILDER_CLASS)
+            && is_a($class->toString(), self::QUERY_BUILDER_CLASS, true);
+    }
+}

--- a/src/Support/ProNudge/ProNudgeCollector.php
+++ b/src/Support/ProNudge/ProNudgeCollector.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Dedoc\Scramble\Support\ProNudge;
+
+use Dedoc\Scramble\Support\RouteInfo;
+
+/** @internal */
+class ProNudgeCollector
+{
+    /**
+     * @var array<string, array<string, true>>
+     */
+    private array $signals = [];
+
+    public function record(ProNudgeSignal $signal, RouteInfo $routeInfo): void
+    {
+        $this->signals[$signal->value][$this->endpointKey($routeInfo)] = true;
+    }
+
+    public function count(ProNudgeSignal $signal): int
+    {
+        return count($this->signals[$signal->value] ?? []);
+    }
+
+    public function hasAny(): bool
+    {
+        foreach (ProNudgeSignal::cases() as $signal) {
+            if ($this->count($signal) > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<array{signal: ProNudgeSignal, count: int}>
+     */
+    public function summaries(): array
+    {
+        $summaries = [];
+
+        foreach (ProNudgeSignal::cases() as $signal) {
+            $count = $this->count($signal);
+
+            if ($count === 0) {
+                continue;
+            }
+
+            $summaries[] = [
+                'signal' => $signal,
+                'count' => $count,
+            ];
+        }
+
+        return $summaries;
+    }
+
+    private function endpointKey(RouteInfo $routeInfo): string
+    {
+        return mb_strtolower($routeInfo->method).':'.$routeInfo->route->uri();
+    }
+}

--- a/src/Support/ProNudge/ProNudgeReporter.php
+++ b/src/Support/ProNudge/ProNudgeReporter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Dedoc\Scramble\Support\ProNudge;
+
+use Illuminate\Console\Command;
+
+/** @internal */
+class ProNudgeReporter
+{
+    public const PRO_URL = 'https://scramble.dedoc.co/pro';
+
+    public function __construct(
+        private ProNudgeCollector $collector,
+    ) {}
+
+    public function report(Command $command): void
+    {
+        if (! $this->collector->hasAny()) {
+            return;
+        }
+
+        $command->newLine();
+        $command->line('Scramble detected:');
+
+        foreach ($this->collector->summaries() as $summary) {
+            $command->line('  • '.$summary['signal']->description($summary['count']));
+        }
+
+        $command->newLine();
+        $this->renderPitch($command);
+        $command->newLine();
+        $command->line('Learn more: <href='.self::PRO_URL.'>'.self::PRO_URL.'</>');
+    }
+
+    private function renderPitch(Command $command): void
+    {
+        $hasQueryBuilder = $this->collector->count(ProNudgeSignal::QueryBuilder) > 0;
+        $hasLaravelData = $this->collector->count(ProNudgeSignal::LaravelDataReturn) > 0
+            || $this->collector->count(ProNudgeSignal::LaravelDataRequest) > 0;
+
+        if ($hasQueryBuilder && $hasLaravelData) {
+            $command->line('Scramble PRO understands these packages and automatically documents:');
+            $command->newLine();
+            $command->line('  • Query Builder filters, sorts, includes, and sparse fieldsets');
+            $command->line('  • Laravel Data request and response schemas');
+
+            return;
+        }
+
+        if ($hasQueryBuilder) {
+            $command->line('Scramble PRO understands Spatie Query Builder and automatically documents filters, sorts, includes, and sparse fieldsets.');
+
+            return;
+        }
+
+        $command->line('Scramble PRO understands Laravel Data and automatically generates accurate request and response schemas from your Data objects.');
+    }
+}

--- a/src/Support/ProNudge/ProNudgeSignal.php
+++ b/src/Support/ProNudge/ProNudgeSignal.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Dedoc\Scramble\Support\ProNudge;
+
+use Illuminate\Support\Str;
+
+/** @internal */
+enum ProNudgeSignal: string
+{
+    case QueryBuilder = 'query_builder';
+    case LaravelDataReturn = 'laravel_data_return';
+    case LaravelDataRequest = 'laravel_data_request';
+
+    public function description(int $count): string
+    {
+        $endpoints = $count.' '.Str::plural('endpoint', $count);
+
+        return match ($this) {
+            self::QueryBuilder => $count === 1
+                ? '1 endpoint uses Spatie Query Builder'
+                : "{$endpoints} use Spatie Query Builder",
+            self::LaravelDataReturn => $count === 1
+                ? '1 endpoint returns Laravel Data objects'
+                : "{$endpoints} return Laravel Data objects",
+            self::LaravelDataRequest => $count === 1
+                ? '1 endpoint accepts Laravel Data objects'
+                : "{$endpoints} accept Laravel Data objects",
+        };
+    }
+}

--- a/tests/Support/ProNudge/ProNudgeCollectorTest.php
+++ b/tests/Support/ProNudge/ProNudgeCollectorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use Dedoc\Scramble\Support\ProNudge\ProNudgeCollector;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeReporter;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeSignal;
+use Dedoc\Scramble\Support\RouteInfo;
+use Illuminate\Console\Command;
+use Illuminate\Routing\Route;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+it('records unique endpoints per signal', function () {
+    $collector = new ProNudgeCollector;
+
+    $routeInfo = new RouteInfo(new Route('GET', 'users', ['uses' => 'UsersController@index']), 'GET');
+    $otherRouteInfo = new RouteInfo(new Route('POST', 'users', ['uses' => 'UsersController@store']), 'POST');
+
+    $collector->record(ProNudgeSignal::LaravelDataReturn, $routeInfo);
+    $collector->record(ProNudgeSignal::LaravelDataReturn, $routeInfo);
+    $collector->record(ProNudgeSignal::LaravelDataReturn, $otherRouteInfo);
+    $collector->record(ProNudgeSignal::QueryBuilder, $routeInfo);
+
+    expect($collector->count(ProNudgeSignal::LaravelDataReturn))->toBe(2)
+        ->and($collector->count(ProNudgeSignal::QueryBuilder))->toBe(1)
+        ->and($collector->count(ProNudgeSignal::LaravelDataRequest))->toBe(0)
+        ->and($collector->hasAny())->toBeTrue();
+});
+
+it('reports both packages with a combined pitch', function () {
+    $collector = new ProNudgeCollector;
+    $routeInfo = new RouteInfo(new Route('GET', 'users', ['uses' => 'UsersController@index']), 'GET');
+
+    $collector->record(ProNudgeSignal::QueryBuilder, $routeInfo);
+    $collector->record(ProNudgeSignal::LaravelDataReturn, $routeInfo);
+    $collector->record(ProNudgeSignal::LaravelDataRequest, $routeInfo);
+
+    $command = makeProNudgeTestCommand($output = new BufferedOutput);
+
+    (new ProNudgeReporter($collector))->report($command);
+
+    $rendered = $output->fetch();
+
+    expect($rendered)
+        ->toContain('Scramble detected:')
+        ->toContain('  • 1 endpoint uses Spatie Query Builder')
+        ->toContain('  • 1 endpoint returns Laravel Data objects')
+        ->toContain('  • 1 endpoint accepts Laravel Data objects')
+        ->toContain('Scramble PRO understands these packages and automatically documents:')
+        ->toContain('  • Query Builder filters, sorts, includes, and sparse fieldsets')
+        ->toContain('  • Laravel Data request and response schemas')
+        ->toContain('Learn more: '.ProNudgeReporter::PRO_URL);
+});
+
+it('reports a query builder only pitch', function () {
+    $collector = new ProNudgeCollector;
+    $routeInfo = new RouteInfo(new Route('GET', 'users', ['uses' => 'UsersController@index']), 'GET');
+
+    $collector->record(ProNudgeSignal::QueryBuilder, $routeInfo);
+
+    $command = makeProNudgeTestCommand($output = new BufferedOutput);
+
+    (new ProNudgeReporter($collector))->report($command);
+
+    $rendered = $output->fetch();
+
+    expect($rendered)
+        ->toContain('Scramble PRO understands Spatie Query Builder and automatically documents')
+        ->toContain('filters, sorts, includes, and sparse fieldsets.')
+        ->not->toContain('Laravel Data');
+});
+
+it('reports a laravel data only pitch', function () {
+    $collector = new ProNudgeCollector;
+    $routeInfo = new RouteInfo(new Route('GET', 'users', ['uses' => 'UsersController@index']), 'GET');
+
+    $collector->record(ProNudgeSignal::LaravelDataReturn, $routeInfo);
+
+    $command = makeProNudgeTestCommand($output = new BufferedOutput);
+
+    (new ProNudgeReporter($collector))->report($command);
+
+    $rendered = $output->fetch();
+
+    expect($rendered)
+        ->toContain('Scramble PRO understands Laravel Data and automatically generates accurate')
+        ->toContain('request and response schemas from your Data objects.')
+        ->not->toContain('Query Builder');
+});
+
+it('does not report when there are no signals', function () {
+    $command = makeProNudgeTestCommand($output = new BufferedOutput);
+
+    (new ProNudgeReporter(new ProNudgeCollector))->report($command);
+
+    expect($output->fetch())->toBe('');
+});
+
+function makeProNudgeTestCommand(OutputInterface $output): Command
+{
+    $command = new class extends Command
+    {
+        protected $name = 'test';
+    };
+
+    $command->setLaravel(app());
+    $command->setOutput(
+        new \Illuminate\Console\OutputStyle(
+            new \Symfony\Component\Console\Input\ArrayInput([]),
+            $output,
+        )
+    );
+
+    return $command;
+}

--- a/tests/Support/ProNudge/ProNudgeExtensionsTest.php
+++ b/tests/Support/ProNudge/ProNudgeExtensionsTest.php
@@ -1,0 +1,132 @@
+<?php
+
+use Dedoc\Scramble\Console\Commands\ExportDocumentation;
+use Dedoc\Scramble\Generator;
+use Dedoc\Scramble\Scramble;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeReporter;
+use Dedoc\Scramble\Support\ProNudge\ProNudgeSignal;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Route as RouteFacade;
+
+use function Pest\Laravel\artisan;
+
+require_once __DIR__.'/stubs/LaravelData.php';
+require_once __DIR__.'/stubs/QueryBuilder.php';
+
+it('collects laravel data return type signals', function () {
+    Scramble::routes(fn (Route $r) => str_starts_with($r->uri, 'api/pro-nudge'));
+
+    RouteFacade::get('api/pro-nudge/data-return', [ProNudge_DataReturn_Controller::class, 'index']);
+    RouteFacade::get('api/pro-nudge/plain', [ProNudge_Plain_Controller::class, 'index']);
+
+    $generator = app(Generator::class);
+    $generator();
+
+    expect($generator->proNudge->count(ProNudgeSignal::LaravelDataReturn))->toBe(1);
+});
+
+it('collects laravel data request body signals', function () {
+    Scramble::routes(fn (Route $r) => str_starts_with($r->uri, 'api/pro-nudge'));
+
+    RouteFacade::post('api/pro-nudge/data-request', [ProNudge_DataRequest_Controller::class, 'store']);
+    RouteFacade::post('api/pro-nudge/plain-request', [ProNudge_Plain_Controller::class, 'store']);
+
+    $generator = app(Generator::class);
+    $generator();
+
+    expect($generator->proNudge->count(ProNudgeSignal::LaravelDataRequest))->toBe(1);
+});
+
+it('collects query builder usage signals', function () {
+    Scramble::routes(fn (Route $r) => str_starts_with($r->uri, 'api/pro-nudge'));
+
+    RouteFacade::get('api/pro-nudge/query-builder', [ProNudge_QueryBuilder_Controller::class, 'index']);
+    RouteFacade::get('api/pro-nudge/plain', [ProNudge_Plain_Controller::class, 'index']);
+
+    $generator = app(Generator::class);
+    $generator();
+
+    expect($generator->proNudge->count(ProNudgeSignal::QueryBuilder))->toBe(1);
+});
+
+it('resets pro nudge collector between generator runs', function () {
+    Scramble::routes(fn (Route $r) => str_starts_with($r->uri, 'api/pro-nudge'));
+
+    RouteFacade::get('api/pro-nudge/data-return', [ProNudge_DataReturn_Controller::class, 'index']);
+
+    $generator = app(Generator::class);
+    $generator();
+
+    expect($generator->proNudge->count(ProNudgeSignal::LaravelDataReturn))->toBe(1);
+
+    Scramble::routes(fn (Route $r) => false);
+    $generator();
+
+    expect($generator->proNudge->hasAny())->toBeFalse();
+});
+
+it('prints pro nudge after export when signals are present', function () {
+    Scramble::routes(fn (Route $r) => str_starts_with($r->uri, 'api/pro-nudge'));
+
+    RouteFacade::get('api/pro-nudge/data-return', [ProNudge_DataReturn_Controller::class, 'index']);
+    RouteFacade::post('api/pro-nudge/data-request', [ProNudge_DataRequest_Controller::class, 'store']);
+    RouteFacade::get('api/pro-nudge/query-builder', [ProNudge_QueryBuilder_Controller::class, 'index']);
+
+    File::shouldReceive('put')->once();
+
+    artisan(ExportDocumentation::class)
+        ->expectsOutputToContain('OpenAPI document exported to api.json.')
+        ->expectsOutputToContain('Scramble detected:')
+        ->expectsOutputToContain('1 endpoint uses Spatie Query Builder')
+        ->expectsOutputToContain('1 endpoint returns Laravel Data objects')
+        ->expectsOutputToContain('1 endpoint accepts Laravel Data objects')
+        ->expectsOutputToContain('Scramble PRO understands these packages and automatically documents:')
+        ->expectsOutputToContain('Query Builder filters, sorts, includes, and sparse fieldsets')
+        ->expectsOutputToContain('Laravel Data request and response schemas')
+        ->expectsOutputToContain('Learn more: '.ProNudgeReporter::PRO_URL)
+        ->assertOk();
+});
+
+class ProNudge_DataReturn_Controller
+{
+    public function index(): ProNudge_SampleData
+    {
+        return new ProNudge_SampleData;
+    }
+}
+
+class ProNudge_DataRequest_Controller
+{
+    public function store(ProNudge_SampleData $data): array
+    {
+        return [];
+    }
+}
+
+class ProNudge_QueryBuilder_Controller
+{
+    public function index()
+    {
+        return \Spatie\QueryBuilder\QueryBuilder::for(ProNudge_SampleModel::class)
+            ->allowedFilters('name')
+            ->get();
+    }
+}
+
+class ProNudge_Plain_Controller
+{
+    public function index(): array
+    {
+        return [];
+    }
+
+    public function store(): array
+    {
+        return [];
+    }
+}
+
+class ProNudge_SampleData extends \Spatie\LaravelData\Data {}
+
+class ProNudge_SampleModel extends \Illuminate\Database\Eloquent\Model {}

--- a/tests/Support/ProNudge/stubs/LaravelData.php
+++ b/tests/Support/ProNudge/stubs/LaravelData.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Spatie\LaravelData;
+
+class Data {}

--- a/tests/Support/ProNudge/stubs/QueryBuilder.php
+++ b/tests/Support/ProNudge/stubs/QueryBuilder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\QueryBuilder;
+
+class QueryBuilder
+{
+    public static function for(mixed $subject): self
+    {
+        return new self;
+    }
+
+    public function allowedFilters(mixed ...$filters): self
+    {
+        return $this;
+    }
+
+    public function get(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
After `scramble:analyze` / `scramble:export`, if routes use Spatie Laravel Data or Query Builder (and Pro isn't installed), print a short tip with counts and a link to Pro.

Skipped entirely when `ScrambleProServiceProvider` is present.
