### PR TITLE
Infer Storage downloads as binary streamed responses

### DIFF
--- a/src/ScrambleServiceProvider.php
+++ b/src/ScrambleServiceProvider.php
@@ -59,6 +59,7 @@ use Dedoc\Scramble\Support\InferExtensions\ResourceCollectionTypeInfer;
 use Dedoc\Scramble\Support\InferExtensions\ResourceResponseMethodReturnTypeExtension;
 use Dedoc\Scramble\Support\InferExtensions\ResponseFactoryTypeInfer;
 use Dedoc\Scramble\Support\InferExtensions\ShallowFunctionDefinition;
+use Dedoc\Scramble\Support\InferExtensions\StorageResponseTypeInfer;
 use Dedoc\Scramble\Support\InferExtensions\TransformsToResourceCollectionExtension;
 use Dedoc\Scramble\Support\InferExtensions\TranslationReturnTypeExtension;
 use Dedoc\Scramble\Support\InferExtensions\TypeTraceInfer;
@@ -207,6 +208,7 @@ class ScrambleServiceProvider extends PackageServiceProvider
                         new ValidatorTypeInfer,
                         new ResourceCollectionTypeInfer,
                         new ResponseFactoryTypeInfer,
+                        new StorageResponseTypeInfer,
 
                         new ArrayMergeReturnTypeExtension,
                         $app->make(TranslationReturnTypeExtension::class),

--- a/src/Support/InferExtensions/BinaryFileResponseTypeFactory.php
+++ b/src/Support/InferExtensions/BinaryFileResponseTypeFactory.php
@@ -2,15 +2,13 @@
 
 namespace Dedoc\Scramble\Support\InferExtensions;
 
+use Dedoc\Scramble\Support\InferExtensions\Concerns\GuessesMimeTypeFromFileType;
 use Dedoc\Scramble\Support\Type\ArrayType;
 use Dedoc\Scramble\Support\Type\Generic;
 use Dedoc\Scramble\Support\Type\Literal\LiteralIntegerType;
 use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
 use Dedoc\Scramble\Support\Type\NullType;
 use Dedoc\Scramble\Support\Type\Type;
-use Dedoc\Scramble\Support\Type\TypeWalker;
-use Dedoc\Scramble\Support\Type\Union;
-use League\MimeTypeDetection\ExtensionMimeTypeDetector;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 /**
@@ -20,6 +18,8 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
  */
 class BinaryFileResponseTypeFactory
 {
+    use GuessesMimeTypeFromFileType;
+
     public function __construct(
         public Type $file,
         public Type $name = new NullType,
@@ -46,22 +46,11 @@ class BinaryFileResponseTypeFactory
     {
         $mimeType = 'application/octet-stream';
 
-        if ($fileMime = $this->guessMimeTypeFromFile()) {
+        if ($fileMime = $this->guessMimeTypeFromFileType($this->file)) {
             $mimeType = $fileMime;
         }
 
         return $mimeType;
-    }
-
-    private function guessMimeTypeFromFile(): ?string
-    {
-        $fileName = $this->guessFileNameFromType($this->file);
-
-        if ($fileName && class_exists(ExtensionMimeTypeDetector::class)) {
-            return (new ExtensionMimeTypeDetector)->detectMimeTypeFromPath($fileName);
-        }
-
-        return null;
     }
 
     private function guessContentDisposition(): ?string
@@ -76,31 +65,6 @@ class BinaryFileResponseTypeFactory
             $this->guessFileNameFromType($this->file),
             $this->guessFileNameFromType($this->name),
         );
-    }
-
-    private function guessFileNameFromType(Type $fileArgumentType): ?string
-    {
-        $stringLiterals = (new TypeWalker)->findAll(
-            Union::wrap(...array_filter([$fileArgumentType->getOriginal(), $fileArgumentType])),
-            fn (Type $t) => $t instanceof LiteralStringType,
-        );
-
-        foreach (array_reverse($stringLiterals) as $stringLiteral) {
-            if (! $stringLiteral instanceof LiteralStringType) {
-                continue;
-            }
-
-            if ($this->isFileName($stringLiteral->value)) {
-                return $stringLiteral->value;
-            }
-        }
-
-        return null;
-    }
-
-    private function isFileName(string $str): bool
-    {
-        return (bool) preg_match('/^.*\.[^.]+$/', $str);
     }
 
     private function getContentDispositionAttachmentHeader(?string $fileName, ?string $overridingFileName): string

--- a/src/Support/InferExtensions/Concerns/GuessesMimeTypeFromFileType.php
+++ b/src/Support/InferExtensions/Concerns/GuessesMimeTypeFromFileType.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Dedoc\Scramble\Support\InferExtensions\Concerns;
+
+use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
+use Dedoc\Scramble\Support\Type\Type;
+use Dedoc\Scramble\Support\Type\TypeWalker;
+use Dedoc\Scramble\Support\Type\Union;
+use League\MimeTypeDetection\ExtensionMimeTypeDetector;
+
+trait GuessesMimeTypeFromFileType
+{
+    protected function guessMimeTypeFromFileType(Type $fileType): ?string
+    {
+        $fileName = $this->guessFileNameFromType($fileType);
+
+        if ($fileName && class_exists(ExtensionMimeTypeDetector::class)) {
+            return (new ExtensionMimeTypeDetector)->detectMimeTypeFromPath($fileName);
+        }
+
+        return null;
+    }
+
+    protected function guessFileNameFromType(Type $fileType): ?string
+    {
+        $stringLiterals = (new TypeWalker)->findAll(
+            Union::wrap(...array_filter([$fileType->getOriginal(), $fileType])),
+            fn (Type $type) => $type instanceof LiteralStringType,
+        );
+
+        foreach (array_reverse($stringLiterals) as $stringLiteral) {
+            if ($stringLiteral instanceof LiteralStringType && $this->isFileName($stringLiteral->value)) {
+                return $stringLiteral->value;
+            }
+        }
+
+        return null;
+    }
+
+    private function isFileName(string $value): bool
+    {
+        return (bool) preg_match('/^.*\.[^.]+$/', $value);
+    }
+}

--- a/src/Support/InferExtensions/StorageResponseTypeInfer.php
+++ b/src/Support/InferExtensions/StorageResponseTypeInfer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Dedoc\Scramble\Support\InferExtensions;
+
+use Dedoc\Scramble\Infer\Extensions\Event\MethodCallEvent;
+use Dedoc\Scramble\Infer\Extensions\MethodReturnTypeExtension;
+use Dedoc\Scramble\Support\InferExtensions\Concerns\GuessesMimeTypeFromFileType;
+use Dedoc\Scramble\Support\Type\ArrayType;
+use Dedoc\Scramble\Support\Type\Generic;
+use Dedoc\Scramble\Support\Type\Literal\LiteralIntegerType;
+use Dedoc\Scramble\Support\Type\NullType;
+use Dedoc\Scramble\Support\Type\ObjectType;
+use Dedoc\Scramble\Support\Type\StringType;
+use Dedoc\Scramble\Support\Type\Type;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemManager;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class StorageResponseTypeInfer implements MethodReturnTypeExtension
+{
+    use GuessesMimeTypeFromFileType;
+
+    public function shouldHandle(ObjectType $type): bool
+    {
+        return $type->isInstanceOf(FilesystemManager::class)
+            || $type->isInstanceOf(Filesystem::class);
+    }
+
+    public function getMethodReturnType(MethodCallEvent $event): ?Type
+    {
+        $arguments = match ($event->name) {
+            'download', 'response' => [
+                $event->getArg('path', 0),
+                $event->getArg('name', 1, new NullType),
+                $event->getArg('headers', 2, new ArrayType),
+            ],
+            'serve' => [
+                $event->getArg('path', 1),
+                $event->getArg('name', 2, new NullType),
+                $event->getArg('headers', 3, new ArrayType),
+            ],
+            default => null,
+        };
+
+        if (! $arguments) {
+            return null;
+        }
+
+        [$file, $name, $headers] = $arguments;
+
+        $responseType = new Generic(StreamedResponse::class, [
+            new StringType,
+            new LiteralIntegerType(200),
+            $headers,
+        ]);
+
+        $responseType->setAttribute(
+            'mimeType',
+            $this->guessMimeTypeFromFileType($file)
+                ?: $this->guessMimeTypeFromFileType($name)
+                ?: 'application/octet-stream',
+        );
+
+        return $responseType;
+    }
+}

--- a/src/Support/OperationExtensions/ResponseExtension.php
+++ b/src/Support/OperationExtensions/ResponseExtension.php
@@ -226,7 +226,30 @@ class ResponseExtension extends OperationExtension
      */
     private function mergeHeaders(Collection $responses): array
     {
-        return array_merge(...$responses->map->headers);
+        $headers = array_merge(...$responses->map->headers);
+
+        foreach ($headers as $name => $header) {
+            if ($responses->contains(fn (Response $response) => ! array_key_exists($name, $response->headers))) {
+                $headers[$name] = $this->makeHeaderOptional($header);
+            }
+        }
+
+        return $headers;
+    }
+
+    private function makeHeaderOptional(Header|Reference $header): Header|Reference
+    {
+        if ($header instanceof Reference) {
+            $resolvedHeader = $header->resolve();
+
+            if (! $resolvedHeader instanceof Header) {
+                return $header;
+            }
+
+            $header = $resolvedHeader;
+        }
+
+        return (clone $header)->setRequired(null);
     }
 
     /**

--- a/src/Support/TypeToSchemaExtensions/StreamedResponseToSchema.php
+++ b/src/Support/TypeToSchemaExtensions/StreamedResponseToSchema.php
@@ -90,8 +90,9 @@ class StreamedResponseToSchema extends TypeToSchemaExtension
             ? $attributeMimeType
             : null;
 
-        return $attributeMimeType
+        return ($this->isServerSentEventsResponse($type) ? $attributeMimeType : null)
             ?: $this->guessMimeTypeFromHeaders($type->templateTypes[2 /* THeaders */])
+            ?: $attributeMimeType
             ?: ($type->isInstanceOf(StreamedJsonResponse::class) ? 'application/json' : self::$defaultMimeType)
             ?: self::$defaultMimeType;
     }
@@ -134,7 +135,13 @@ class StreamedResponseToSchema extends TypeToSchemaExtension
             return $schema;
         }
 
-        return new StringType;
+        $stringType = new StringType;
+
+        if (! in_array($this->getContentType($type), BinaryFileResponseToSchema::$nonBinaryMimeTypes)) {
+            $stringType->format('binary');
+        }
+
+        return $stringType;
     }
 
     private function makeExample(Generic $type): ?string

--- a/tests/Support/OperationExtensions/ResponseExtensionTest.php
+++ b/tests/Support/OperationExtensions/ResponseExtensionTest.php
@@ -49,6 +49,7 @@ it('combines responses with different content types', function () {
     expect($response = $openApiDocument['paths']['/test']['get']['responses'][200])
         ->not->toBeNull()
         ->and($response['headers'])->toHaveKey('Content-Disposition')
+        ->and($response['headers']['Content-Disposition'])->not->toHaveKey('required')
         ->and($response['content'])->toBe([
             'application/pdf' => ['schema' => ['type' => 'string', 'format' => 'binary']],
             'application/json' => [
@@ -71,6 +72,24 @@ class MultipleMimes_ResponseExtensionTest_Controller
         }
 
         return response()->download('data.pdf');
+    }
+}
+
+it('marks streamed response headers optional when another same-status response is not streamed', function () {
+    $openApiDocument = generateForRoute(fn () => RouteFacade::get('api/test', PartiallyStreamed_ResponseExtensionTest_Controller::class));
+
+    expect($openApiDocument['paths']['/test']['get']['responses'][200]['headers']['Transfer-Encoding'])
+        ->not->toHaveKey('required');
+});
+class PartiallyStreamed_ResponseExtensionTest_Controller
+{
+    public function __invoke()
+    {
+        if (foobar()) {
+            return response()->stream(fn () => null);
+        }
+
+        return response()->json(['foo' => 'bar']);
     }
 }
 

--- a/tests/Support/TypeToSchemaExtensions/StreamedResponseToSchemaTest.php
+++ b/tests/Support/TypeToSchemaExtensions/StreamedResponseToSchemaTest.php
@@ -8,7 +8,15 @@ use Dedoc\Scramble\OpenApiContext;
 use Dedoc\Scramble\Support\Generator\Components;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\TypeTransformer;
+use Dedoc\Scramble\Support\Type\ArrayItemType_;
+use Dedoc\Scramble\Support\Type\Generic;
+use Dedoc\Scramble\Support\Type\KeyedArrayType;
+use Dedoc\Scramble\Support\Type\Literal\LiteralIntegerType;
+use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
+use Dedoc\Scramble\Support\Type\StringType as InferStringType;
 use Dedoc\Scramble\Support\TypeToSchemaExtensions\StreamedResponseToSchema;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 beforeEach(function () {
     $this->components = new Components;
@@ -124,6 +132,107 @@ it('transforms plain streamed type to response', function () {
                 'required' => true,
                 'schema' => ['type' => 'string', 'enum' => ['chunked']],
             ],
+        ],
+    ]);
+});
+
+it('documents a streamed download with a binary content type', function () {
+    $type = new Generic(StreamedResponse::class, [
+        new InferStringType,
+        new LiteralIntegerType(200),
+        new KeyedArrayType([
+            new ArrayItemType_(
+                'Content-Type',
+                new LiteralStringType('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
+            ),
+        ]),
+    ]);
+
+    $response = $this->transformer->toResponse($type);
+
+    expect($response->toArray())->toBeSameJson([
+        'description' => '',
+        'content' => [
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => [
+                'schema' => [
+                    'type' => 'string',
+                    'format' => 'binary',
+                ],
+            ],
+        ],
+        'headers' => [
+            'Transfer-Encoding' => [
+                'required' => true,
+                'schema' => ['type' => 'string', 'enum' => ['chunked']],
+            ],
+        ],
+    ]);
+});
+
+it('documents Storage streamed file responses as binary', function (string $expression) {
+    $type = getStatementType($expression);
+
+    expect($type->toString())->toBe(StreamedResponse::class.'<string, int(200), array{Content-Type: string(application/vnd.openxmlformats-officedocument.spreadsheetml.sheet)}>');
+
+    $response = $this->transformer->toResponse($type);
+
+    expect($response->toArray())->toBeSameJson([
+        'description' => '',
+        'content' => [
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => [
+                'schema' => [
+                    'type' => 'string',
+                    'format' => 'binary',
+                ],
+            ],
+        ],
+        'headers' => [
+            'Transfer-Encoding' => [
+                'required' => true,
+                'schema' => ['type' => 'string', 'enum' => ['chunked']],
+            ],
+        ],
+    ]);
+})->with([
+    'download' => Storage::class."::download(\$pathToSpreadSheet, 'device_export_'.now()->format('Ymd_His').'.xlsx', ['Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'])",
+    'disk download' => Storage::class."::disk()->download(\$pathToSpreadSheet, 'device_export_'.now()->format('Ymd_His').'.xlsx', ['Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'])",
+    'response' => Storage::class."::response(\$pathToSpreadSheet, 'device_export_'.now()->format('Ymd_His').'.xlsx', ['Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'])",
+    'serve' => Storage::class."::serve(\$request, \$pathToSpreadSheet, 'device_export_'.now()->format('Ymd_His').'.xlsx', ['Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'])",
+]);
+
+it('infers Storage response MIME type from file arguments', function (string $expression, string $contentType) {
+    $type = getStatementType($expression);
+
+    expect($type->getAttribute('mimeType'))->toBe($contentType);
+
+    $content = $this->transformer->toResponse($type)->toArray()['content'];
+
+    expect($content)->toHaveKey($contentType)
+        ->and($content[$contentType]['schema'])->toBe([
+            'type' => 'string',
+            'format' => 'binary',
+        ]);
+})->with([
+    'path' => [
+        Storage::class."::download('exports/report.xlsx')",
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ],
+    'name fallback' => [
+        Storage::class."::download(\$path, 'report.pdf')",
+        'application/pdf',
+    ],
+]);
+
+it('prefers an explicit Storage response content type over the file extension', function () {
+    $type = getStatementType(
+        Storage::class."::download('exports/report.xlsx', headers: ['Content-Type' => 'text/csv'])",
+    );
+
+    $content = $this->transformer->toResponse($type)->toArray()['content'];
+
+    expect($content)->toBe([
+        'text/csv' => [
+            'schema' => ['type' => 'string'],
         ],
     ]);
 });


### PR DESCRIPTION
fixes #1224 
  
Adds out-of-the-box inference for `Storage::download()` responses, including content type headers. Streamed XLSX downloads are now documented as `string<binary>`, while JSON and CSV branches remain correctly typed.

When both streamed and not streamed responses returned, ensures `Transfer-Encoding` header is optional.