### PR TITLE
Fix pagination documentation for mixed Scout and Eloquent queries

### DIFF
--- a/src/Support/InferExtensions/AfterModelDefinitionCreatedExtension.php
+++ b/src/Support/InferExtensions/AfterModelDefinitionCreatedExtension.php
@@ -5,6 +5,8 @@ namespace Dedoc\Scramble\Support\InferExtensions;
 use Dedoc\Scramble\Infer\Definition\ClassDefinition;
 use Dedoc\Scramble\Infer\Extensions\AfterClassDefinitionCreatedExtension;
 use Dedoc\Scramble\Infer\Extensions\Event\ClassDefinitionCreatedEvent;
+use Dedoc\Scramble\Infer\Extensions\Event\StaticMethodCallEvent;
+use Dedoc\Scramble\Infer\Extensions\StaticMethodReturnTypeExtension;
 use Dedoc\Scramble\Support\Type\ArrayItemType_;
 use Dedoc\Scramble\Support\Type\ArrayMerge;
 use Dedoc\Scramble\Support\Type\ConditionalType;
@@ -22,8 +24,10 @@ use Dedoc\Scramble\Support\Type\Type;
 use Dedoc\Scramble\Support\Type\WithProperties;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Builder as ScoutBuilder;
+use Laravel\Scout\Searchable;
 
-class AfterModelDefinitionCreatedExtension implements AfterClassDefinitionCreatedExtension
+class AfterModelDefinitionCreatedExtension implements AfterClassDefinitionCreatedExtension, StaticMethodReturnTypeExtension
 {
     public function shouldHandle(string $name): bool
     {
@@ -38,6 +42,24 @@ class AfterModelDefinitionCreatedExtension implements AfterClassDefinitionCreate
         $definition->methods['newQuery'] = $this->buildNewQueryMethodDefinition($definition);
         $definition->methods['load'] = $this->buildLoadMethodDefinition($definition);
         $definition->methods['loadMissing'] = $this->buildLoadMissingMethodDefinition($definition);
+    }
+
+    public function getStaticMethodReturnType(StaticMethodCallEvent $event): ?Type
+    {
+        if (! $definition = $event->scope->index->getClass($event->callee)) {
+            return null;
+        }
+
+        if (in_array(Searchable::class, class_uses_recursive($event->callee), true)) {
+            return match ($event->name) {
+                'search' => new Generic(ScoutBuilder::class, [
+                    $this->buildSeededModelType($definition),
+                ]),
+                default => null,
+            };
+        }
+
+        return null;
     }
 
     private function buildQueryMethodDefinition(ClassDefinition $definition): ShallowFunctionDefinition
@@ -77,13 +99,18 @@ class AfterModelDefinitionCreatedExtension implements AfterClassDefinitionCreate
          * >
          */
         return new Generic(ModelBuilderTypeResolver::resolveClass($definition->name), [
-            new Generic(WithProperties::class, [
-                new ObjectType($definition->name),
-                new KeyedArrayType([
-                    new ArrayItemType_('relations', new Generic(EagerLoadRelationsList::class, [
-                        $this->resolveWithDefaultType($definition),
-                    ])),
-                ]),
+            $this->buildSeededModelType($definition),
+        ]);
+    }
+
+    private function buildSeededModelType(ClassDefinition $definition): Generic
+    {
+        return new Generic(WithProperties::class, [
+            new ObjectType($definition->name),
+            new KeyedArrayType([
+                new ArrayItemType_('relations', new Generic(EagerLoadRelationsList::class, [
+                    $this->resolveWithDefaultType($definition),
+                ])),
             ]),
         ]);
     }

--- a/src/Support/Type/KeyedArrayType.php
+++ b/src/Support/Type/KeyedArrayType.php
@@ -39,7 +39,38 @@ class KeyedArrayType extends AbstractType
 
     public function isSame(Type $type)
     {
-        return false;
+        if (
+            ! $type instanceof static
+            || $type->isList !== $this->isList
+            || count($type->items) !== count($this->items)
+        ) {
+            return false;
+        }
+
+        foreach ($this->items as $index => $item) {
+            $otherItem = $type->items[$index];
+
+            if (
+                $item->key !== $otherItem->key
+                || $item->isOptional !== $otherItem->isOptional
+                || $item->shouldUnpack !== $otherItem->shouldUnpack
+                || ! $item->value->isSame($otherItem->value)
+                || ! $this->keyTypesAreSame($item->keyType, $otherItem->keyType)
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function keyTypesAreSame(?Type $left, ?Type $right): bool
+    {
+        if ($left === null || $right === null) {
+            return $left === $right;
+        }
+
+        return $left->isSame($right);
     }
 
     public function getItemValueTypeByKey(string|int $key, Type $default = new UnknownType): Type

--- a/src/Support/Type/TypeWidener.php
+++ b/src/Support/Type/TypeWidener.php
@@ -7,6 +7,8 @@ use Dedoc\Scramble\Support\Type\Literal\LiteralFloatType;
 use Dedoc\Scramble\Support\Type\Literal\LiteralIntegerType;
 use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
 use Illuminate\Http\Resources\MissingValue;
+use Illuminate\Pagination\AbstractCursorPaginator;
+use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Enumerable;
 
 class TypeWidener
@@ -105,7 +107,9 @@ class TypeWidener
             $a instanceof Generic
             && $b instanceof Generic
             && $a->name === $b->name
-            && $a->isInstanceOf(Enumerable::class)
+            && ($a->isInstanceOf(Enumerable::class)
+                || $a->isInstanceOf(AbstractPaginator::class)
+                || $a->isInstanceOf(AbstractCursorPaginator::class))
         ) {
             return new Generic($a->name, [
                 (new Union([$a->templateTypes[0] ?? new UnknownType, $b->templateTypes[0] ?? new UnknownType]))->widen(),

--- a/tests/Support/InferExtensions/ModelExtensionTest.php
+++ b/tests/Support/InferExtensions/ModelExtensionTest.php
@@ -12,10 +12,13 @@ use Dedoc\Scramble\Support\Type\Reference\PropertyFetchReferenceType;
 use Dedoc\Scramble\Support\Type\SelfType;
 use Dedoc\Scramble\Support\Type\TypeWalker;
 use Dedoc\Scramble\Tests\Files\SamplePostModel;
+use Dedoc\Scramble\Tests\Files\SampleUserModel;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Laravel\Scout\Builder as ScoutBuilder;
+use Laravel\Scout\Searchable;
 
 beforeEach(function () {
     $this->index = new Index;
@@ -35,6 +38,13 @@ class UserModel_ModelExtensionTest extends Model
 }
 
 class PostModel_ModelExtensionTest extends Model {}
+
+class SearchableModel_ModelExtensionTest extends Model
+{
+    use Searchable;
+
+    protected $with = ['posts'];
+}
 
 describe('model annotations (introduced in 11.15.0)', function () {
     it('handles static', function () {
@@ -102,6 +112,30 @@ describe('model annotations (introduced in 11.15.0)', function () {
 
         expect($relationsType->toString())->toBe('list{string(parent), string(children), string(user)}');
     });
+
+    it('seeds model relations from $with on Scout search()', function (string $model, string $expectedRelationsType) {
+        $builderType = getStatementType($model.'::search()');
+
+        expect($builderType)->toBeInstanceOf(Generic::class)
+            ->and($builderType->name)->toBe(ScoutBuilder::class);
+
+        $relationsType = ReferenceTypeResolver::getInstance()
+            ->resolve(
+                new GlobalScope,
+                new PropertyFetchReferenceType($builderType->templateTypes[0], 'relations'),
+            );
+
+        expect($relationsType->toString())->toBe($expectedRelationsType);
+    })->with([
+        'without default eager loads' => [
+            SampleUserModel::class,
+            'list{}',
+        ],
+        'with default eager loads' => [
+            SearchableModel_ModelExtensionTest::class,
+            'list{string(posts)}',
+        ],
+    ]);
 
     it('carries loaded relations from $with through static model shortcuts', function (string $expression, string $expectedRelationsType) {
         $type = getStatementType($expression);

--- a/tests/Support/Type/KeyedArrayTypeTest.php
+++ b/tests/Support/Type/KeyedArrayTypeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Dedoc\Scramble\Tests\Support\Type;
+
+use Dedoc\Scramble\Support\Type\ArrayItemType_;
+use Dedoc\Scramble\Support\Type\IntegerType;
+use Dedoc\Scramble\Support\Type\KeyedArrayType;
+use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
+use Dedoc\Scramble\Support\Type\StringType;
+
+it('compares keyed arrays structurally while ignoring attributes', function () {
+    $leftItem = new ArrayItemType_(
+        key: 'name',
+        value: new StringType,
+        isOptional: true,
+        shouldUnpack: true,
+        keyType: new LiteralStringType('name'),
+    );
+    $leftItem->setAttribute('source', 'left');
+
+    $rightItem = new ArrayItemType_(
+        key: 'name',
+        value: new StringType,
+        isOptional: true,
+        shouldUnpack: true,
+        keyType: new LiteralStringType('name'),
+    );
+    $rightItem->setAttribute('source', 'right');
+
+    $left = new KeyedArrayType([$leftItem], isList: false);
+    $right = new KeyedArrayType([$rightItem], isList: false);
+    $left->setAttribute('source', 'left');
+    $right->setAttribute('source', 'right');
+
+    expect($left->isSame($right))->toBeTrue()
+        ->and($right->isSame($left))->toBeTrue();
+});
+
+it('distinguishes keyed arrays with different structures', function () {
+    $base = new KeyedArrayType([
+        new ArrayItemType_(
+            key: 'name',
+            value: new StringType,
+            keyType: new LiteralStringType('name'),
+        ),
+    ], isList: false);
+
+    $differentKey = $base->clone();
+    $differentKey->items[0]->key = 'title';
+
+    $differentValue = $base->clone();
+    $differentValue->items[0]->value = new IntegerType;
+
+    $differentOptionality = $base->clone();
+    $differentOptionality->items[0]->isOptional = true;
+
+    $differentUnpacking = $base->clone();
+    $differentUnpacking->items[0]->shouldUnpack = true;
+
+    $differentKeyType = $base->clone();
+    $differentKeyType->items[0]->keyType = new IntegerType;
+
+    $differentArrayKind = $base->clone();
+    $differentArrayKind->isList = true;
+
+    expect($base->isSame($differentKey))->toBeFalse()
+        ->and($base->isSame($differentValue))->toBeFalse()
+        ->and($base->isSame($differentOptionality))->toBeFalse()
+        ->and($base->isSame($differentUnpacking))->toBeFalse()
+        ->and($base->isSame($differentKeyType))->toBeFalse()
+        ->and($base->isSame($differentArrayKind))->toBeFalse();
+});
+
+it('compares keyed array items in order', function () {
+    $first = new KeyedArrayType([
+        new ArrayItemType_('first', new StringType),
+        new ArrayItemType_('second', new IntegerType),
+    ]);
+    $reversed = new KeyedArrayType([
+        new ArrayItemType_('second', new IntegerType),
+        new ArrayItemType_('first', new StringType),
+    ]);
+
+    expect($first->isSame($reversed))->toBeFalse();
+});

--- a/tests/Support/Type/TypeWidenerTest.php
+++ b/tests/Support/Type/TypeWidenerTest.php
@@ -2,6 +2,9 @@
 
 namespace Dedoc\Scramble\Tests\Support\Type;
 
+use Dedoc\Scramble\Support\Type\Generic;
+use Dedoc\Scramble\Support\Type\IntegerType;
+use Dedoc\Scramble\Support\Type\KeyedArrayType;
 use Dedoc\Scramble\Support\Type\MixedType;
 use Dedoc\Scramble\Support\Type\ObjectType;
 use Dedoc\Scramble\Support\Type\StringType;
@@ -15,6 +18,7 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Resources\MissingValue;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\LazyCollection;
@@ -52,6 +56,35 @@ test('widens allowed key value generic collections', function (string $collectio
     LazyCollection::class,
     Enumerable::class,
 ]);
+
+test('widens same paginator item types', function () {
+    $modelWithoutKnownRelations = new ObjectType(SampleUserModel::class);
+    $modelWithKnownRelations = new ObjectType(SampleUserModel::class);
+    $modelWithKnownRelations->propertyTypes['relations'] = new KeyedArrayType;
+
+    $type = new Union([
+        new Generic(LengthAwarePaginator::class, [new IntegerType, $modelWithoutKnownRelations]),
+        new Generic(LengthAwarePaginator::class, [new IntegerType, $modelWithKnownRelations]),
+    ]);
+
+    $widened = $type->widen();
+
+    expect($widened)
+        ->toBeInstanceOf(Generic::class)
+        ->and($widened->name)->toBe(LengthAwarePaginator::class)
+        ->and($widened->templateTypes[0])->toBeInstanceOf(IntegerType::class)
+        ->and($widened->templateTypes[1])->toBeInstanceOf(Union::class)
+        ->and($widened->templateTypes[1]->types)->toHaveCount(2);
+});
+
+test('does not widen different paginator classes', function () {
+    $type = new Union([
+        new Generic(LengthAwarePaginator::class, [new IntegerType, new ObjectType(SampleUserModel::class)]),
+        new Generic(Paginator::class, [new IntegerType, new ObjectType(SampleUserModel::class)]),
+    ]);
+
+    expect($type->widen())->toBeInstanceOf(Union::class);
+});
 
 test('does not widen anonymous resource collection templates as key value pairs', function () {
     $type = TestUtils::parseType(AnonymousResourceCollection::class.'<unknown, array<mixed>, App\Http\Brands\Events\Resources\EventResource>'

--- a/tests/Support/TypeToSchemaExtensions/AnonymousResourceCollectionTypeToSchemaTest.php
+++ b/tests/Support/TypeToSchemaExtensions/AnonymousResourceCollectionTypeToSchemaTest.php
@@ -13,9 +13,12 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Route;
+use Laravel\Scout\Searchable;
 
 class User_AnonymousResourceCollectionTypeToSchemaTest extends Model
 {
+    use Searchable;
+
     protected $table = 'users';
 }
 
@@ -114,6 +117,39 @@ class UserServicePaginator_AnonymousResourceCollectionTypeToSchemaTest
      */
     public function allUsers(): LengthAwarePaginator
     {
+        return User_AnonymousResourceCollectionTypeToSchemaTest::query()->paginate();
+    }
+}
+
+it('documents paginated response from service with Scout and Eloquent pagination branches', function () {
+    $openApiDocument = generateForRoute(fn () => Route::get('test', [MixedPaginatorPagination_AnonymousResourceCollectionTypeToSchemaTestController::class, 'index']));
+
+    expect($responses = $openApiDocument['paths']['/test']['get']['responses'])
+        ->toHaveKey(200)
+        ->and($schema = $responses[200]['content']['application/json']['schema'])
+        ->toHaveKeys(['type', 'properties'])
+        ->and($schema['properties'])
+        ->toHaveKeys(['data', 'meta', 'links']);
+});
+class MixedPaginatorPagination_AnonymousResourceCollectionTypeToSchemaTestController
+{
+    public function index(MixedPaginatorService_AnonymousResourceCollectionTypeToSchemaTest $service): AnonymousResourceCollection
+    {
+        return UserResource_AnonymousResourceCollectionTypeToSchemaTest::collection($service->users(null));
+    }
+}
+
+class MixedPaginatorService_AnonymousResourceCollectionTypeToSchemaTest
+{
+    /**
+     * @return LengthAwarePaginator<int, User_AnonymousResourceCollectionTypeToSchemaTest>
+     */
+    public function users(?string $search): LengthAwarePaginator
+    {
+        if ($search !== null) {
+            return User_AnonymousResourceCollectionTypeToSchemaTest::search($search)->paginate();
+        }
+
         return User_AnonymousResourceCollectionTypeToSchemaTest::query()->paginate();
     }
 }


### PR DESCRIPTION
Seeds Scout search builders with model relation state and widens paginator generics across branches. Also adds structural equality for keyed arrays and regression coverage for the missing pagination envelope.

fixes #1242 