### PR TITLE
Infer model property types from PHPDocs without database access

### DIFF
--- a/src/Infer/DefinitionBuilders/ReflectionPropertyPhpDocTypeExtractor.php
+++ b/src/Infer/DefinitionBuilders/ReflectionPropertyPhpDocTypeExtractor.php
@@ -71,14 +71,73 @@ class ReflectionPropertyPhpDocTypeExtractor
     {
         $properties = [];
 
-        foreach ([
-            ...$this->classPhpDoc->getPropertyTagValues(),
-            ...$this->classPhpDoc->getPropertyReadTagValues(),
-        ] as $propertyTagValue) {
-            $properties[ltrim($propertyTagValue->propertyName, '$')] = PhpDocTypeHelper::toType($propertyTagValue->type);
+        foreach ($this->getPropertyTagsSources() as $phpDoc) {
+            foreach ([
+                ...$phpDoc->getPropertyTagValues(),
+                ...$phpDoc->getPropertyReadTagValues(),
+            ] as $propertyTagValue) {
+                $properties[ltrim($propertyTagValue->propertyName, '$')] = PhpDocTypeHelper::toType($propertyTagValue->type);
+            }
         }
 
         return $properties;
+    }
+
+    /**
+     * Property tags may be defined not only on the class itself, but also on the interfaces it implements
+     * and the traits it uses. Tags defined closer to the class win, so the sources are collected from the
+     * least to the most specific one: interfaces are mere contracts, traits are compiled into the class,
+     * and the class itself always has the final say.
+     *
+     * @return list<PhpDocNode>
+     */
+    private function getPropertyTagsSources(): array
+    {
+        $phpDocs = [];
+
+        foreach ($this->getInterfaces($this->classReflection) as $interfaceReflection) {
+            $phpDocs[] = $this->getClassPhpDoc($interfaceReflection);
+        }
+
+        foreach ($this->getTraits($this->classReflection) as $traitReflection) {
+            $phpDocs[] = $this->getClassPhpDoc($traitReflection);
+        }
+
+        $phpDocs[] = $this->classPhpDoc;
+
+        return $phpDocs;
+    }
+
+    /**
+     * Reflection returns all the implemented interfaces flattened in an unspecified order, so they are
+     * sorted by the number of interfaces they extend themselves, making an interface take precedence
+     * over the ones it inherits the tags from.
+     *
+     * @param  ReflectionClass<covariant object>  $classReflection
+     * @return list<ReflectionClass<object>>
+     */
+    private function getInterfaces(ReflectionClass $classReflection): array
+    {
+        $interfaces = array_values($classReflection->getInterfaces());
+
+        usort($interfaces, fn (ReflectionClass $a, ReflectionClass $b) => count($a->getInterfaces()) <=> count($b->getInterfaces()));
+
+        return $interfaces;
+    }
+
+    /**
+     * @param  ReflectionClass<covariant object>  $classReflection
+     * @return list<ReflectionClass<object>>
+     */
+    private function getTraits(ReflectionClass $classReflection): array
+    {
+        $traits = [];
+
+        foreach ($classReflection->getTraits() as $traitReflection) {
+            $traits = [...$traits, ...$this->getTraits($traitReflection), $traitReflection];
+        }
+
+        return $traits;
     }
 
     private function getVarType(PhpDocNode $phpDoc): ?Type

--- a/src/Support/InferExtensions/ModelExtension.php
+++ b/src/Support/InferExtensions/ModelExtension.php
@@ -42,9 +42,11 @@ use Dedoc\Scramble\Support\Type\Union;
 use Dedoc\Scramble\Support\Type\UnknownType;
 use Illuminate\Database\Eloquent\Attributes\UseResource;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use ReflectionClass;
+use ReflectionNamedType;
 use Throwable;
 
 class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension, StaticMethodReturnTypeExtension
@@ -84,6 +86,10 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
             ? $propertyType
             : null;
 
+        if ($annotatedType && $this->isRelationMethod($event->getInstance()->name, $event->getName())) {
+            return $annotatedType;
+        }
+
         if (! $this->hasProperty($event->getInstance(), $event->getName())) {
             return $annotatedType;
         }
@@ -109,6 +115,31 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
         }
 
         throw new \LogicException('Should not happen');
+    }
+
+    /**
+     * A relation is documented with the type of the related model, so an annotated relation needs no
+     * database introspection: the annotation already carries everything the schema would tell us, the
+     * nullability of the relation included. Only a declared return type is accepted as the signal here,
+     * as establishing it in any other way would need the very database this check exists to avoid.
+     */
+    private function isRelationMethod(string $modelClassName, string $name): bool
+    {
+        if (! class_exists($modelClassName)) {
+            return false;
+        }
+
+        $reflection = new ReflectionClass($modelClassName);
+
+        if (! $reflection->hasMethod($name)) {
+            return false;
+        }
+
+        $returnType = $reflection->getMethod($name)->getReturnType();
+
+        return $returnType instanceof ReflectionNamedType
+            && ! $returnType->isBuiltin()
+            && is_a($returnType->getName(), Relation::class, true);
     }
 
     private function refineAnnotatedType(?Type $annotatedType, Type $inferredType): Type

--- a/src/Support/InferExtensions/ModelExtension.php
+++ b/src/Support/InferExtensions/ModelExtension.php
@@ -42,11 +42,9 @@ use Dedoc\Scramble\Support\Type\Union;
 use Dedoc\Scramble\Support\Type\UnknownType;
 use Illuminate\Database\Eloquent\Attributes\UseResource;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use ReflectionClass;
-use ReflectionNamedType;
 use Throwable;
 
 class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension, StaticMethodReturnTypeExtension
@@ -55,6 +53,9 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
 
     /** @var array<string, mixed> */
     private array $cache = [];
+
+    /** @var array<string, Collection<string, mixed>> */
+    private array $castsCache = [];
 
     public function __construct(
         private ?DiagnosticsCollector $diagnostics = null,
@@ -86,12 +87,21 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
             ? $propertyType
             : null;
 
-        if ($annotatedType && $this->isRelationMethod($event->getInstance()->name, $event->getName())) {
-            return $annotatedType;
+        if ($annotatedType) {
+            return $this->refineAnnotatedTypeFromCasts($annotatedType, $event);
+        }
+
+        /*
+         * A property the model really declares is resolved from the class definition rather than from the
+         * schema, Eloquent's own internals such as `relations` among them. There is nothing to introspect
+         * for those, as a declared property shadows the magic attribute access a column would go through.
+         */
+        if (property_exists($event->getInstance()->name, $event->getName())) {
+            return null;
         }
 
         if (! $this->hasProperty($event->getInstance(), $event->getName())) {
-            return $annotatedType;
+            return null;
         }
 
         $info = $this->getModelInfo($event->getInstance());
@@ -101,53 +111,47 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
                 ?? $this->getAttributeTypeFromDbColumnType($attribute['type'], $attribute['driver'])
                 ?? new UnknownType("Virtual attribute ({$attribute['name']}) type inference not supported.");
 
-            $inferredType = $attribute['nullable']
+            return $attribute['nullable']
                 ? Union::wrap([$baseType, new NullType])
                 : $baseType;
-
-            return $this->refineAnnotatedType($annotatedType, $inferredType);
         }
 
         if ($relation = $info->get('relations')->get($event->getName())) {
-            $inferredType = $this->getRelationType($relation);
-
-            return $this->refineAnnotatedType($annotatedType, $inferredType);
+            return $this->getRelationType($relation);
         }
 
         throw new \LogicException('Should not happen');
     }
 
     /**
-     * A relation is documented with the type of the related model, so an annotated relation needs no
-     * database introspection: the annotation already carries everything the schema would tell us, the
-     * nullability of the relation included. Only a declared return type is accepted as the signal here,
-     * as establishing it in any other way would need the very database this check exists to avoid.
+     * An annotation is the more specific source of truth for a property, so the schema has nothing to add
+     * to it: the one thing that can still refine an annotation is the Eloquent casts, and those are
+     * declared on the model itself. Leaving the schema unread here is what keeps a fully annotated model
+     * documentable without a database at all.
      */
-    private function isRelationMethod(string $modelClassName, string $name): bool
+    private function refineAnnotatedTypeFromCasts(Type $annotatedType, PropertyFetchEvent $event): Type
     {
-        if (! class_exists($modelClassName)) {
-            return false;
-        }
+        $cast = $this->getModelCasts($event->getInstance())->get($event->getName());
 
-        $reflection = new ReflectionClass($modelClassName);
+        $inferredType = is_string($cast)
+            ? $this->getAttributeTypeFromEloquentCasts($cast, $event->scope)
+            : null;
 
-        if (! $reflection->hasMethod($name)) {
-            return false;
-        }
-
-        $returnType = $reflection->getMethod($name)->getReturnType();
-
-        return $returnType instanceof ReflectionNamedType
-            && ! $returnType->isBuiltin()
-            && is_a($returnType->getName(), Relation::class, true);
+        return $inferredType
+            ? $this->refineAnnotatedType($annotatedType, $inferredType)
+            : $annotatedType;
     }
 
-    private function refineAnnotatedType(?Type $annotatedType, Type $inferredType): Type
+    /**
+     * @return Collection<string, mixed>
+     */
+    private function getModelCasts(ObjectType $type): Collection
     {
-        if (! $annotatedType) {
-            return $inferredType;
-        }
+        return $this->castsCache[$type->name] ??= (new ModelInfo($type->name))->getCasts();
+    }
 
+    private function refineAnnotatedType(Type $annotatedType, Type $inferredType): Type
+    {
         return (new TypeRefiner)->refine($annotatedType, $inferredType);
     }
 

--- a/src/Support/InferExtensions/ModelExtension.php
+++ b/src/Support/InferExtensions/ModelExtension.php
@@ -139,7 +139,7 @@ class ModelExtension implements MethodReturnTypeExtension, PropertyTypeExtension
 
         return $inferredType
             ? $this->refineAnnotatedType($annotatedType, $inferredType)
-            : $annotatedType;
+            : $annotatedType->clone();
     }
 
     /**

--- a/src/Support/ResponseExtractor/ModelInfo.php
+++ b/src/Support/ResponseExtractor/ModelInfo.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
-use PDOException;
 use ReflectionClass;
 use ReflectionMethod;
 use SplFileObject;
@@ -40,8 +39,7 @@ class ModelInfo
     {
         $class = $this->qualifyModel($this->class);
 
-        $reflectionClass = new ReflectionClass($class);
-        if (! $reflectionClass->isInstantiable()) {
+        if (! $model = $this->newModelInstance()) {
             return collect([
                 'instance' => null,
                 'class' => $class,
@@ -51,10 +49,7 @@ class ModelInfo
             ]);
         }
 
-        /** @var Model $model */
-        $model = app()->make($class);
-
-        $tableMissing = $this->tableIsMissing($model);
+        $tableMissing = ! $model->getConnection()->getSchemaBuilder()->hasTable($model->getTable());
 
         return $this->displayJson(
             $model,
@@ -66,17 +61,28 @@ class ModelInfo
     }
 
     /**
-     * An unreachable database is treated the same way as a table that is yet to be created: the schema
-     * simply cannot be read, so the documentation gets built from the annotations and casts alone. This
-     * keeps the documentation generatable in environments without a database, such as CI.
+     * The Eloquent casts are declared on the model itself, so unlike the rest of the model information
+     * they can be read without touching the schema.
+     *
+     * @return \Illuminate\Support\Collection<string, mixed>
      */
-    private function tableIsMissing(Model $model): bool
+    public function getCasts()
     {
-        try {
-            return ! $model->getConnection()->getSchemaBuilder()->hasTable($model->getTable());
-        } catch (PDOException) {
-            return true;
+        return ($model = $this->newModelInstance())
+            ? $this->getCastsWithDates($model)
+            : collect();
+    }
+
+    private function newModelInstance(): ?Model
+    {
+        $class = $this->qualifyModel($this->class);
+
+        if (! (new ReflectionClass($class))->isInstantiable()) {
+            return null;
         }
+
+        /** @var Model */
+        return app()->make($class);
     }
 
     /**
@@ -259,11 +265,7 @@ class ModelInfo
             return false;
         }
 
-        try {
-            $columns = collect($foreignKeyModel->getConnection()->getSchemaBuilder()->getColumns($foreignKeyModel->getTable()));
-        } catch (PDOException) {
-            return false;
-        }
+        $columns = collect($foreignKeyModel->getConnection()->getSchemaBuilder()->getColumns($foreignKeyModel->getTable()));
 
         foreach ($foreignKeys as $foreignKey) {
             $column = $columns->firstWhere('name', Str::afterLast($foreignKey, '.'));

--- a/src/Support/ResponseExtractor/ModelInfo.php
+++ b/src/Support/ResponseExtractor/ModelInfo.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
+use PDOException;
 use ReflectionClass;
 use ReflectionMethod;
 use SplFileObject;
@@ -53,7 +54,7 @@ class ModelInfo
         /** @var Model $model */
         $model = app()->make($class);
 
-        $tableMissing = ! $model->getConnection()->getSchemaBuilder()->hasTable($model->getTable());
+        $tableMissing = $this->tableIsMissing($model);
 
         return $this->displayJson(
             $model,
@@ -62,6 +63,20 @@ class ModelInfo
             $this->getRelations($model),
             $tableMissing,
         );
+    }
+
+    /**
+     * An unreachable database is treated the same way as a table that is yet to be created: the schema
+     * simply cannot be read, so the documentation gets built from the annotations and casts alone. This
+     * keeps the documentation generatable in environments without a database, such as CI.
+     */
+    private function tableIsMissing(Model $model): bool
+    {
+        try {
+            return ! $model->getConnection()->getSchemaBuilder()->hasTable($model->getTable());
+        } catch (PDOException) {
+            return true;
+        }
     }
 
     /**
@@ -244,7 +259,11 @@ class ModelInfo
             return false;
         }
 
-        $columns = collect($foreignKeyModel->getConnection()->getSchemaBuilder()->getColumns($foreignKeyModel->getTable()));
+        try {
+            $columns = collect($foreignKeyModel->getConnection()->getSchemaBuilder()->getColumns($foreignKeyModel->getTable()));
+        } catch (PDOException) {
+            return false;
+        }
 
         foreach ($foreignKeys as $foreignKey) {
             $column = $columns->firstWhere('name', Str::afterLast($foreignKey, '.'));

--- a/tests/Infer/DefinitionBuilders/ReflectionPropertyPhpDocTypeExtractorTest.php
+++ b/tests/Infer/DefinitionBuilders/ReflectionPropertyPhpDocTypeExtractorTest.php
@@ -17,6 +17,23 @@ it('extracts reflection property types from phpdoc', function (string $property,
     'imported type' => ['importedType', ImportedModel::class],
     'imported class property type' => ['classImportedType', ImportedModel::class],
     'magic class property' => ['magicProperty', 'string'],
+    'interface property' => ['interfaceProperty', 'string'],
+    'parent interface property' => ['parentInterfaceProperty', 'boolean'],
+    'trait property' => ['traitProperty', 'int'],
+    'nested trait property' => ['nestedTraitProperty', 'float'],
+]);
+
+it('prioritizes class property PHPDoc over the one defined in interfaces and traits', function (string $property, string $expectedType) {
+    $extractor = new ReflectionPropertyPhpDocTypeExtractor(
+        new ReflectionClass(PhpDocPropertyTypes_ReflectionPropertyPhpDocTypeExtractorTest::class),
+    );
+
+    expect($extractor->getType($property)?->toString())->toBe($expectedType);
+})->with([
+    'class over trait and interface' => ['inheritedPrecedence', 'string'],
+    'trait over interface' => ['traitOverInterfacePrecedence', 'string'],
+    'trait over nested trait' => ['traitInheritancePrecedence', 'string'],
+    'interface over parent interface' => ['interfaceInheritancePrecedence', 'string'],
 ]);
 
 it('prioritizes class property PHPDoc over property and promoted parameter PHPDoc', function () {
@@ -29,14 +46,48 @@ it('prioritizes class property PHPDoc over property and promoted parameter PHPDo
 });
 
 /**
+ * @property-read bool $parentInterfaceProperty
+ * @property-read int $interfaceInheritancePrecedence
+ */
+interface PhpDocPropertyTypesParentInterface_ReflectionPropertyPhpDocTypeExtractorTest {}
+
+/**
+ * @property-read string $interfaceProperty
+ * @property-read int $inheritedPrecedence
+ * @property-read int $traitOverInterfacePrecedence
+ * @property-read string $interfaceInheritancePrecedence
+ */
+interface PhpDocPropertyTypesInterface_ReflectionPropertyPhpDocTypeExtractorTest extends PhpDocPropertyTypesParentInterface_ReflectionPropertyPhpDocTypeExtractorTest {}
+
+/**
+ * @property-read float $nestedTraitProperty
+ * @property-read int $traitInheritancePrecedence
+ */
+trait PhpDocPropertyTypesNestedTrait_ReflectionPropertyPhpDocTypeExtractorTest {}
+
+/**
+ * @property-read int $traitProperty
+ * @property-read bool $inheritedPrecedence
+ * @property-read string $traitOverInterfacePrecedence
+ * @property-read string $traitInheritancePrecedence
+ */
+trait PhpDocPropertyTypesTrait_ReflectionPropertyPhpDocTypeExtractorTest
+{
+    use PhpDocPropertyTypesNestedTrait_ReflectionPropertyPhpDocTypeExtractorTest;
+}
+
+/**
  * @property string $classProperty
  * @property-read bool $classPropertyRead
  * @property int $classPrecedence
  * @property ImportedModel $classImportedType
  * @property string $magicProperty
+ * @property-read string $inheritedPrecedence
  */
-class PhpDocPropertyTypes_ReflectionPropertyPhpDocTypeExtractorTest
+class PhpDocPropertyTypes_ReflectionPropertyPhpDocTypeExtractorTest implements PhpDocPropertyTypesInterface_ReflectionPropertyPhpDocTypeExtractorTest
 {
+    use PhpDocPropertyTypesTrait_ReflectionPropertyPhpDocTypeExtractorTest;
+
     public mixed $classProperty;
 
     public mixed $classPropertyRead;

--- a/tests/InferExtensions/ModelExtensionTest.php
+++ b/tests/InferExtensions/ModelExtensionTest.php
@@ -3,7 +3,6 @@
 use Carbon\Carbon;
 use Dedoc\Scramble\Infer;
 use Dedoc\Scramble\Infer\Services\ReferenceTypeResolver;
-use Dedoc\Scramble\Support\ResponseExtractor\ModelInfo;
 use Dedoc\Scramble\Support\Type\ArrayItemType_;
 use Dedoc\Scramble\Support\Type\IntegerType;
 use Dedoc\Scramble\Support\Type\KeyedArrayType;
@@ -20,7 +19,6 @@ use Illuminate\Database\Eloquent\Attributes\UseResource;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -686,65 +684,79 @@ it('uses custom collection type from newCollection for all', function () {
         ->toBe(FooCollection_ModelExtensionTest::class.'<int, '.Foo_ModelExtensionTest::class.'>');
 });
 
-it('resolves an annotated relation without querying the database', function () {
-    $this->infer->analyzeClass(ModelExtensionTest_ModelWithAnnotatedRelation::class);
+it('resolves annotated properties without querying the database', function () {
+    $this->infer->analyzeClass(ModelExtensionTest_AnnotatedModel::class);
 
     $queries = [];
     DB::listen(function (QueryExecuted $query) use (&$queries) {
         $queries[] = $query->sql;
     });
 
-    $propertyType = (new ObjectType(ModelExtensionTest_ModelWithAnnotatedRelation::class))
-        ->getPropertyType('annotatedOwner');
+    $object = new ObjectType(ModelExtensionTest_AnnotatedModel::class);
 
-    expect($propertyType->toString())->toBe(RelationNullabilityOwner_ModelExtensionTest::class.'|null')
+    expect($object->getPropertyType('title')->toString())->toBe('string')
+        ->and($object->getPropertyType('owner')->toString())
+        ->toBe(RelationNullabilityOwner_ModelExtensionTest::class.'|null')
         ->and($queries)->toBe([]);
 });
 
-it('falls back to the database for a relation without a declared return type', function () {
-    $this->infer->analyzeClass(ModelExtensionTest_ModelWithAnnotatedRelation::class);
+it('still refines an annotated property with the Eloquent casts', function () {
+    $this->infer->analyzeClass(ModelExtensionTest_AnnotatedModel::class);
 
     $queries = [];
     DB::listen(function (QueryExecuted $query) use (&$queries) {
         $queries[] = $query->sql;
     });
 
-    (new ObjectType(ModelExtensionTest_ModelWithAnnotatedRelation::class))
-        ->getPropertyType('undeclaredOwner');
+    $propertyType = (new ObjectType(ModelExtensionTest_AnnotatedModel::class))
+        ->getPropertyType('approved_at');
+
+    $carbonType = (new TypeWalker)->first($propertyType, fn ($type) => $type->isInstanceOf(Carbon::class));
+
+    expect($propertyType->toString())->toBe(Carbon::class.'|null')
+        ->and($carbonType?->getAttribute('format'))->toBe('date')
+        ->and($queries)->toBe([]);
+});
+
+it('reads the schema for a property that is not annotated', function () {
+    $this->infer->analyzeClass(ModelExtensionTest_AnnotatedModel::class);
+
+    $queries = [];
+    DB::listen(function (QueryExecuted $query) use (&$queries) {
+        $queries[] = $query->sql;
+    });
+
+    (new ObjectType(ModelExtensionTest_AnnotatedModel::class))->getPropertyType('nullable_owner_id');
 
     expect($queries)->not->toBe([]);
 });
 
 /**
- * @property-read RelationNullabilityOwner_ModelExtensionTest|null $annotatedOwner
- * @property-read RelationNullabilityOwner_ModelExtensionTest|null $undeclaredOwner
+ * @property string $title
+ * @property Carbon|null $approved_at
+ * @property-read RelationNullabilityOwner_ModelExtensionTest|null $owner
  */
-class ModelExtensionTest_ModelWithAnnotatedRelation extends Model
+class ModelExtensionTest_AnnotatedModel extends Model
 {
     protected $table = 'relation_nullability_models';
 
-    public function annotatedOwner(): BelongsTo
-    {
-        return $this->belongsTo(RelationNullabilityOwner_ModelExtensionTest::class, 'required_owner_id');
-    }
+    protected $casts = [
+        'approved_at' => 'datetime:Y-m-d',
+    ];
 
-    public function undeclaredOwner()
+    public function owner()
     {
         return $this->belongsTo(RelationNullabilityOwner_ModelExtensionTest::class, 'required_owner_id');
     }
 }
 
-it('documents a model from its annotations when the database is unreachable', function () {
+it('documents a model on an unreachable connection from its annotations', function () {
     config()->set('database.connections.unreachable', [
         'driver' => 'sqlite',
         'database' => __DIR__.'/no-such-directory/database.sqlite',
     ]);
 
     $this->infer->analyzeClass(ModelExtensionTest_ModelOnUnreachableConnection::class);
-
-    $info = (new ModelInfo(ModelExtensionTest_ModelOnUnreachableConnection::class))->handle();
-
-    expect($info->get('table_missing'))->toBeTrue();
 
     $object = new ObjectType(ModelExtensionTest_ModelOnUnreachableConnection::class);
 

--- a/tests/InferExtensions/ModelExtensionTest.php
+++ b/tests/InferExtensions/ModelExtensionTest.php
@@ -3,6 +3,7 @@
 use Carbon\Carbon;
 use Dedoc\Scramble\Infer;
 use Dedoc\Scramble\Infer\Services\ReferenceTypeResolver;
+use Dedoc\Scramble\Support\ResponseExtractor\ModelInfo;
 use Dedoc\Scramble\Support\Type\ArrayItemType_;
 use Dedoc\Scramble\Support\Type\IntegerType;
 use Dedoc\Scramble\Support\Type\KeyedArrayType;
@@ -19,7 +20,10 @@ use Illuminate\Database\Eloquent\Attributes\UseResource;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Spatie\Permission\Models\Role;
 
@@ -681,3 +685,86 @@ it('uses custom collection type from newCollection for all', function () {
     expect($type->toString())
         ->toBe(FooCollection_ModelExtensionTest::class.'<int, '.Foo_ModelExtensionTest::class.'>');
 });
+
+it('resolves an annotated relation without querying the database', function () {
+    $this->infer->analyzeClass(ModelExtensionTest_ModelWithAnnotatedRelation::class);
+
+    $queries = [];
+    DB::listen(function (QueryExecuted $query) use (&$queries) {
+        $queries[] = $query->sql;
+    });
+
+    $propertyType = (new ObjectType(ModelExtensionTest_ModelWithAnnotatedRelation::class))
+        ->getPropertyType('annotatedOwner');
+
+    expect($propertyType->toString())->toBe(RelationNullabilityOwner_ModelExtensionTest::class.'|null')
+        ->and($queries)->toBe([]);
+});
+
+it('falls back to the database for a relation without a declared return type', function () {
+    $this->infer->analyzeClass(ModelExtensionTest_ModelWithAnnotatedRelation::class);
+
+    $queries = [];
+    DB::listen(function (QueryExecuted $query) use (&$queries) {
+        $queries[] = $query->sql;
+    });
+
+    (new ObjectType(ModelExtensionTest_ModelWithAnnotatedRelation::class))
+        ->getPropertyType('undeclaredOwner');
+
+    expect($queries)->not->toBe([]);
+});
+
+/**
+ * @property-read RelationNullabilityOwner_ModelExtensionTest|null $annotatedOwner
+ * @property-read RelationNullabilityOwner_ModelExtensionTest|null $undeclaredOwner
+ */
+class ModelExtensionTest_ModelWithAnnotatedRelation extends Model
+{
+    protected $table = 'relation_nullability_models';
+
+    public function annotatedOwner(): BelongsTo
+    {
+        return $this->belongsTo(RelationNullabilityOwner_ModelExtensionTest::class, 'required_owner_id');
+    }
+
+    public function undeclaredOwner()
+    {
+        return $this->belongsTo(RelationNullabilityOwner_ModelExtensionTest::class, 'required_owner_id');
+    }
+}
+
+it('documents a model from its annotations when the database is unreachable', function () {
+    config()->set('database.connections.unreachable', [
+        'driver' => 'sqlite',
+        'database' => __DIR__.'/no-such-directory/database.sqlite',
+    ]);
+
+    $this->infer->analyzeClass(ModelExtensionTest_ModelOnUnreachableConnection::class);
+
+    $info = (new ModelInfo(ModelExtensionTest_ModelOnUnreachableConnection::class))->handle();
+
+    expect($info->get('table_missing'))->toBeTrue();
+
+    $object = new ObjectType(ModelExtensionTest_ModelOnUnreachableConnection::class);
+
+    expect($object->getPropertyType('title')->toString())->toBe('string')
+        ->and($object->getPropertyType('owner')->toString())
+        ->toBe(RelationNullabilityOwner_ModelExtensionTest::class.'|null');
+});
+
+/**
+ * @property string $title
+ * @property-read RelationNullabilityOwner_ModelExtensionTest|null $owner
+ */
+class ModelExtensionTest_ModelOnUnreachableConnection extends Model
+{
+    protected $connection = 'unreachable';
+
+    protected $table = 'relation_nullability_models';
+
+    public function owner()
+    {
+        return $this->belongsTo(RelationNullabilityOwner_ModelExtensionTest::class, 'required_owner_id');
+    }
+}

--- a/tests/InferExtensions/ModelExtensionTest.php
+++ b/tests/InferExtensions/ModelExtensionTest.php
@@ -10,6 +10,8 @@ use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
 use Dedoc\Scramble\Support\Type\ObjectType;
 use Dedoc\Scramble\Support\Type\Reference\MethodCallReferenceType;
 use Dedoc\Scramble\Support\Type\Reference\PropertyFetchReferenceType;
+use Dedoc\Scramble\Support\Type\StringType;
+use Dedoc\Scramble\Support\Type\Type;
 use Dedoc\Scramble\Support\Type\TypeWalker;
 use Dedoc\Scramble\Tests\Files\SamplePostModel;
 use Dedoc\Scramble\Tests\Files\SampleUserModel;
@@ -734,6 +736,7 @@ it('reads the schema for a property that is not annotated', function () {
 /**
  * @property string $title
  * @property Carbon|null $approved_at
+ * @property Carbon|null $custom_at
  * @property-read RelationNullabilityOwner_ModelExtensionTest|null $owner
  */
 class ModelExtensionTest_AnnotatedModel extends Model
@@ -780,3 +783,21 @@ class ModelExtensionTest_ModelOnUnreachableConnection extends Model
         return $this->belongsTo(RelationNullabilityOwner_ModelExtensionTest::class, 'required_owner_id');
     }
 }
+
+it('hands out a copy of an annotated property type', function () {
+    $this->infer->analyzeClass(ModelExtensionTest_AnnotatedModel::class);
+
+    $object = new ObjectType(ModelExtensionTest_AnnotatedModel::class);
+
+    /*
+     * Callers such as the toArray() inference replace types in place, so an annotated property type has to
+     * be handed out as a copy. Sharing the definition's own instance would let one analysed method rewrite
+     * the model's documented types for every later caller.
+     */
+    (new TypeWalker)->replace(
+        $object->getPropertyType('custom_at'),
+        fn (Type $type) => $type->isInstanceOf(Carbon::class) ? new StringType : null,
+    );
+
+    expect($object->getPropertyType('custom_at')->toString())->toBe(Carbon::class.'|null');
+});

--- a/tests/Support/InferExtensions/ModelExtensionTest.php
+++ b/tests/Support/InferExtensions/ModelExtensionTest.php
@@ -46,6 +46,32 @@ class SearchableModel_ModelExtensionTest extends Model
     protected $with = ['posts'];
 }
 
+/**
+ * @property-read PostModel_ModelExtensionTest|null $interfaceRelation
+ *
+ * @phpstan-require-extends Model
+ */
+interface Imageable_ModelExtensionTest {}
+
+/**
+ * @property-read PostModel_ModelExtensionTest|null $traitRelation
+ */
+trait Imageable_ModelExtensionTestTrait {}
+
+class ImageableModel_ModelExtensionTest extends Model implements Imageable_ModelExtensionTest
+{
+    use Imageable_ModelExtensionTestTrait;
+}
+
+it('uses property tags defined on implemented interfaces and used traits', function (string $property, string $expectedType) {
+    $type = getStatementType('(new '.ImageableModel_ModelExtensionTest::class.')->'.$property);
+
+    expect($type->toString())->toBe($expectedType);
+})->with([
+    'interface' => ['interfaceRelation', PostModel_ModelExtensionTest::class.'|null'],
+    'trait' => ['traitRelation', PostModel_ModelExtensionTest::class.'|null'],
+]);
+
 describe('model annotations (introduced in 11.15.0)', function () {
     it('handles static', function () {
         $type = getStatementType(UserModel_ModelExtensionTest::class.'::query()');


### PR DESCRIPTION
Hi! For context: in CI we generate the OpenAPI document without database access, so we rely on types being properly documented in our codebase. Two things got in the way:

1. **Interface and trait PHPDocs are now read.** We declare `@property-read` on shared interfaces and traits, but only the model's own docblock was used, so the tags had to be duplicated onto every model. Tags closer to the class still win (class > traits > interfaces), so nothing that resolved before changes.

2. **A documented property no longer reads the schema.** `getPropertyType()` queries `hasTable()` through `ModelInfo` before using the annotation it already has, so documented properties still needed a database. They are now refined from the Eloquent casts only, which produces the same types as before.

Our document now comes out byte-identical with and without a database.

Full disclosure, I am not familiar with this codebase and the code was written by an LLM. I have tested it in my projects.