### PR TITLE
Preserve pagination metadata for resource collection JSON responses

### DIFF
--- a/src/Support/InferExtensions/JsonResourceExtension.php
+++ b/src/Support/InferExtensions/JsonResourceExtension.php
@@ -34,8 +34,10 @@ use Dedoc\Scramble\Support\Type\StringType;
 use Dedoc\Scramble\Support\Type\Type;
 use Dedoc\Scramble\Support\Type\Union;
 use Dedoc\Scramble\Support\Type\UnknownType;
+use Dedoc\Scramble\Support\TypeManagers\ResourceCollectionTypeManager;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Http\Resources\Json\ResourceResponse;
 use Illuminate\Http\Resources\MergeValue;
 use Illuminate\Http\Resources\MissingValue;
@@ -59,7 +61,9 @@ class JsonResourceExtension implements MethodReturnTypeExtension, PropertyTypeEx
                 : null,
 
             'response', 'toResponse' => new Generic(JsonResponse::class, [
-                new Generic(ResourceResponse::class, [$event->getInstance()]),
+                $event->getInstance()->isInstanceOf(ResourceCollection::class)
+                    ? ResourceCollectionTypeManager::make($event->getInstance())->getResponseType()
+                    : new Generic(ResourceResponse::class, [$event->getInstance()]),
                 new UnknownType,
                 new ArrayType,
             ]),

--- a/tests/Support/TypeToSchemaExtensions/AnonymousResourceCollectionTypeToSchemaTest.php
+++ b/tests/Support/TypeToSchemaExtensions/AnonymousResourceCollectionTypeToSchemaTest.php
@@ -8,6 +8,7 @@ use Dedoc\Scramble\OpenApiContext;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\TypeTransformer;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -51,6 +52,27 @@ it('documents inferred pagination response', function () {
         ->and($schema['properties'])
         ->toHaveKeys(['data', 'meta', 'links']);
 });
+
+it('documents inferred pagination response converted to a JsonResponse', function () {
+    $openApiDocument = generateForRoute(fn () => Route::get('test', [JsonResponsePagination_AnonymousResourceCollectionTypeToSchemaTestController::class, 'index']));
+
+    expect($responses = $openApiDocument['paths']['/test']['get']['responses'])
+        ->toHaveKey(200)
+        ->and($schema = $responses[200]['content']['application/json']['schema'])
+        ->toHaveKeys(['type', 'properties'])
+        ->and($schema['properties'])
+        ->toHaveKeys(['data', 'meta', 'links']);
+});
+
+class JsonResponsePagination_AnonymousResourceCollectionTypeToSchemaTestController
+{
+    public function index(Request $request): JsonResponse
+    {
+        return UserResource_AnonymousResourceCollectionTypeToSchemaTest::collection(
+            User_AnonymousResourceCollectionTypeToSchemaTest::query()->paginate()
+        )->toResponse($request);
+    }
+}
 
 it('documents paginated response from service builder union chain', function () {
     $openApiDocument = generateForRoute(fn () => Route::get('test', ServiceBuilderPagination_AnonymousResourceCollectionTypeToSchemaTestController::class));


### PR DESCRIPTION
fixes #1250


Fix pagination schema inference when `response()` or `toResponse()` is called on a paginated resource collection. 