### PR TITLE
Infer arithmetic, concat, and clone instead of unknown

### DIFF
--- a/src/Infer/Flow/ExpressionTypeInferrer.php
+++ b/src/Infer/Flow/ExpressionTypeInferrer.php
@@ -12,6 +12,7 @@ use Dedoc\Scramble\Infer\SimpleTypeGetters\ConstFetchTypeGetter;
 use Dedoc\Scramble\Infer\SimpleTypeGetters\ScalarTypeGetter;
 use Dedoc\Scramble\Support\Type\ArrayItemType_;
 use Dedoc\Scramble\Support\Type\ArrayType;
+use Dedoc\Scramble\Support\Type\BinaryOpType;
 use Dedoc\Scramble\Support\Type\BooleanType;
 use Dedoc\Scramble\Support\Type\CallableStringType;
 use Dedoc\Scramble\Support\Type\CoalesceType;
@@ -96,6 +97,18 @@ class ExpressionTypeInferrer
             || $expr instanceof Expr\BinaryOp\GreaterOrEqual
             || $expr instanceof Expr\BinaryOp\Smaller
             || $expr instanceof Expr\BinaryOp\SmallerOrEqual => new BooleanType,
+            $expr instanceof Expr\BinaryOp\Plus
+            || $expr instanceof Expr\BinaryOp\Minus
+            || $expr instanceof Expr\BinaryOp\Mul
+            || $expr instanceof Expr\BinaryOp\Div
+            || $expr instanceof Expr\BinaryOp\Mod
+            || $expr instanceof Expr\BinaryOp\Pow
+            || $expr instanceof Expr\BinaryOp\Concat => new BinaryOpType(
+                $this->infer($expr->left, $variableTypeGetter),
+                $this->infer($expr->right, $variableTypeGetter),
+                $expr->getOperatorSigil(),
+            ),
+            $expr instanceof Expr\Clone_ => $this->infer($expr->expr, $variableTypeGetter),
             $expr instanceof Expr\BooleanNot => (new BooleanNotTypeGetter)($expr),
             default => null,
         };

--- a/src/Infer/Services/ReferenceTypeResolver.php
+++ b/src/Infer/Services/ReferenceTypeResolver.php
@@ -58,8 +58,6 @@ class ReferenceTypeResolver
 
     public function resolve(Scope $scope, Type $type): Type
     {
-        $originalType = $type;
-
         $resolvedType = RecursionGuard::run(
             $type,
             fn () => (new TypeWalker)->map($type, fn (Type $t) => $this->doResolve($t, $type, $scope)),
@@ -67,7 +65,7 @@ class ReferenceTypeResolver
         );
 
         // Type finalization: removing duplicates from union, unpacking array items (inside `replace`), calling resolving extensions.
-        return $this->finalizeType($resolvedType, $originalType);
+        return $this->finalizeType($resolvedType);
     }
 
     private function doResolve(Type $t, Type $type, Scope $scope): Type
@@ -191,7 +189,7 @@ class ReferenceTypeResolver
         });
     }
 
-    private function finalizeType(Type $type, Type $originalType): Type
+    private function finalizeType(Type $type): Type
     {
         $attributes = $type->attributes();
 
@@ -203,8 +201,7 @@ class ReferenceTypeResolver
 
         return $traverser
             ->traverse($type)
-            ->mergeAttributes($attributes)
-            ->setOriginal($originalType);
+            ->mergeAttributes($attributes);
     }
 
     private function resolveConstFetchReferenceType(Scope $scope, ConstFetchReferenceType $type): Type

--- a/src/Infer/Services/UnionNormalizingTypeVisitor.php
+++ b/src/Infer/Services/UnionNormalizingTypeVisitor.php
@@ -16,7 +16,6 @@ class UnionNormalizingTypeVisitor extends AbstractTypeVisitor
         }
 
         return TypeHelper::mergeTypes(...$type->types)
-            ->setOriginal($type->getOriginal())
             ->mergeAttributes($type->attributes())
             ->widen();
     }

--- a/src/Support/InferExtensions/Concerns/GuessesMimeTypeFromFileType.php
+++ b/src/Support/InferExtensions/Concerns/GuessesMimeTypeFromFileType.php
@@ -5,7 +5,6 @@ namespace Dedoc\Scramble\Support\InferExtensions\Concerns;
 use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
 use Dedoc\Scramble\Support\Type\Type;
 use Dedoc\Scramble\Support\Type\TypeWalker;
-use Dedoc\Scramble\Support\Type\Union;
 use League\MimeTypeDetection\ExtensionMimeTypeDetector;
 
 trait GuessesMimeTypeFromFileType
@@ -24,7 +23,7 @@ trait GuessesMimeTypeFromFileType
     protected function guessFileNameFromType(Type $fileType): ?string
     {
         $stringLiterals = (new TypeWalker)->findAll(
-            Union::wrap(...array_filter([$fileType->getOriginal(), $fileType])),
+            $fileType,
             fn (Type $type) => $type instanceof LiteralStringType,
         );
 

--- a/src/Support/Type/AbstractType.php
+++ b/src/Support/Type/AbstractType.php
@@ -10,21 +10,6 @@ abstract class AbstractType implements Type
 {
     use TypeAttributes;
 
-    public ?Type $original = null;
-
-    /** @return $this */
-    public function setOriginal(?Type $original): self
-    {
-        $this->original = $original;
-
-        return $this;
-    }
-
-    public function getOriginal(): ?Type
-    {
-        return $this->original;
-    }
-
     public function nodes(): array
     {
         return [];

--- a/src/Support/Type/BinaryOpType.php
+++ b/src/Support/Type/BinaryOpType.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Dedoc\Scramble\Support\Type;
+
+use Dedoc\Scramble\Support\Type\Contracts\LateResolvingType;
+use Dedoc\Scramble\Support\Type\Literal\LiteralFloatType;
+use Dedoc\Scramble\Support\Type\Literal\LiteralIntegerType;
+use Throwable;
+
+class BinaryOpType extends AbstractType implements LateResolvingType
+{
+    public function __construct(
+        public Type $left,
+        public Type $right,
+        public string $operator,
+    ) {}
+
+    public function nodes(): array
+    {
+        return ['left', 'right'];
+    }
+
+    public function resolve(): Type
+    {
+        return $this->evaluate($this->left, $this->right);
+    }
+
+    public function isResolvable(): bool
+    {
+        return TypeHelper::isResolvable($this->left)
+            && TypeHelper::isResolvable($this->right);
+    }
+
+    public function isSame(Type $type)
+    {
+        return $type instanceof static
+            && $this->operator === $type->operator
+            && $this->left->isSame($type->left)
+            && $this->right->isSame($type->right);
+    }
+
+    public function toString(): string
+    {
+        return $this->left->toString().$this->operator.$this->right->toString();
+    }
+
+    private function evaluate(Type $left, Type $right): Type
+    {
+        $left = $this->unwrap($left);
+        $right = $this->unwrap($right);
+
+        if ($left instanceof Union || $right instanceof Union) {
+            $results = [];
+
+            foreach ($left instanceof Union ? $left->types : [$left] as $leftType) {
+                foreach ($right instanceof Union ? $right->types : [$right] as $rightType) {
+                    $results[] = $this->evaluate($leftType, $rightType);
+                }
+            }
+
+            return Union::wrap($results)->widen();
+        }
+
+        if ($this->operator === '.') {
+            return ConcatenatedStringType::fromParts([$left, $right]);
+        }
+
+        return $this->evaluateArithmetic($left, $right);
+    }
+
+    private function unwrap(Type $type): Type
+    {
+        if ($type instanceof TemplateType && $type->is) {
+            return $this->unwrap($type->is);
+        }
+
+        return $type;
+    }
+
+    private function evaluateArithmetic(Type $left, Type $right): Type
+    {
+        $leftNumber = $this->literalNumber($left);
+        $rightNumber = $this->literalNumber($right);
+
+        if ($leftNumber !== null && $rightNumber !== null) {
+            $value = $this->applyOperator($leftNumber, $rightNumber);
+
+            if ($value !== null) {
+                return is_int($value)
+                    ? new LiteralIntegerType($value)
+                    : new LiteralFloatType($value);
+            }
+        }
+
+        $leftIsInt = $left instanceof IntegerType;
+        $rightIsInt = $right instanceof IntegerType;
+        $leftIsFloat = $left instanceof FloatType;
+        $rightIsFloat = $right instanceof FloatType;
+
+        if (! ($leftIsInt || $leftIsFloat) || ! ($rightIsInt || $rightIsFloat)) {
+            return new UnknownType;
+        }
+
+        if ($this->operator === '%') {
+            return new IntegerType;
+        }
+
+        if ($this->operator === '/' || $this->operator === '**') {
+            if ($leftIsInt && $rightIsInt) {
+                return Union::wrap([new IntegerType, new FloatType]);
+            }
+
+            return new FloatType;
+        }
+
+        if ($leftIsFloat || $rightIsFloat) {
+            return new FloatType;
+        }
+
+        return new IntegerType;
+    }
+
+    private function applyOperator(int|float $left, int|float $right): int|float|null
+    {
+        try {
+            return match ($this->operator) {
+                '+' => $left + $right,
+                '-' => $left - $right,
+                '*' => $left * $right,
+                '/' => $right == 0 ? null : $left / $right,
+                '%' => $right == 0 ? null : $left % $right,
+                '**' => $left ** $right,
+                default => null,
+            };
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function literalNumber(Type $type): int|float|null
+    {
+        if ($type instanceof LiteralIntegerType) {
+            return $type->value;
+        }
+
+        if ($type instanceof LiteralFloatType) {
+            return $type->value;
+        }
+
+        return null;
+    }
+}

--- a/src/Support/Type/ConcatenatedStringType.php
+++ b/src/Support/Type/ConcatenatedStringType.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Dedoc\Scramble\Support\Type;
+
+use Dedoc\Scramble\Support\Type\Contracts\LiteralType;
+use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
+
+class ConcatenatedStringType extends StringType
+{
+    /**
+     * @param  Type[]  $parts
+     */
+    private function __construct(public array $parts) {}
+
+    /**
+     * @param  Type[]  $parts
+     */
+    public static function fromParts(array $parts): Type
+    {
+        $flattened = [];
+
+        foreach ($parts as $part) {
+            if ($part instanceof self) {
+                array_push($flattened, ...$part->parts);
+
+                continue;
+            }
+
+            $flattened[] = $part;
+        }
+
+        $collapsed = [];
+
+        foreach ($flattened as $part) {
+            $literal = self::stringifyLiteral($part);
+            $part = $literal !== null ? new LiteralStringType($literal) : $part;
+
+            $lastIndex = array_key_last($collapsed);
+            $last = $lastIndex !== null ? $collapsed[$lastIndex] : null;
+
+            if ($part instanceof LiteralStringType && $last instanceof LiteralStringType) {
+                $collapsed[$lastIndex] = new LiteralStringType($last->value.$part->value);
+
+                continue;
+            }
+
+            $collapsed[] = $part;
+        }
+
+        if (count($collapsed) === 1) {
+            return $collapsed[0];
+        }
+
+        return new self($collapsed);
+    }
+
+    public function nodes(): array
+    {
+        return ['parts'];
+    }
+
+    public function isSame(Type $type)
+    {
+        if (! $type instanceof static || count($this->parts) !== count($type->parts)) {
+            return false;
+        }
+
+        foreach ($this->parts as $i => $part) {
+            if (! $part->isSame($type->parts[$i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function toString(): string
+    {
+        $body = '';
+
+        foreach ($this->parts as $part) {
+            if ($part instanceof LiteralStringType) {
+                $body .= self::escapeTemplateLiteral($part->value);
+
+                continue;
+            }
+
+            $body .= '${'.$part->toString().'}';
+        }
+
+        return 'string(`'.$body.'`)';
+    }
+
+    private static function stringifyLiteral(Type $type): ?string
+    {
+        if (! $type instanceof LiteralType) {
+            return null;
+        }
+
+        $value = $type->getValue();
+
+        return is_scalar($value) ? (string) $value : null;
+    }
+
+    private static function escapeTemplateLiteral(string $value): string
+    {
+        return str_replace(
+            ['\\', '`', '${'],
+            ['\\\\', '\\`', '\\${'],
+            $value,
+        );
+    }
+}

--- a/src/Support/Type/Type.php
+++ b/src/Support/Type/Type.php
@@ -42,11 +42,6 @@ interface Type
 
     public function getMethodDefinition(string $methodName, Scope $scope = new GlobalScope): ?FunctionLikeDefinition;
 
-    /** @return $this */
-    public function setOriginal(?Type $original): self;
-
-    public function getOriginal(): ?Type;
-
     public function widen(): Type;
 
     /**

--- a/src/Support/Type/TypeHelper.php
+++ b/src/Support/Type/TypeHelper.php
@@ -352,6 +352,15 @@ class TypeHelper
         {
             public int $count = 0;
 
+            public function enter(Type $type): Type|int|null
+            {
+                if ($type instanceof ConcatenatedStringType) {
+                    return TypeVisitor::DONT_TRAVERSE_CHILDREN;
+                }
+
+                return null;
+            }
+
             public function leave(Type $type): ?Type
             {
                 if (

--- a/src/Support/Type/TypeWidener.php
+++ b/src/Support/Type/TypeWidener.php
@@ -92,7 +92,7 @@ class TypeWidener
 
         // string|'wow' -> string
         if (
-            ($a instanceof StringType && ! $a instanceof LiteralStringType)
+            $a::class === StringType::class
             && $b instanceof LiteralStringType
         ) {
             return new StringType;

--- a/tests/ComplexInferTypesTest.php
+++ b/tests/ComplexInferTypesTest.php
@@ -68,6 +68,35 @@ EOD;
         ->toBe('array{foo: string(bar)}');
 });
 
+it('infers arithmetic of int-returning method calls in array items', function () {
+    $code = <<<'EOD'
+<?php
+class Foo {
+    public function price(): int
+    {
+        return 100;
+    }
+    public function fee(): int
+    {
+        return 5;
+    }
+    public function toArray(): array
+    {
+        return [
+            'price' => $this->price(),
+            'fee' => $this->fee(),
+            'total' => $this->price() + $this->fee(),
+        ];
+    }
+}
+EOD;
+
+    $result = analyzeFile($code);
+
+    expect($result->getClassDefinition('Foo')->getMethodCallType('toArray')->toString())
+        ->toBe('array{price: int(100), fee: int(5), total: int(105)}');
+});
+
 /*
  * When int, float, bool, return type annotated, there is no point in using types from return
  * as there is no more useful information about the function can be extracted.

--- a/tests/Infer/Services/TemplateTypesSolverTest.php
+++ b/tests/Infer/Services/TemplateTypesSolverTest.php
@@ -62,7 +62,7 @@ it('accepts this parameter', function () {
         ->resolve(
             new GlobalScope,
             new MethodCallReferenceType($type, 'callCallback', [
-                getStatementType('fn ($d) => $d->getT()')->getOriginal(),
+                getUnresolvedStatementType('fn ($d) => $d->getT()'),
             ])
         );
 

--- a/tests/Infer/SimpleExpressionsTest.php
+++ b/tests/Infer/SimpleExpressionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Dedoc\Scramble\Support\Type\IntegerType;
+
 it(
     'infers simple types',
     fn ($statement, $expectedType) => expect(getStatementType($statement)->toString())->toBe($expectedType),
@@ -29,11 +31,68 @@ it(
 ]);
 
 it(
+    'infers arithmetic operations',
+    fn ($statement, $expectedType) => expect(getStatementType($statement)->toString())->toBe($expectedType),
+)->with([
+    ['1 + 2', 'int(3)'],
+    ['1 - 2', 'int(-1)'],
+    ['2 * 3', 'int(6)'],
+    ['5 % 2', 'int(1)'],
+    ['2 ** 3', 'int(8)'],
+]);
+
+it(
+    'infers concatenation',
+    fn ($statement, $expectedType) => expect(getStatementType($statement)->toString())->toBe($expectedType),
+)->with([
+    ['"foo" . "bar"', 'string(foobar)'],
+    ['"foo" . 1', 'string(foo1)'],
+    ['"foo" . $a', 'string(`foo${unknown}`)'],
+    ['$a . "bar"', 'string(`${unknown}bar`)'],
+    ['$a . $b', 'string(`${unknown}${unknown}`)'],
+    ['"foo" . $a . "bar" . "baz"', 'string(`foo${unknown}barbaz`)'],
+    ['\'foo`bar\' . $a', 'string(`foo\\`bar${unknown}`)'],
+    ['\'${x}\' . $a', 'string(`\\${x}${unknown}`)'],
+]);
+
+it('infers arithmetic of int-returning method calls', function () {
+    $foo = Foo_SimpleExpressionsTest::class;
+
+    expect(getStatementType("(new {$foo})->price() + (new {$foo})->fee()"))
+        ->toBeInstanceOf(IntegerType::class);
+});
+
+it('infers clone as the type of the cloned expression', function () {
+    $expression = 'new '.Foo_SimpleExpressionsTest::class;
+
+    expect(getStatementType("clone {$expression}")->toString())
+        ->toBe(getStatementType($expression)->toString());
+});
+
+it('infers method calls on cloned objects', function () {
+    expect(getStatementType('(clone new '.Foo_SimpleExpressionsTest::class.')->price()'))
+        ->toBeInstanceOf(IntegerType::class);
+});
+
+it(
     'doesnt fail on dynamic static fetch',
     fn ($statement, $expectedType) => expect(getStatementType($statement)->toString())->toBe($expectedType),
 )->with([
     ['Something::{$v}', 'unknown'],
 ]);
+
+class Foo_SimpleExpressionsTest
+{
+    public function price(): int
+    {
+        return 100;
+    }
+
+    public function fee(): int
+    {
+        return 5;
+    }
+}
 
 // @todo
 // casts test (int, float, bool, string)

--- a/tests/InferExtensions/ModelExtensionTest.php
+++ b/tests/InferExtensions/ModelExtensionTest.php
@@ -637,6 +637,11 @@ it('preserves custom query builder type when query is overridden', function () {
         ->toBeInstanceOf(IntegerType::class);
 });
 
+it('preserves count type when the query is cloned', function () {
+    expect(getStatementType('(clone '.ModelWithOverriddenQuery_ModelExtensionTest::class.'::query())->count()'))
+        ->toBeInstanceOf(IntegerType::class);
+});
+
 class ModelWithOverriddenQuery_ModelExtensionTest extends Model
 {
     /** @return FooBuilder_ModelExtensionTest<static> */

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -239,6 +239,11 @@ function getStatementType(string $statement, array $extensions = []): ?Type
     return analyzeFile('<?php', $extensions)->getExpressionType($statement);
 }
 
+function getUnresolvedStatementType(string $statement, array $extensions = []): ?Type
+{
+    return analyzeFile('<?php', $extensions)->getUnresolvedExpressionType($statement);
+}
+
 function getVariableTypeAfter(string $body, string $var, ?ReferenceTypeResolver $referenceTypeResolver = null): Type
 {
     $index = app(Index::class);
@@ -263,8 +268,7 @@ function getVariableTypeAfter(string $body, string $var, ?ReferenceTypeResolver 
     );
 
     return ($referenceTypeResolver ?? new ReferenceTypeResolver($index))
-        ->resolve($scope, $unresolvedType)
-        ->setOriginal($unresolvedType);
+        ->resolve($scope, $unresolvedType);
 }
 
 dataset('extendableTemplateTypes', [

--- a/tests/ResponsesInferTypesTest.php
+++ b/tests/ResponsesInferTypesTest.php
@@ -16,8 +16,8 @@ it('infers response factory expressions', function (string $expression, string $
     ['response()->json(status: 329)', 'Illuminate\Http\JsonResponse<array<mixed>, int(329), array<mixed>>'],
     ["response()->make('Hello')", 'Illuminate\Http\Response<string(Hello), int(200), array<mixed>>'],
     ["response()->download(base_path('/tmp/wow.txt'))", 'Symfony\Component\HttpFoundation\BinaryFileResponse<string, int(200), array<mixed>, string(attachment)>', [
-        'mimeType' => 'text/plain',
-        'contentDisposition' => 'attachment; filename=wow.txt',
+        'mimeType' => 'application/octet-stream',
+        'contentDisposition' => 'attachment',
     ]],
     ["response()->download('/tmp/wow.txt')", 'Symfony\Component\HttpFoundation\BinaryFileResponse<string(/tmp/wow.txt), int(200), array<mixed>, string(attachment)>', [
         'mimeType' => 'text/plain',

--- a/tests/Support/TypeToSchemaExtensions/StreamedResponseToSchemaTest.php
+++ b/tests/Support/TypeToSchemaExtensions/StreamedResponseToSchemaTest.php
@@ -221,6 +221,10 @@ it('infers Storage response MIME type from file arguments', function (string $ex
         Storage::class."::download(\$path, 'report.pdf')",
         'application/pdf',
     ],
+    'concatenated name' => [
+        Storage::class."::download(\$path, 'export_'.now()->format('Ymd').'.xlsx')",
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ],
 ]);
 
 it('prefers an explicit Storage response content type over the file extension', function () {

--- a/tests/Utils/AnalysisResult.php
+++ b/tests/Utils/AnalysisResult.php
@@ -13,6 +13,7 @@ use Dedoc\Scramble\Infer\Services\FileNameResolver;
 use Dedoc\Scramble\Infer\Services\ReferenceTypeResolver;
 use Dedoc\Scramble\Infer\TypeInferer;
 use Dedoc\Scramble\Infer\Visitors\PhpDocResolver;
+use Dedoc\Scramble\Support\Type\Type;
 use PhpParser;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
@@ -34,6 +35,23 @@ class AnalysisResult
 
     public function getExpressionType(string $code)
     {
+        [$scope, $unresolvedType] = $this->inferAssignedExpression($code);
+
+        return (new ReferenceTypeResolver($this->index))->resolve($scope, $unresolvedType);
+    }
+
+    public function getUnresolvedExpressionType(string $code)
+    {
+        [, $unresolvedType] = $this->inferAssignedExpression($code);
+
+        return $unresolvedType;
+    }
+
+    /**
+     * @return array{0: Scope, 1: Type}
+     */
+    private function inferAssignedExpression(string $code): array
+    {
         $code = '<?php $a = '.$code.';';
 
         $fileAst = (new PhpParser\ParserFactory)->createForHostVersion()->parse($code);
@@ -52,12 +70,13 @@ class AnalysisResult
         ));
         $traverser->traverse($fileAst);
 
-        $unresolvedType = $scope->getType(
-            new Node\Expr\Variable('a', [
-                'startLine' => INF,
-            ]),
-        );
-
-        return (new ReferenceTypeResolver($this->index))->resolve($scope, $unresolvedType)->setOriginal($unresolvedType);
+        return [
+            $scope,
+            $scope->getType(
+                new Node\Expr\Variable('a', [
+                    'startLine' => INF,
+                ]),
+            ),
+        ];
     }
 }


### PR DESCRIPTION
These expressions were falling through inference and becoming `UnknownType`, which OpenAPI treats as `string`. `$price + $fee` showed up as a string field; `clone $query` lost the query type.

Arithmetic now folds literals (`1 + 2` → `int(3)`) and otherwise follows PHP (`int + int` → `int`, a float operand → `float`, `/` and `**` of two ints → `int|float`). Concat of known literals still collapses (`"foo"."bar"` → `string(foobar)`). Mixed concat keeps a `ConcatenatedStringType` so leftover fragments stay visible (`"export_".now()->format('Ymd').".xlsx"` → `string(\`export_${string}.xlsx\`)`), which is enough to guess a download MIME from the extension. `clone` is the type of the cloned expression.

`getOriginal()` on types is gone. It only existed so MIME guessing could walk the pre-resolve tree; concatenated strings make that unnecessary. `base_path('file.txt')` no longer contributes a filename to MIME/disposition.

fixes #1256 