### PR TITLE
Add PHP's Deprecated attribute support

### DIFF
--- a/src/Support/OperationExtensions/DeprecationExtension.php
+++ b/src/Support/OperationExtensions/DeprecationExtension.php
@@ -9,6 +9,9 @@ use Dedoc\Scramble\Support\PhpDoc;
 use Dedoc\Scramble\Support\RouteInfo;
 use Illuminate\Support\Str;
 use PHPStan\PhpDocParser\Ast\PhpDoc\DeprecatedTagValueNode;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionFunctionAbstract;
 use ReflectionMethod;
 
 /**
@@ -30,23 +33,45 @@ class DeprecationExtension extends OperationExtension
             ? $this->getClassDeprecatedTagValues($reflectionAction->getDeclaringClass()->getName())
             : [];
         $deprecatedTags = $routeInfo->phpDoc()->getDeprecatedTagValues();
+        $deprecatedClassAttributes = $reflectionAction instanceof ReflectionMethod
+            ? $this->getDeprecatedAttributeDescriptions($reflectionAction->getDeclaringClass())
+            : [];
+        $deprecatedAttributes = $this->getDeprecatedAttributeDescriptions($reflectionAction);
 
         // Skip if no deprecations found
-        if (! $deprecatedClassTags && ! $deprecatedTags) {
+        if (! $deprecatedClassTags && ! $deprecatedTags && ! $deprecatedClassAttributes && ! $deprecatedAttributes) {
             return;
         }
 
-        $description = Str::of($this->generateDescription($deprecatedClassTags));
+        $description = Str::of($this->generateDescription($deprecatedClassTags, $deprecatedClassAttributes));
 
         if ($description->isNotEmpty()) {
             $description = $description->append("\n\n");
         }
 
-        $description = $description->append($this->generateDescription($deprecatedTags));
+        $description = $description->append($this->generateDescription($deprecatedTags, $deprecatedAttributes));
 
         $operation
             ->description((string) $description)
             ->deprecated(true);
+    }
+
+    /**
+     * @param  ReflectionClass<object>|ReflectionFunctionAbstract  $reflection
+     * @return array<string>
+     */
+    private function getDeprecatedAttributeDescriptions(ReflectionClass|ReflectionFunctionAbstract $reflection): array
+    {
+        return array_map(function (ReflectionAttribute $attribute) {
+            $arguments = $attribute->getArguments();
+            $message = $arguments['message'] ?? $arguments[0] ?? null;
+            $since = $arguments['since'] ?? $arguments[1] ?? null;
+
+            return implode(' ', array_filter(
+                [$since, $message],
+                fn ($argument) => is_string($argument) && $argument !== '',
+            ));
+        }, $reflection->getAttributes('Deprecated'));
     }
 
     protected function isExplicitlyMarkedNotDeprecated(RouteInfo $routeInfo): bool
@@ -72,9 +97,16 @@ class DeprecationExtension extends OperationExtension
 
     /**
      * @param  array<DeprecatedTagValueNode>  $deprecatedTagValues
+     * @param  array<string>  $deprecatedAttributeDescriptions
      */
-    private function generateDescription(array $deprecatedTagValues): string
+    private function generateDescription(array $deprecatedTagValues, array $deprecatedAttributeDescriptions): string
     {
-        return implode("\n", array_map(fn ($tag) => $tag->description, $deprecatedTagValues));
+        return implode("\n", array_filter(
+            [
+                ...array_map(fn ($tag) => $tag->description, $deprecatedTagValues),
+                ...$deprecatedAttributeDescriptions,
+            ],
+            fn ($description) => $description !== '',
+        ));
     }
 }

--- a/tests/Support/OperationExtensions/DeprecationExtensionTest.php
+++ b/tests/Support/OperationExtensions/DeprecationExtensionTest.php
@@ -45,6 +45,44 @@ class Deprecated_Description_ResponseExtensionTest_Controller
     }
 }
 
+it('deprecated attribute sets key and description', function () {
+    $openApiDocument = generateForRoute(function () {
+        return RouteFacade::get('api/test', [Deprecated_Attribute_ResponseExtensionTest_Controller::class, 'deprecated']);
+    });
+
+    expect($openApiDocument['paths']['/test']['get'])
+        ->toHaveKey('description', '1.0.0 Use replacement instead')
+        ->toHaveKey('deprecated', true);
+});
+
+class Deprecated_Attribute_ResponseExtensionTest_Controller
+{
+    #[\Deprecated(message: 'Use replacement instead', since: '1.0.0')]
+    public function deprecated()
+    {
+        return false;
+    }
+}
+
+it('deprecated attribute without arguments sets deprecation key', function () {
+    $openApiDocument = generateForRoute(function () {
+        return RouteFacade::get('api/test', [Deprecated_Attribute_Without_Arguments_ResponseExtensionTest_Controller::class, 'deprecated']);
+    });
+
+    expect($openApiDocument['paths']['/test']['get'])
+        ->not()->toHaveKey('description')
+        ->toHaveKey('deprecated', true);
+});
+
+class Deprecated_Attribute_Without_Arguments_ResponseExtensionTest_Controller
+{
+    #[\Deprecated]
+    public function deprecated()
+    {
+        return false;
+    }
+}
+
 it('deprecated class with description sets keys', function () {
     $openApiDocument = generateForRoute(function () {
         return RouteFacade::get('api/test', [Deprecated_Class_Description_ResponseExtensionTest_Controller::class, 'deprecated']);


### PR DESCRIPTION
Adds support for `#[\Deprecated]` on API endpoints and preserves the `since` and `message` values in the operation description.

fixes #1220
