### PR TITLE
Preserve inferred model type metadata with compatible PHPDoc properties

### DIFF
--- a/src/Support/InferExtensions/ModelExtension.php
+++ b/src/Support/InferExtensions/ModelExtension.php
@@ -71,12 +71,12 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
             ?->getPropertyDefinition($event->getName())
             ?->type;
 
-        if ($propertyType?->getAttribute('source') === 'phpDoc') {
-            return $propertyType;
-        }
+        $annotatedType = $propertyType?->getAttribute('source') === 'phpDoc'
+            ? $propertyType
+            : null;
 
         if (! $this->hasProperty($event->getInstance(), $event->getName())) {
-            return null;
+            return $annotatedType;
         }
 
         $info = $this->getModelInfo($event->getInstance());
@@ -86,18 +86,48 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
                 ?? $this->getAttributeTypeFromDbColumnType($attribute['type'], $attribute['driver'])
                 ?? new UnknownType("Virtual attribute ({$attribute['name']}) type inference not supported.");
 
-            if ($attribute['nullable']) {
-                return Union::wrap([$baseType, new NullType]);
-            }
+            $inferredType = $attribute['nullable']
+                ? Union::wrap([$baseType, new NullType])
+                : $baseType;
 
-            return $baseType;
+            return $this->refineAnnotatedType($annotatedType, $inferredType);
         }
 
         if ($relation = $info->get('relations')->get($event->getName())) {
-            return $this->getRelationType($relation);
+            $inferredType = $this->getRelationType($relation);
+
+            return $this->refineAnnotatedType($annotatedType, $inferredType);
         }
 
         throw new \LogicException('Should not happen');
+    }
+
+    private function refineAnnotatedType(?Type $annotatedType, Type $inferredType): Type
+    {
+        if (! $annotatedType?->accepts($inferredType)) {
+            return $annotatedType ?? $inferredType;
+        }
+
+        if (! $annotatedType instanceof Union) {
+            return $inferredType;
+        }
+
+        $inferredTypes = $inferredType instanceof Union
+            ? $inferredType->types
+            : [$inferredType];
+
+        $refinedTypes = collect($annotatedType->types)
+            ->flatMap(function (Type $annotatedMember) use ($inferredTypes) {
+                $acceptedInferredTypes = array_filter(
+                    $inferredTypes,
+                    fn (Type $inferredMember) => $annotatedMember->accepts($inferredMember),
+                );
+
+                return $acceptedInferredTypes ?: [$annotatedMember];
+            })
+            ->all();
+
+        return Union::wrap($refinedTypes)->mergeAttributes($annotatedType->attributes());
     }
 
     /**

--- a/tests/InferExtensions/ModelExtensionTest.php
+++ b/tests/InferExtensions/ModelExtensionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Dedoc\Scramble\Infer;
 use Dedoc\Scramble\Infer\Services\ReferenceTypeResolver;
 use Dedoc\Scramble\Support\Type\ArrayItemType_;
@@ -87,6 +88,24 @@ class ModelExtensionTest_ModelWithRelationOverride extends SamplePostModel {}
 class ModelExtensionTest_ModelWithLegacyCollectionProperty extends SamplePostModel {}
 
 class ModelExtensionTest_OverriddenUser extends Model {}
+
+it('refines a compatible PHPDoc union with the inferred model attribute type', function () {
+    $this->infer->analyzeClass(ModelExtensionTest_ModelWithAnnotatedDate::class);
+
+    $propertyType = (new ObjectType(ModelExtensionTest_ModelWithAnnotatedDate::class))
+        ->getPropertyType('title');
+
+    expect($propertyType->toString())->toBe(Carbon::class.'|null')
+        ->and($propertyType->getAttribute('source'))->toBe('phpDoc');
+});
+
+/** @property Carbon|null $title */
+class ModelExtensionTest_ModelWithAnnotatedDate extends SamplePostModel
+{
+    protected $casts = [
+        'title' => 'datetime:Y-m-d',
+    ];
+}
 
 it('adds toArray method type the model class without defined toArray class', function () {
     $this->infer->analyzeClass(SampleUserModel::class);

--- a/tests/TypeToSchemaTransformerTest.php
+++ b/tests/TypeToSchemaTransformerTest.php
@@ -437,13 +437,50 @@ it('infers date column when casted to date', function () {
         'format' => 'date',
     ]);
 });
+
+it('preserves cast date formats through compatible model property annotations', function () {
+    $transformer = new TypeTransformer(app(Infer::class), $this->context, [CarbonInterfaceToSchema::class, JsonResourceTypeToSchema::class]);
+
+    $transformer->transform(new ObjectType(InferTypesTest_JsonResourceWithAnnotatedCarbonAttributes::class));
+
+    $properties = $this->context->openApi->components->getSchema(InferTypesTest_JsonResourceWithAnnotatedCarbonAttributes::class)->toArray()['properties'];
+
+    expect($properties['date'])->toBe([
+        'type' => 'string',
+        'format' => 'date',
+    ])->and($properties['nullable_date'])->toBe([
+        'type' => ['string', 'null'],
+        'format' => 'date',
+    ]);
+});
+
+/**
+ * @property \Carbon\Carbon $body
+ * @property \Carbon\Carbon|null $title
+ */
 class SamplePostWithDateApprovedAtModel extends \Illuminate\Database\Eloquent\Model
 {
     protected $table = 'posts';
 
     protected $casts = [
+        'body' => 'datetime:Y-m-d',
+        'title' => 'datetime:Y-m-d',
         'approved_at' => 'datetime:Y-m-d',
     ];
+}
+
+/**
+ * @property SamplePostWithDateApprovedAtModel $resource
+ */
+class InferTypesTest_JsonResourceWithAnnotatedCarbonAttributes extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'date' => $this->resource->body,
+            'nullable_date' => $this->resource->title,
+        ];
+    }
 }
 
 it('infers date column directly referenced in json as date-time', function () {


### PR DESCRIPTION
Uses the narrower inferred model property type when compatible with its PHPDoc annotation, while preserving union members such as `null`. Fixes Carbon date casts losing their inferred format.

fixes #1239 